### PR TITLE
Level exits

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,7 @@ set(core_sources
     game_logic/player_control_system.hpp
     game_logic/player_interaction_system.cpp
     game_logic/player_interaction_system.hpp
+    game_logic/trigger_components.hpp
     loader/actor_image_package.cpp
     loader/actor_image_package.hpp
     loader/audio_package.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,6 +97,8 @@ set(core_sources
     game.cpp
     game.hpp
     game_mode.hpp
+    game_session_mode.cpp
+    game_session_mode.hpp
     ingame_mode.cpp
     ingame_mode.hpp
     intro_demo_loop_mode.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(core_sources
+    base/boost_variant.hpp
     base/grid.hpp
     base/spatial_types.hpp
     base/warnings.hpp

--- a/src/base/boost_variant.hpp
+++ b/src/base/boost_variant.hpp
@@ -1,0 +1,27 @@
+/* Copyright (C) 2016, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
+#define BOOST_MPL_LIMIT_LIST_SIZE 30
+#define BOOST_MPL_LIMIT_VECTOR_SIZE 30
+
+#include <base/warnings.hpp>
+
+RIGEL_DISABLE_WARNINGS
+#include <boost/variant.hpp>
+RIGEL_RESTORE_WARNINGS

--- a/src/base/spatial_types.hpp
+++ b/src/base/spatial_types.hpp
@@ -96,6 +96,14 @@ struct Rect {
   ValueT bottom() const {
     return bottomLeft().y;
   }
+
+  ValueT left() const {
+    return topLeft.x;
+  }
+
+  ValueT right() const {
+    return bottomRight().x;
+  }
 };
 
 

--- a/src/data/duke_script.hpp
+++ b/src/data/duke_script.hpp
@@ -16,15 +16,7 @@
 
 #pragma once
 
-#include <base/warnings.hpp>
-
-#define BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
-#define BOOST_MPL_LIMIT_LIST_SIZE 30
-#define BOOST_MPL_LIMIT_VECTOR_SIZE 30
-
-RIGEL_DISABLE_WARNINGS
-#include <boost/variant.hpp>
-RIGEL_RESTORE_WARNINGS
+#include <base/boost_variant.hpp>
 
 #include <string>
 #include <vector>

--- a/src/engine/physics_system.cpp
+++ b/src/engine/physics_system.cpp
@@ -32,6 +32,16 @@ using components::WorldPosition;
 using data::map::CollisionData;
 
 
+BoundingBox toWorldSpace(
+  const BoundingBox& bbox,
+  const base::Vector& entityPosition
+) {
+  return bbox + base::Vector(
+    entityPosition.x,
+    entityPosition.y - (bbox.size.height - 1));
+}
+
+
 PhysicsSystem::PhysicsSystem(const data::map::Map& map)
   : mCollisionData(map.width(), map.height())
 {
@@ -102,15 +112,6 @@ const data::map::CollisionData& PhysicsSystem::worldAt(
 ) const {
   static const auto emptyCollisionData = CollisionData{};
   return mCollisionData.valueAtWithDefault(x, y, emptyCollisionData);
-}
-
-BoundingBox PhysicsSystem::toWorldSpace(
-  const BoundingBox& bbox,
-  const base::Vector& entityPosition
-) const {
-  return bbox + base::Vector(
-    entityPosition.x,
-    entityPosition.y - (bbox.size.height - 1));
 }
 
 

--- a/src/engine/physics_system.hpp
+++ b/src/engine/physics_system.hpp
@@ -48,6 +48,10 @@ struct Physical {
 }
 
 
+BoundingBox toWorldSpace(
+  const BoundingBox& bbox, const base::Vector& entityPosition);
+
+
 /** Implements game physics/world interaction
  *
  * Operates on all entities with Physical and WorldPosition components.
@@ -66,9 +70,6 @@ public:
 
 private:
   const data::map::CollisionData& worldAt(int x, int y) const;
-
-  BoundingBox toWorldSpace(
-    const BoundingBox& bbox, const base::Vector& entityPosition) const;
 
   base::Vector applyHorizontalMovement(
     const BoundingBox& bbox,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -22,6 +22,7 @@
 #include <loader/duke_script_loader.hpp>
 #include <sdl_utils/error.hpp>
 
+#include <game_session_mode.hpp>
 #include <ingame_mode.hpp>
 #include <intro_demo_loop_mode.hpp>
 #include <menu_mode.hpp>
@@ -124,7 +125,7 @@ void Game::run(const Options& options) {
     int episode, level;
     std::tie(episode, level) = *options.mLevelToJumpTo;
 
-    mpCurrentGameMode = std::make_unique<IngameMode>(
+    mpCurrentGameMode = std::make_unique<GameSessionMode>(
       episode,
       level,
       data::Difficulty::Medium,
@@ -311,7 +312,7 @@ void Game::scheduleNewGameStart(
   const int episode,
   const data::Difficulty difficulty
 ) {
-  mpNextGameMode = std::make_unique<IngameMode>(
+  mpNextGameMode = std::make_unique<GameSessionMode>(
     episode,
     0,
     difficulty,

--- a/src/game_logic/entity_configuration.ipp
+++ b/src/game_logic/entity_configuration.ipp
@@ -493,6 +493,10 @@ void configureEntity(
       entity.assign<Animated>(Animated{{AnimationSequence(4)}});
       break;
 
+    case 139: // level exit
+      entity.assign<Trigger>(TriggerType::LevelExit);
+      break;
+
     case 102: // dynamic wall: falls down, sinks into ground (when seen)
     case 106: // shootable wall, explodes into small pieces
     case 116: // door, opened by blue key (slides into ground)
@@ -500,8 +504,6 @@ void configureEntity(
     case 138: // dynamic wall: falls down, stays intact
     case 142: // unknown dynamic geometry
     case 143: // shootable wall, burns away
-
-    case 139: // level exit
 
     case 221: // water
     case 233: // water surface A

--- a/src/game_logic/entity_factory.cpp
+++ b/src/game_logic/entity_factory.cpp
@@ -95,6 +95,7 @@ public:
     VisualsAndBounds result;
 
     if (actor.mAssignedArea) {
+      // TODO: Implement dynamic geometry
       const auto sectionRect = *actor.mAssignedArea;
       for (
         auto mapRow=sectionRect.topLeft.y;

--- a/src/game_logic/entity_factory.cpp
+++ b/src/game_logic/entity_factory.cpp
@@ -23,6 +23,7 @@
 #include <engine/rendering_system.hpp>
 #include <game_logic/collectable_components.hpp>
 #include <game_logic/player_control_system.hpp>
+#include <game_logic/trigger_components.hpp>
 #include <map>
 #include <utility>
 

--- a/src/game_logic/trigger_components.hpp
+++ b/src/game_logic/trigger_components.hpp
@@ -1,0 +1,40 @@
+/* Copyright (C) 2016, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+
+namespace rigel { namespace game_logic {
+
+namespace components {
+
+enum class TriggerType {
+  LevelExit
+};
+
+
+struct Trigger {
+  explicit Trigger(const TriggerType type)
+    : mType(type)
+  {
+  }
+
+  TriggerType mType;
+};
+
+}
+
+}}

--- a/src/game_session_mode.cpp
+++ b/src/game_session_mode.cpp
@@ -42,6 +42,13 @@ GameSessionMode::GameSessionMode(
 
 
 void GameSessionMode::handleEvent(const SDL_Event& event) {
+  // This is temporary - remove when in-game menu implemented
+  if (event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_ESCAPE) {
+    mContext.mpServiceProvider->fadeOutScreen();
+    mContext.mpServiceProvider->scheduleEnterMainMenu();
+    return;
+  }
+
   atria::variant::match(mCurrentStage,
     [&event](std::unique_ptr<IngameMode>& pIngameMode) {
       pIngameMode->handleEvent(event);

--- a/src/game_session_mode.cpp
+++ b/src/game_session_mode.cpp
@@ -1,0 +1,87 @@
+/* Copyright (C) 2016, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "game_session_mode.hpp"
+
+#include <base/warnings.hpp>
+
+RIGEL_DISABLE_WARNINGS
+#include <atria/variant/match_boost.hpp>
+RIGEL_RESTORE_WARNINGS
+
+
+namespace rigel {
+
+GameSessionMode::GameSessionMode(
+  const int episode,
+  const int level,
+  const data::Difficulty difficulty,
+  Context context
+)
+  : mCurrentStage(std::make_unique<IngameMode>(
+      episode, level, difficulty, context))
+  , mEpisode(episode)
+  , mCurrentLevelNr(level)
+  , mDifficulty(difficulty)
+  , mContext(std::move(context))
+{
+}
+
+
+void GameSessionMode::handleEvent(const SDL_Event& event) {
+  atria::variant::match(mCurrentStage,
+    [&event](std::unique_ptr<IngameMode>& pIngameMode) {
+      pIngameMode->handleEvent(event);
+    },
+
+    [](auto&) {}
+    );
+}
+
+
+void GameSessionMode::updateAndRender(engine::TimeDelta dt) {
+  atria::variant::match(mCurrentStage,
+    [this, &dt](std::unique_ptr<IngameMode>& pIngameMode) {
+      pIngameMode->updateAndRender(dt);
+
+      if (pIngameMode->levelFinished()) {
+        auto bonusScreen = ui::BonusScreen{mContext, {}, 0};
+        fadeToNewStage(bonusScreen);
+        mCurrentStage = std::move(bonusScreen);
+      }
+    },
+
+    [this, &dt](ui::BonusScreen& bonusScreen) {
+      bonusScreen.updateAndRender(dt);
+
+      if (bonusScreen.finished()) {
+        auto pNextIngameMode = std::make_unique<IngameMode>(
+          mEpisode, ++mCurrentLevelNr, mDifficulty, mContext);
+        fadeToNewStage(*pNextIngameMode);
+        mCurrentStage = std::move(pNextIngameMode);
+      }
+    });
+}
+
+
+template<typename StageT>
+void GameSessionMode::fadeToNewStage(StageT& stage) {
+  mContext.mpServiceProvider->fadeOutScreen();
+  stage.updateAndRender(0);
+  mContext.mpServiceProvider->fadeInScreen();
+}
+
+}

--- a/src/game_session_mode.hpp
+++ b/src/game_session_mode.hpp
@@ -1,0 +1,56 @@
+/* Copyright (C) 2016, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <base/boost_variant.hpp>
+#include <ui/bonus_screen.hpp>
+
+#include <game_mode.hpp>
+#include <ingame_mode.hpp>
+
+
+namespace rigel {
+
+class GameSessionMode : public GameMode {
+public:
+  GameSessionMode(
+    int episode,
+    int level,
+    data::Difficulty difficulty,
+    Context context);
+
+  void handleEvent(const SDL_Event& event) override;
+  void updateAndRender(engine::TimeDelta dt) override;
+
+private:
+  template<typename StageT>
+  void fadeToNewStage(StageT& stage);
+
+private:
+  using SessionStage = boost::variant<
+    std::unique_ptr<IngameMode>,
+    ui::BonusScreen
+  >;
+
+  SessionStage mCurrentStage;
+  const int mEpisode;
+  int mCurrentLevelNr;
+  const data::Difficulty mDifficulty;
+  Context mContext;
+};
+
+}

--- a/src/ingame_mode.cpp
+++ b/src/ingame_mode.cpp
@@ -107,13 +107,6 @@ void IngameMode::handleEvent(const SDL_Event& event) {
     return;
   }
 
-  // This is temporary - remove when in-game menu implemented
-  if (event.key.keysym.sym == SDLK_ESCAPE) {
-    mpServiceProvider->fadeOutScreen();
-    mpServiceProvider->scheduleEnterMainMenu();
-    return;
-  }
-
   const auto keyPressed = event.type == SDL_KEYDOWN;
   switch (event.key.keysym.sym) {
     case SDLK_UP:

--- a/src/ingame_mode.cpp
+++ b/src/ingame_mode.cpp
@@ -22,6 +22,7 @@
 #include <engine/physics_system.hpp>
 #include <engine/rendering_system.hpp>
 #include <game_logic/player_interaction_system.hpp>
+#include <game_logic/trigger_components.hpp>
 #include <loader/resource_loader.hpp>
 #include <ui/utils.hpp>
 
@@ -77,6 +78,7 @@ IngameMode::IngameMode(
 )
   : mpRenderer(context.mpRenderer)
   , mpServiceProvider(context.mpServiceProvider)
+  , mLevelFinished(false)
   , mHudRenderer(
       &mPlayerModel,
       levelNumber + 1,
@@ -137,14 +139,22 @@ void IngameMode::handleEvent(const SDL_Event& event) {
 void IngameMode::updateAndRender(engine::TimeDelta dt) {
   // ----------
   // updating
-  mEntities.systems.update<PlayerControlSystem>(dt);
-  mEntities.systems.update<PlayerInteractionSystem>(dt);
-  mEntities.systems.update<PhysicsSystem>(dt);
-  mEntities.systems.update<MapScrollSystem>(dt);
-  mHudRenderer.update(dt);
+  if (!mLevelFinished) {
+    mEntities.systems.update<PlayerControlSystem>(dt);
+    mEntities.systems.update<PlayerInteractionSystem>(dt);
+    mEntities.systems.update<PhysicsSystem>(dt);
+    mEntities.systems.update<MapScrollSystem>(dt);
+    mHudRenderer.update(dt);
+
+    checkForLevelExitReached();
+  }
 
   // ----------
   // rendering
+  if (mLevelFinished) {
+    dt = 0;
+  }
+
   {
     sdl_utils::RenderTargetTexture::Binder
       bindRenderTarget(mIngameViewPortRenderTarget, mpRenderer);
@@ -157,6 +167,11 @@ void IngameMode::updateAndRender(engine::TimeDelta dt) {
     mpRenderer,
     data::GameTraits::inGameViewPortOffset.x,
     data::GameTraits::inGameViewPortOffset.y);
+}
+
+
+bool IngameMode::levelFinished() const {
+  return mLevelFinished;
 }
 
 
@@ -215,6 +230,42 @@ void IngameMode::loadLevel(
   mEntities.systems.configure();
 
   mpServiceProvider->playMusic(level.mMusicFile);
+}
+
+
+void IngameMode::checkForLevelExitReached() {
+  using engine::components::WorldPosition;
+  using engine::components::Physical;
+  using game_logic::components::Trigger;
+  using game_logic::components::TriggerType;
+
+  mEntities.entities.each<Trigger, WorldPosition>(
+    [this](
+      entityx::Entity,
+      const Trigger& trigger,
+      const WorldPosition& triggerPosition
+    ) {
+      if (trigger.mType != TriggerType::LevelExit || mLevelFinished) {
+        return;
+      }
+
+      const auto& playerPosition =
+        *mPlayerEntity.component<WorldPosition>().get();
+      const auto playerBBox = toWorldSpace(
+        mPlayerEntity.component<Physical>().get()->mCollisionRect,
+        playerPosition);
+
+      const auto playerAboveOrAtTriggerHeight =
+        playerBBox.bottom() <= triggerPosition.y;
+      const auto touchingTriggerOnXAxis =
+        triggerPosition.x >= playerBBox.left() &&
+        triggerPosition.x <= (playerBBox.right() + 1);
+
+      // TODO: Add check for trigger being visible on-screen to properly
+      // replicate the original game's behavior
+
+      mLevelFinished = playerAboveOrAtTriggerHeight && touchingTriggerOnXAxis;
+    });
 }
 
 }

--- a/src/ingame_mode.hpp
+++ b/src/ingame_mode.hpp
@@ -43,6 +43,8 @@ public:
   void handleEvent(const SDL_Event& event) override;
   void updateAndRender(engine::TimeDelta dt) override;
 
+  bool levelFinished() const;
+
 private:
   void showLoadingScreen(int episode, const loader::ResourceLoader& resources);
 
@@ -53,12 +55,15 @@ private:
     const loader::ResourceLoader& resources
   );
 
+  void checkForLevelExitReached();
+
 private:
   SDL_Renderer* mpRenderer;
   IGameServiceProvider* mpServiceProvider;
   data::PlayerModel mPlayerModel;
   base::Vector mScrollOffset;
   game_logic::PlayerInputState mPlayerInputs;
+  bool mLevelFinished;
 
   entityx::EntityX mEntities;
   entityx::Entity mPlayerEntity;

--- a/src/ingame_mode.hpp
+++ b/src/ingame_mode.hpp
@@ -35,11 +35,6 @@ namespace rigel {
 class IngameMode : public GameMode {
 public:
   IngameMode(
-    const std::string& levelName,
-    data::Difficulty difficulty,
-    Context context);
-
-  IngameMode(
     int episode,
     int level,
     data::Difficulty difficulty,

--- a/src/loader/level_loader.cpp
+++ b/src/loader/level_loader.cpp
@@ -268,11 +268,11 @@ ActorList preProcessActorDescriptions(
           {
             auto tileSection = grid.findTileSectionRect(col, row);
             if (tileSection) {
-            actors.emplace_back(LevelData::Actor{
-              actor.mPosition,
-              actor.mID,
-              tileSection
-            });
+              actors.emplace_back(LevelData::Actor{
+                actor.mPosition,
+                actor.mID,
+                tileSection
+              });
             }
           }
           break;

--- a/src/ui/bonus_screen.cpp
+++ b/src/ui/bonus_screen.cpp
@@ -80,7 +80,6 @@ BonusScreen::BonusScreen(
 )
   : mState(scoreBeforeAddingBonuses)
   , mpRenderer(context.mpRenderer)
-  , mpServiceProvider(context.mpServiceProvider)
   , mBackgroundTexture(ui::fullScreenImageAsTexture(
       context.mpRenderer,
       *context.mpResources,
@@ -91,9 +90,10 @@ BonusScreen::BonusScreen(
 
   engine::TimeDelta time = 0.0;
   if (!achievedBonuses.empty()) {
-    time = setupBonusSummationSequence(achievedBonuses);
+    time =
+      setupBonusSummationSequence(achievedBonuses, context.mpServiceProvider);
   } else {
-    time = setupNoBonusSequence();
+    time = setupNoBonusSequence(context.mpServiceProvider);
   }
 
   time += slowTicksToTime(FINAL_DELAY_TICKS);
@@ -134,7 +134,8 @@ void BonusScreen::updateSequence(const engine::TimeDelta timeDelta) {
 
 
 engine::TimeDelta BonusScreen::setupBonusSummationSequence(
-  const std::set<BonusNumber>& achievedBonuses
+  const std::set<BonusNumber>& achievedBonuses,
+  IGameServiceProvider* pServiceProvider
 ) {
   auto time = slowTicksToTime(INITIAL_DELAY_TICKS);
 
@@ -154,7 +155,7 @@ engine::TimeDelta BonusScreen::setupBonusSummationSequence(
 
     mEvents.emplace_back(Event{
       time,
-      [pServiceProvider = mpServiceProvider, bonus](State& state) {
+      [pServiceProvider = pServiceProvider, bonus](State& state) {
         state.mRunningText += " " + to_string(bonus);
         pServiceProvider->playSound(data::SoundId::BigExplosion);
       }
@@ -172,7 +173,7 @@ engine::TimeDelta BonusScreen::setupBonusSummationSequence(
     for (int iteration = 0; iteration < 100; ++iteration) {
       mEvents.emplace_back(Event{
         time,
-        [pServiceProvider = mpServiceProvider, iteration](State& state) {
+        [pServiceProvider = pServiceProvider, iteration](State& state) {
           state.mScore += 1000;
           pServiceProvider->playSound(data::SoundId::DukeJumping);
 
@@ -194,7 +195,7 @@ engine::TimeDelta BonusScreen::setupBonusSummationSequence(
 
     mEvents.emplace_back(Event{
       time,
-      [pServiceProvider = mpServiceProvider](State& state) {
+      [pServiceProvider = pServiceProvider](State& state) {
         state.mRunningText = "       0 PTS";
         pServiceProvider->playSound(data::SoundId::BigExplosion);
       }
@@ -206,7 +207,9 @@ engine::TimeDelta BonusScreen::setupBonusSummationSequence(
   return time;
 }
 
-engine::TimeDelta BonusScreen::setupNoBonusSequence() {
+engine::TimeDelta BonusScreen::setupNoBonusSequence(
+  IGameServiceProvider* pServiceProvider
+) {
   auto time = slowTicksToTime(100 + INITIAL_DELAY_TICKS);
 
   for (int i = 0; i < 14; ++i) {
@@ -221,7 +224,7 @@ engine::TimeDelta BonusScreen::setupNoBonusSequence() {
 
   mEvents.emplace_back(Event{
     time,
-    [pServiceProvider = mpServiceProvider](State&) {
+    [pServiceProvider = pServiceProvider](State&) {
       pServiceProvider->playSound(data::SoundId::BigExplosion);
     }
   });
@@ -239,7 +242,7 @@ engine::TimeDelta BonusScreen::setupNoBonusSequence() {
 
   mEvents.emplace_back(Event{
     time,
-    [pServiceProvider = mpServiceProvider](State&) {
+    [pServiceProvider = pServiceProvider](State&) {
       pServiceProvider->playSound(data::SoundId::BigExplosion);
     }
   });
@@ -258,7 +261,7 @@ engine::TimeDelta BonusScreen::setupNoBonusSequence() {
   time += slowTicksToTime(15);
   mEvents.emplace_back(Event{
     time,
-    [pServiceProvider = mpServiceProvider](State&) {
+    [pServiceProvider = pServiceProvider](State&) {
       pServiceProvider->playSound(data::SoundId::BigExplosion);
     }
   });

--- a/src/ui/bonus_screen.hpp
+++ b/src/ui/bonus_screen.hpp
@@ -38,9 +38,20 @@ public:
   void updateAndRender(engine::TimeDelta dt);
 
 private:
+  struct State {
+    explicit State(const int score)
+      : mScore(score)
+    {
+    }
+
+    int mScore;
+    std::string mRunningText;
+    bool mIsDone = false;
+  };
+
   struct Event {
     engine::TimeDelta mTime;
-    std::function<void()> mAction;
+    std::function<void(State&)> mAction;
   };
 
   engine::TimeDelta setupBonusSummationSequence(
@@ -49,13 +60,11 @@ private:
   void updateSequence(engine::TimeDelta timeDelta);
 
 private:
-  int mScore;
-  std::string mRunningText;
+  State mState;
 
   engine::TimeDelta mElapsedTime = 0.0;
   std::vector<Event> mEvents;
   std::size_t mNextEvent = 0;
-  bool mIsDone = false;
 
   SDL_Renderer* mpRenderer;
   IGameServiceProvider* mpServiceProvider;

--- a/src/ui/bonus_screen.hpp
+++ b/src/ui/bonus_screen.hpp
@@ -59,8 +59,10 @@ private:
   };
 
   engine::TimeDelta setupBonusSummationSequence(
-    const std::set<BonusNumber>& achievedBonuses);
-  engine::TimeDelta setupNoBonusSequence();
+    const std::set<BonusNumber>& achievedBonuses,
+    IGameServiceProvider* pServiceProvider);
+  engine::TimeDelta setupNoBonusSequence(
+    IGameServiceProvider* pServiceProvider);
   void updateSequence(engine::TimeDelta timeDelta);
 
 private:
@@ -71,7 +73,6 @@ private:
   std::size_t mNextEvent = 0;
 
   SDL_Renderer* mpRenderer;
-  IGameServiceProvider* mpServiceProvider;
   sdl_utils::OwningTexture mBackgroundTexture;
   ui::MenuElementRenderer mTextRenderer;
 };

--- a/src/ui/bonus_screen.hpp
+++ b/src/ui/bonus_screen.hpp
@@ -37,6 +37,10 @@ public:
 
   void updateAndRender(engine::TimeDelta dt);
 
+  bool finished() const {
+    return mState.mIsDone;
+  }
+
 private:
   struct State {
     explicit State(const int score)


### PR DESCRIPTION
Implements level exit triggers, integrates the bonus screen and makes it possible to transition to the next level upon reaching the exit. Many levels can currently not be finished due to missing player
movement (e.g. hanging on poles) or entities (e.g. rocket elevator), but it's already possible for some, e.g. L3 and L6.

Closes #15 and #44 