### PR TITLE
Add different weapon types for player

### DIFF
--- a/src/data/player_data.hpp
+++ b/src/data/player_data.hpp
@@ -79,6 +79,11 @@ struct PlayerModel {
       mWeapon == WeaponType::FlameThrower ? MAX_AMMO_FLAME_THROWER : MAX_AMMO;
   }
 
+  void switchToWeapon(const WeaponType type) {
+    mWeapon = type;
+    mAmmo = currentMaxAmmo();
+  }
+
   std::unordered_set<CollectableLetterType> mCollectedLetters;
   std::unordered_set<InventoryItemType> mInventory;
 };

--- a/src/data/player_data.hpp
+++ b/src/data/player_data.hpp
@@ -84,6 +84,10 @@ struct PlayerModel {
     mAmmo = currentMaxAmmo();
   }
 
+  bool currentWeaponConsumesAmmo() const {
+    return mWeapon != WeaponType::Normal;
+  }
+
   std::unordered_set<CollectableLetterType> mCollectedLetters;
   std::unordered_set<InventoryItemType> mInventory;
 };

--- a/src/engine/physics_system.cpp
+++ b/src/engine/physics_system.cpp
@@ -152,7 +152,10 @@ std::tuple<base::Vector, bool> PhysicsSystem::applyHorizontalMovement(
   const auto movementDirection = movingRight ? 1 : -1;
   const auto startX = currentPosition.x + movementDirection;
   const auto endX = newPosition.x + movementDirection;
-  const auto xOffset = movingRight ? bbox.size.width-1u : 0u;
+  const auto boundingBoxOffsetX = bbox.left() - currentPosition.x;
+  const auto xOffset =
+    (movingRight ? bbox.size.width-1u : 0u) +
+    boundingBoxOffsetX;
   auto hasCollision = [movingRight](const auto& cellData) {
     if (movingRight) {
       return cellData.isSolidLeft();
@@ -240,7 +243,10 @@ std::tuple<base::Vector, float, bool> PhysicsSystem::applyVerticalMovement(
   const auto movementDirection = movingDown ? 1 : -1;
   const auto startY = currentPosition.y + movementDirection;
   const auto endY = newPosition.y + movementDirection;
-  const auto yOffset = movingDown ? 0 : -(bbox.size.height - 1);
+  const auto boundingBoxOffsetY = bbox.bottom() - currentPosition.y;
+  const auto yOffset =
+    (movingDown ? 0 : -(bbox.size.height - 1)) +
+    boundingBoxOffsetY;
   auto hasCollision = [movingDown](const auto& cellData) {
     if (movingDown) {
       return cellData.isSolidTop();

--- a/src/game_logic/entity_configuration.ipp
+++ b/src/game_logic/entity_configuration.ipp
@@ -98,6 +98,23 @@ ActorID actorIdForProjectile(
 }
 
 
+int damageForProjectileType(const ProjectileType type) {
+  switch (type) {
+    case ProjectileType::PlayerFlameShot:
+      return 2;
+
+    case ProjectileType::PlayerLaserShot:
+      return 4;
+
+    case ProjectileType::PlayerRocketShot:
+      return 8;
+
+    default:
+      return 1;
+  }
+}
+
+
 void configureProjectile(
   entityx::Entity entity,
   const ProjectileType type,
@@ -129,9 +146,10 @@ void configureProjectile(
     }
   }
 
+  const auto damageAmount = damageForProjectileType(type);
   entity.assign<WorldPosition>(position);
   entity.assign<Physical>(Physical{velocity, false});
-  entity.assign<DamageInflicting>(1);
+  entity.assign<DamageInflicting>(damageAmount);
 }
 
 

--- a/src/game_logic/entity_configuration.ipp
+++ b/src/game_logic/entity_configuration.ipp
@@ -69,11 +69,11 @@
 
 ActorID actorIdForProjectile(
   const ProjectileType type,
-  const base::Point<float>& velocity
+  const base::Point<float>& directionVector
 ) {
-  const auto isHorizontal = velocity.x != 0.0f;
-  const auto isGoingRight = velocity.x > 0.0f;
-  const auto isGoingUp = velocity.y < 0.0f;
+  const auto isHorizontal = directionVector.x != 0.0f;
+  const auto isGoingRight = directionVector.x > 0.0f;
+  const auto isGoingUp = directionVector.y < 0.0f;
 
   switch (type) {
     case ProjectileType::PlayerRegularShot:
@@ -98,6 +98,18 @@ ActorID actorIdForProjectile(
 }
 
 
+float speedForProjectileType(const ProjectileType type) {
+  switch (type) {
+    case ProjectileType::PlayerLaserShot:
+    case ProjectileType::PlayerFlameShot:
+      return 5.0f;
+
+    default:
+      return 2.0f;
+  }
+}
+
+
 int damageForProjectileType(const ProjectileType type) {
   switch (type) {
     case ProjectileType::PlayerFlameShot:
@@ -119,11 +131,11 @@ void configureProjectile(
   entityx::Entity entity,
   const ProjectileType type,
   WorldPosition position,
-  const base::Point<float>& velocity,
+  const base::Point<float>& directionVector,
   const BoundingBox& boundingBox
 ) {
-  const auto isHorizontal = velocity.x != 0.0f;
-  const auto isGoingLeft = velocity.x < 0.0f;
+  const auto isHorizontal = directionVector.x != 0.0f;
+  const auto isGoingLeft = directionVector.x < 0.0f;
 
   // Position adjustment for the flame thrower shot
   if (type == ProjectileType::PlayerFlameShot) {
@@ -146,9 +158,10 @@ void configureProjectile(
     }
   }
 
+  const auto speed = speedForProjectileType(type);
   const auto damageAmount = damageForProjectileType(type);
   entity.assign<WorldPosition>(position);
-  entity.assign<Physical>(Physical{velocity, false});
+  entity.assign<Physical>(Physical{directionVector * speed, false});
   entity.assign<DamageInflicting>(damageAmount);
 }
 

--- a/src/game_logic/entity_factory.cpp
+++ b/src/game_logic/entity_factory.cpp
@@ -164,22 +164,17 @@ Sprite EntityFactory::makeSpriteFromActorIDs(const vector<ActorID>& actorIDs) {
 
 
 entityx::Entity EntityFactory::createProjectile(
-  const ProjectileType,
+  const ProjectileType type,
   const WorldPosition& pos,
   const base::Point<float>& velocity
 ) {
   auto entity = mpEntityManager->create();
-  entity.assign<WorldPosition>(pos);
-
-  // TODO: This is only temporary, it always creates a "player regular shot"
-  // projectile. We need to add a type parameter, and parameterize the sprite
-  // ID on that type in addition to the direction vector.
-  auto sprite = createSpriteForId(
-    velocity.x != 0.0f ? 26 : 27);
+  auto sprite = createSpriteForId(actorIdForProjectile(type, velocity));
+  const auto boundingBox = inferBoundingBox(sprite.mFrames[0]);
   entity.assign<Sprite>(sprite);
-  entity.assign<BoundingBox>(inferBoundingBox(sprite.mFrames[0]));
-  entity.assign<Physical>(Physical{velocity, false});
-  entity.assign<DamageInflicting>(1);
+  entity.assign<BoundingBox>(boundingBox);
+
+  configureProjectile(entity, type, pos, velocity, boundingBox);
 
   return entity;
 }

--- a/src/game_logic/entity_factory.cpp
+++ b/src/game_logic/entity_factory.cpp
@@ -166,15 +166,15 @@ Sprite EntityFactory::makeSpriteFromActorIDs(const vector<ActorID>& actorIDs) {
 entityx::Entity EntityFactory::createProjectile(
   const ProjectileType type,
   const WorldPosition& pos,
-  const base::Point<float>& velocity
+  const base::Point<float>& directionVector
 ) {
   auto entity = mpEntityManager->create();
-  auto sprite = createSpriteForId(actorIdForProjectile(type, velocity));
+  auto sprite = createSpriteForId(actorIdForProjectile(type, directionVector));
   const auto boundingBox = inferBoundingBox(sprite.mFrames[0]);
   entity.assign<Sprite>(sprite);
   entity.assign<BoundingBox>(boundingBox);
 
-  configureProjectile(entity, type, pos, velocity, boundingBox);
+  configureProjectile(entity, type, pos, directionVector, boundingBox);
 
   return entity;
 }

--- a/src/game_logic/entity_factory.cpp
+++ b/src/game_logic/entity_factory.cpp
@@ -164,6 +164,7 @@ Sprite EntityFactory::makeSpriteFromActorIDs(const vector<ActorID>& actorIDs) {
 
 
 entityx::Entity EntityFactory::createProjectile(
+  const ProjectileType,
   const WorldPosition& pos,
   const base::Point<float>& velocity
 ) {

--- a/src/game_logic/entity_factory.hpp
+++ b/src/game_logic/entity_factory.hpp
@@ -37,6 +37,13 @@ namespace rigel { namespace loader { class ActorImagePackage; }}
 
 namespace rigel { namespace game_logic {
 
+enum class ProjectileType {
+  PlayerRegularShot,
+  PlayerLaserShot,
+  PlayerRocketShot,
+  PlayerFlameShot
+};
+
 
 class EntityFactory {
 public:
@@ -51,6 +58,7 @@ public:
     data::map::Map& map);
 
   entityx::Entity createProjectile(
+    ProjectileType type,
     const engine::components::WorldPosition& pos,
     const base::Point<float>& velocity);
 

--- a/src/game_logic/player/attack_system.cpp
+++ b/src/game_logic/player/attack_system.cpp
@@ -31,9 +31,6 @@ namespace ex = entityx;
 
 namespace {
 
-const auto DUKE_SHOT_VELOCITY = 2.0f;
-
-
 ProjectileType projectileTypeForWeapon(const WeaponType weaponType) {
   switch (weaponType) {
     case WeaponType::Normal:
@@ -143,19 +140,18 @@ void AttackSystem::fireShot(
   const auto shotOffset =
     WorldPosition{shotOffsetHorizontal, shotOffsetVertical};
 
-  const auto directionAdjustment = state != PlayerState::LookingUp
+  const auto direction = state != PlayerState::LookingUp
     ? (facingRight ? 1.0f : -1.0f)
     : -1.0f;
-  const auto velocity = DUKE_SHOT_VELOCITY * directionAdjustment;
 
-  const auto velocityVector = state == PlayerState::LookingUp
-    ? base::Point<float>{0.0f, velocity}
-    : base::Point<float>{velocity, 0.0f};
+  const auto directionVector = state == PlayerState::LookingUp
+    ? base::Point<float>{0.0f, direction}
+    : base::Point<float>{direction, 0.0f};
 
   mFireShotFunc(
     projectileTypeForWeapon(mpPlayerModel->mWeapon),
     shotOffset + playerPosition,
-    velocityVector);
+    directionVector);
   mpServiceProvider->playSound(soundIdForWeapon(mpPlayerModel->mWeapon));
 
   if (mpPlayerModel->currentWeaponConsumesAmmo()) {

--- a/src/game_logic/player/attack_system.hpp
+++ b/src/game_logic/player/attack_system.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "base/warnings.hpp"
+#include "game_logic/entity_factory.hpp"
 #include "game_logic/player_control_system.hpp"
 
 RIGEL_DISABLE_WARNINGS
@@ -29,6 +30,8 @@ namespace rigel {
   struct IGameServiceProvider;
 }
 
+namespace rigel { namespace data { struct PlayerModel; }}
+
 namespace rigel { namespace game_logic { namespace components {
   struct PlayerControlled;
 }}}
@@ -39,12 +42,14 @@ namespace rigel { namespace game_logic { namespace player {
 class AttackSystem : public entityx::System<AttackSystem> {
 public:
   using FireShotFunc = std::function<void(
+    ProjectileType type,
     const engine::components::WorldPosition&,
     const base::Point<float>&
   )>;
 
   AttackSystem(
     entityx::Entity playerEntity,
+    data::PlayerModel* pPlayerModel,
     IGameServiceProvider* pServiceProvider,
     FireShotFunc fireShotFunc);
 
@@ -64,6 +69,7 @@ private:
 
 private:
   entityx::Entity mPlayerEntity;
+  data::PlayerModel* mpPlayerModel;
   IGameServiceProvider* mpServiceProvider;
   FireShotFunc mFireShotFunc;
   PlayerInputState mInputState;

--- a/src/game_logic/player_interaction_system.cpp
+++ b/src/game_logic/player_interaction_system.cpp
@@ -120,9 +120,7 @@ void PlayerInteractionSystem::update(
         }
 
         if (collectable.mGivenWeapon) {
-          mpPlayerModel->mWeapon = *collectable.mGivenWeapon;
-          mpPlayerModel->mAmmo = mpPlayerModel->currentMaxAmmo();
-
+          mpPlayerModel->switchToWeapon(*collectable.mGivenWeapon);
           soundToPlay = SoundId::WeaponPickup;
         }
 

--- a/src/ingame_mode.cpp
+++ b/src/ingame_mode.cpp
@@ -260,9 +260,9 @@ void IngameMode::loadLevel(
     [this](
       const game_logic::ProjectileType type,
       const engine::components::WorldPosition& pos,
-      const base::Point<float>& velocity
+      const base::Point<float>& directionVector
     ) {
-      mEntityFactory.createProjectile(type, pos, velocity);
+      mEntityFactory.createProjectile(type, pos, directionVector);
     });
   mEntities.systems.add<game_logic::player::DamageSystem>(
     mPlayerEntity,

--- a/src/ingame_mode.cpp
+++ b/src/ingame_mode.cpp
@@ -255,12 +255,14 @@ void IngameMode::loadLevel(
     mpServiceProvider);
   mEntities.systems.add<game_logic::player::AttackSystem>(
     mPlayerEntity,
+    &mPlayerModel,
     mpServiceProvider,
     [this](
+      const game_logic::ProjectileType type,
       const engine::components::WorldPosition& pos,
       const base::Point<float>& velocity
     ) {
-      mEntityFactory.createProjectile(pos, velocity);
+      mEntityFactory.createProjectile(type, pos, velocity);
     });
   mEntities.systems.add<game_logic::player::DamageSystem>(
     mPlayerEntity,

--- a/test/test_player_attack_system.cpp
+++ b/test/test_player_attack_system.cpp
@@ -18,6 +18,7 @@
 
 #include <base/spatial_types_printing.hpp>
 #include <base/warnings.hpp>
+#include <data/player_data.hpp>
 #include <game_logic/player/attack_system.hpp>
 #include <game_logic/player_control_system.hpp>
 #include <game_mode.hpp>
@@ -44,6 +45,7 @@ namespace ex = entityx;
 
 
 struct FireShotParameters {
+  ProjectileType type;
   WorldPosition position;
   base::Point<float> velocity;
 };
@@ -84,18 +86,25 @@ TEST_CASE("Player attack system works as expected") {
   player.assign<WorldPosition>(0, 0);
   initializePlayerEntity(player, true);
 
+  data::PlayerModel playerModel;
+
   FireShotParameters fireShotParameters;
   auto fireShotSpy = atria::testing::spy([&fireShotParameters](
+    const ProjectileType type,
     const WorldPosition& position,
     const base::Point<float>& velocity
   ) {
+    fireShotParameters.type = type;
     fireShotParameters.position = position;
     fireShotParameters.velocity = velocity;
   });
 
   MockServiceProvider mockServiceProvicer;
   entityx.systems.add<player::AttackSystem>(
-    player, &mockServiceProvicer, fireShotSpy);
+    player,
+    &playerModel,
+    &mockServiceProvicer,
+    fireShotSpy);
   entityx.systems.configure();
   auto& attackSystem = *entityx.systems.system<player::AttackSystem>();
 
@@ -246,14 +255,148 @@ TEST_CASE("Player attack system works as expected") {
   }
 
 
+  SECTION("Shot type depends on player's current weapon") {
+    SECTION("Regular shot") {
+      updateWithInput(shootingInputState);
+      REQUIRE(fireShotParameters.type == ProjectileType::PlayerRegularShot);
+    }
+
+    SECTION("Laser shot") {
+      playerModel.mWeapon = data::WeaponType::Laser;
+
+      updateWithInput(shootingInputState);
+      REQUIRE(fireShotParameters.type == ProjectileType::PlayerLaserShot);
+    }
+
+    SECTION("Rocket shot") {
+      playerModel.mWeapon = data::WeaponType::Rocket;
+
+      updateWithInput(shootingInputState);
+      REQUIRE(fireShotParameters.type == ProjectileType::PlayerRocketShot);
+    }
+
+    SECTION("Flame shot") {
+      playerModel.mWeapon = data::WeaponType::FlameThrower;
+
+      updateWithInput(shootingInputState);
+      REQUIRE(fireShotParameters.type == ProjectileType::PlayerFlameShot);
+    }
+  }
+
+
   SECTION("Shooting triggers appropriate sound") {
     REQUIRE(mockServiceProvicer.mLastTriggeredSoundId == boost::none);
 
-    updateWithInput(shootingInputState);
+    SECTION("Normal shot") {
+      updateWithInput(shootingInputState);
+      REQUIRE(mockServiceProvicer.mLastTriggeredSoundId != boost::none);
+      REQUIRE(
+          *mockServiceProvicer.mLastTriggeredSoundId ==
+          data::SoundId::DukeNormalShot);
+    }
 
-    REQUIRE(mockServiceProvicer.mLastTriggeredSoundId != boost::none);
-    REQUIRE(
-      *mockServiceProvicer.mLastTriggeredSoundId ==
-      data::SoundId::DukeNormalShot);
+    SECTION("Laser") {
+      playerModel.mWeapon = data::WeaponType::Laser;
+
+      updateWithInput(shootingInputState);
+      REQUIRE(mockServiceProvicer.mLastTriggeredSoundId != boost::none);
+      REQUIRE(
+          *mockServiceProvicer.mLastTriggeredSoundId ==
+          data::SoundId::DukeLaserShot);
+    }
+
+    SECTION("Rocket launcher") {
+      playerModel.mWeapon = data::WeaponType::Rocket;
+
+      // The rocket launcher also uses the normal shot sound
+      updateWithInput(shootingInputState);
+      REQUIRE(mockServiceProvicer.mLastTriggeredSoundId != boost::none);
+      REQUIRE(
+          *mockServiceProvicer.mLastTriggeredSoundId ==
+          data::SoundId::DukeNormalShot);
+    }
+
+    SECTION("Flame thrower") {
+      playerModel.mWeapon = data::WeaponType::FlameThrower;
+
+      updateWithInput(shootingInputState);
+      REQUIRE(mockServiceProvicer.mLastTriggeredSoundId != boost::none);
+      REQUIRE(
+          *mockServiceProvicer.mLastTriggeredSoundId ==
+          data::SoundId::FlameThrowerShot);
+    }
+
+    SECTION("Last shot before ammo depletion still uses appropriate sound") {
+      playerModel.mWeapon = data::WeaponType::Laser;
+      playerModel.mAmmo = 1;
+
+      updateWithInput(shootingInputState);
+
+      REQUIRE(
+          *mockServiceProvicer.mLastTriggeredSoundId ==
+          data::SoundId::DukeLaserShot);
+    }
+  }
+
+
+  const auto fireOneShot = [
+    &updateWithInput, &shootingInputState, &defaultInputState
+  ]() {
+    updateWithInput(shootingInputState);
+    updateWithInput(defaultInputState);
+  };
+
+  SECTION("Ammo consumption for non-regular weapons works") {
+    SECTION("Normal shot doesn't consume ammo") {
+      playerModel.mAmmo = 42;
+      fireOneShot();
+      REQUIRE(playerModel.mAmmo == 42);
+    }
+
+    SECTION("Laser consumes 1 unit of ammo per shot") {
+      playerModel.mWeapon = data::WeaponType::Laser;
+      playerModel.mAmmo = 10;
+
+      fireOneShot();
+      REQUIRE(playerModel.mAmmo == 9);
+    }
+
+    SECTION("Rocket launcher consumes 1 unit of ammo per shot") {
+      playerModel.mWeapon = data::WeaponType::Rocket;
+      playerModel.mAmmo = 10;
+
+      fireOneShot();
+      REQUIRE(playerModel.mAmmo == 9);
+    }
+
+    SECTION("Flame thrower consumes 1 unit of ammo per shot") {
+      playerModel.mWeapon = data::WeaponType::FlameThrower;
+      playerModel.mAmmo = 10;
+
+      fireOneShot();
+      REQUIRE(playerModel.mAmmo == 9);
+    }
+
+    SECTION("Multiple shots consume several units of ammo") {
+      playerModel.mWeapon = data::WeaponType::Laser;
+      playerModel.mAmmo = 20;
+
+      const auto shotsToFire = 15;
+      for (int i = 0; i < shotsToFire; ++i) {
+        fireOneShot();
+      }
+
+      REQUIRE(playerModel.mAmmo == 20 - shotsToFire);
+    }
+
+    SECTION("Depleting ammo switches back to normal weapon") {
+      playerModel.mWeapon = data::WeaponType::Rocket;
+      playerModel.mAmmo = 1;
+
+      fireOneShot();
+
+      REQUIRE(playerModel.mWeapon == data::WeaponType::Normal);
+      REQUIRE(playerModel.mAmmo == playerModel.currentMaxAmmo());
+    }
   }
 }

--- a/test/test_player_attack_system.cpp
+++ b/test/test_player_attack_system.cpp
@@ -47,7 +47,7 @@ namespace ex = entityx;
 struct FireShotParameters {
   ProjectileType type;
   WorldPosition position;
-  base::Point<float> velocity;
+  base::Point<float> directionVector;
 };
 
 
@@ -92,11 +92,11 @@ TEST_CASE("Player attack system works as expected") {
   auto fireShotSpy = atria::testing::spy([&fireShotParameters](
     const ProjectileType type,
     const WorldPosition& position,
-    const base::Point<float>& velocity
+    const base::Point<float>& directionVector
   ) {
     fireShotParameters.type = type;
     fireShotParameters.position = position;
-    fireShotParameters.velocity = velocity;
+    fireShotParameters.directionVector = directionVector;
   });
 
   MockServiceProvider mockServiceProvicer;
@@ -151,9 +151,9 @@ TEST_CASE("Player attack system works as expected") {
         updateWithInput(shootingInputState);
 
         const auto expectedPosition = WorldPosition{3, -2};
-        const auto expectedVelocity = base::Point<float>{2.0f, 0.0f};
+        const auto expectedVector = base::Point<float>{1.0f, 0.0f};
         REQUIRE(fireShotParameters.position == expectedPosition);
-        REQUIRE(fireShotParameters.velocity == expectedVelocity);
+        REQUIRE(fireShotParameters.directionVector == expectedVector);
       }
 
       SECTION("Facing left") {
@@ -162,9 +162,9 @@ TEST_CASE("Player attack system works as expected") {
         updateWithInput(shootingInputState);
 
         const auto expectedPosition = WorldPosition{-1, -2};
-        const auto expectedVelocity = base::Point<float>{-2.0f, 0.0f};
+        const auto expectedVector = base::Point<float>{-1.0f, 0.0f};
         REQUIRE(fireShotParameters.position == expectedPosition);
-        REQUIRE(fireShotParameters.velocity == expectedVelocity);
+        REQUIRE(fireShotParameters.directionVector == expectedVector);
       }
 
       SECTION("Player position offset") {
@@ -191,9 +191,9 @@ TEST_CASE("Player attack system works as expected") {
         updateWithInput(shootingInputState);
 
         const auto expectedPosition = WorldPosition{3, -1};
-        const auto expectedVelocity = base::Point<float>{2.0f, 0.0f};
+        const auto expectedVector = base::Point<float>{1.0f, 0.0f};
         REQUIRE(fireShotParameters.position == expectedPosition);
-        REQUIRE(fireShotParameters.velocity == expectedVelocity);
+        REQUIRE(fireShotParameters.directionVector == expectedVector);
       }
 
       SECTION("Facing left") {
@@ -202,9 +202,9 @@ TEST_CASE("Player attack system works as expected") {
         updateWithInput(shootingInputState);
 
         const auto expectedPosition = WorldPosition{-1, -1};
-        const auto expectedVelocity = base::Point<float>{-2.0f, 0.0f};
+        const auto expectedVector = base::Point<float>{-1.0f, 0.0f};
         REQUIRE(fireShotParameters.position == expectedPosition);
-        REQUIRE(fireShotParameters.velocity == expectedVelocity);
+        REQUIRE(fireShotParameters.directionVector == expectedVector);
       }
     }
 
@@ -215,9 +215,9 @@ TEST_CASE("Player attack system works as expected") {
         updateWithInput(shootingInputState);
 
         const auto expectedPosition = WorldPosition{2, -5};
-        const auto expectedVelocity = base::Point<float>{0.0f, -2.0f};
+        const auto expectedVector = base::Point<float>{0.0f, -1.0f};
         REQUIRE(fireShotParameters.position == expectedPosition);
-        REQUIRE(fireShotParameters.velocity == expectedVelocity);
+        REQUIRE(fireShotParameters.directionVector == expectedVector);
       }
 
       SECTION("Facing left") {
@@ -226,9 +226,9 @@ TEST_CASE("Player attack system works as expected") {
         updateWithInput(shootingInputState);
 
         const auto expectedPosition = WorldPosition{0, -5};
-        const auto expectedVelocity = base::Point<float>{0.0f, -2.0f};
+        const auto expectedVector = base::Point<float>{0.0f, -1.0f};
         REQUIRE(fireShotParameters.position == expectedPosition);
-        REQUIRE(fireShotParameters.velocity == expectedVelocity);
+        REQUIRE(fireShotParameters.directionVector == expectedVector);
       }
     }
   }


### PR DESCRIPTION
Adds support for the different player weapons (laser, flame thrower, rocket launcher). The player's shots now have the correct sound, sprite, and damage multiplier according to the currently carried weapon. The non-regular weapons use ammo, and are reset back to the normal weapon when they are depleted.

Still missing at this point:

- always rapid fire for flame thrower
- laser going through enemies/walls
- flame thrower going through walls?? Not entirely clear yet, but seems like that's the case in the original game
- downwards shot (jetpack) for flame thrower
- weird projectile positioning for left-facing shots as found in the original game

It's also worth noting that the original game doesn't show ammo consumption correctly for the flame thrower. The flame thrower has twice as much ammo (64 instead of 32) as the other weapons. RigelEngine correctly accounts for that, and simply makes the ammo bar go down slower when using the flame thrower. But the original game would use the same scaling as for the other weapons, so the first 32 shots would not show any change on the ammo bar (everything above 32 was simply out of range), and the last 32 would make the bar go down as if the weapon had only ever had 32 shots. I decided that it's not worth it to recreate this bug 😉