### PR TITLE
Shootable walls

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,7 @@ set(core_sources
     engine/timing.hpp
     engine/visual_components.hpp
     game_logic/collectable_components.hpp
+    game_logic/damage_components.hpp
     game_logic/damage_infliction_system.cpp
     game_logic/damage_infliction_system.hpp
     game_logic/entity_configuration.ipp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,7 @@ set(core_sources
     game_logic/damage_components.hpp
     game_logic/damage_infliction_system.cpp
     game_logic/damage_infliction_system.hpp
+    game_logic/dynamic_geometry_components.hpp
     game_logic/entity_configuration.ipp
     game_logic/entity_factory.cpp
     game_logic/entity_factory.hpp

--- a/src/data/map.cpp
+++ b/src/data/map.cpp
@@ -78,6 +78,13 @@ void Map::clearSection(
 }
 
 
+bool Map::coordinatesValid(const int xS, const int yS) const {
+  const auto x = static_cast<size_t>(xS);
+  const auto y = static_cast<size_t>(yS);
+  return x < mWidthInTiles && y < mHeightInTiles;
+}
+
+
 const map::TileIndex& Map::tileRefAt(
   const int layerS,
   const int xS,

--- a/src/data/map.cpp
+++ b/src/data/map.cpp
@@ -63,6 +63,21 @@ void Map::setTileAt(
 }
 
 
+void Map::clearSection(
+  const int x,
+  const int y,
+  const int width,
+  const int height
+) {
+  for (auto row = y; row < y+height; ++row) {
+    for (auto col = x; col < x + width; ++col) {
+      setTileAt(0, col, row, 0);
+      setTileAt(1, col, row, 0);
+    }
+  }
+}
+
+
 const map::TileIndex& Map::tileRefAt(
   const int layerS,
   const int xS,

--- a/src/data/map.hpp
+++ b/src/data/map.hpp
@@ -70,6 +70,8 @@ public:
     return static_cast<int>(mHeightInTiles);
   }
 
+  void clearSection(int x, int y, int width, int height);
+
 
 private:
   const TileIndex& tileRefAt(int layer, int x, int y) const;

--- a/src/data/map.hpp
+++ b/src/data/map.hpp
@@ -72,6 +72,9 @@ public:
 
   void clearSection(int x, int y, int width, int height);
 
+  /** Returns true if the given coordinates are valid/inside the map. */
+  bool coordinatesValid(int x, int y) const;
+
 
 private:
   const TileIndex& tileRefAt(int layer, int x, int y) const;

--- a/src/engine/physics_system.cpp
+++ b/src/engine/physics_system.cpp
@@ -44,23 +44,12 @@ BoundingBox toWorldSpace(
 
 
 PhysicsSystem::PhysicsSystem(
-  const data::map::Map& map,
-  const data::map::TileAttributes& tileAttributes
+  const data::map::Map* pMap,
+  const data::map::TileAttributes* pTileAttributes
 )
-  : mCollisionData(map.width(), map.height())
+  : mpMap(pMap)
+  , mpTileAttributes(pTileAttributes)
 {
-  for (int row=0; row<map.height(); ++row) {
-    for (int col=0; col<map.width(); ++col) {
-      auto collisionData1 =
-        tileAttributes.collisionData(
-          map.tileAt(0, col, row));
-      auto collisionData2 =
-        tileAttributes.collisionData(
-          map.tileAt(1, col, row));
-      mCollisionData.setValueAt(
-        col, row, CollisionData{collisionData1, collisionData2});
-    }
-  }
 }
 
 
@@ -131,11 +120,19 @@ void PhysicsSystem::update(
 }
 
 
-const data::map::CollisionData& PhysicsSystem::worldAt(
+data::map::CollisionData PhysicsSystem::worldAt(
   const int x, const int y
 ) const {
-  static const auto emptyCollisionData = CollisionData{};
-  return mCollisionData.valueAtWithDefault(x, y, emptyCollisionData);
+  if (!mpMap->coordinatesValid(x, y)) {
+    return CollisionData{};
+  }
+
+  const auto collisionData1 =
+    mpTileAttributes->collisionData(mpMap->tileAt(0, x, y));
+  const auto collisionData2 =
+    mpTileAttributes->collisionData(mpMap->tileAt(1, x, y));
+
+  return CollisionData{collisionData1, collisionData2};
 }
 
 

--- a/src/engine/physics_system.hpp
+++ b/src/engine/physics_system.hpp
@@ -50,8 +50,8 @@ namespace rigel { namespace engine {
 class PhysicsSystem : public entityx::System<PhysicsSystem> {
 public:
   explicit PhysicsSystem(
-    const data::map::Map& map,
-    const data::map::TileAttributes& tileAttributes);
+    const data::map::Map* pMap,
+    const data::map::TileAttributes* pTileAttributes);
 
   void update(
     entityx::EntityManager& es,
@@ -59,7 +59,7 @@ public:
     entityx::TimeDelta dt) override;
 
 private:
-  const data::map::CollisionData& worldAt(int x, int y) const;
+  data::map::CollisionData worldAt(int x, int y) const;
 
   std::tuple<base::Vector, bool> applyHorizontalMovement(
     const components::BoundingBox& bbox,
@@ -81,7 +81,8 @@ private:
     float currentVelocity);
 
 private:
-  base::Grid<data::map::CollisionData> mCollisionData;
+  const data::map::Map* mpMap;
+  const data::map::TileAttributes* mpTileAttributes;
   TimeStepper mTimeStepper;
 };
 

--- a/src/game_logic/damage_infliction_system.hpp
+++ b/src/game_logic/damage_infliction_system.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "base/warnings.hpp"
+#include "data/map.hpp"
 
 RIGEL_DISABLE_WARNINGS
 #include <entityx/entityx.h>
@@ -33,6 +34,7 @@ class DamageInflictionSystem : public entityx::System<DamageInflictionSystem> {
 public:
   DamageInflictionSystem(
     data::PlayerModel* pPlayerModel,
+    data::map::Map* pMap,
     IGameServiceProvider* pServiceProvider);
 
   void update(
@@ -43,6 +45,7 @@ public:
 
 private:
   data::PlayerModel* mpPlayerModel;
+  data::map::Map* mpMap;
   IGameServiceProvider* mpServiceProvider;
 };
 

--- a/src/game_logic/dynamic_geometry_components.hpp
+++ b/src/game_logic/dynamic_geometry_components.hpp
@@ -1,0 +1,34 @@
+/* Copyright (C) 2016, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "engine/base_components.hpp"
+
+
+namespace rigel { namespace game_logic { namespace components {
+
+struct MapGeometryLink {
+  explicit MapGeometryLink(engine::components::BoundingBox geometrySection)
+    : mLinkedGeometrySection(geometrySection)
+  {
+  }
+
+  engine::components::BoundingBox mLinkedGeometrySection;
+};
+
+
+}}}

--- a/src/game_logic/entity_configuration.ipp
+++ b/src/game_logic/entity_configuration.ipp
@@ -798,8 +798,24 @@ void configureEntity(
       entity.assign<Trigger>(TriggerType::LevelExit);
       break;
 
-    case 102: // dynamic wall: falls down, sinks into ground (when seen)
     case 106: // shootable wall, explodes into small pieces
+      entity.assign<Shootable>(1);
+      {
+        // If we keep the bounding box unchanged, the collision from the
+        // underlying map geometry will prevent projectiles from ever reaching
+        // the bounding box, thus preventing the wall's destruction.
+        // Making the bounding box slightly wider solves this problem in a
+        // simple way, without making the world collision detection more
+        // complicated. It seems that the original game is actually doing
+        // something similar, too.
+        auto adjustedBbox = boundingBox;
+        adjustedBbox.size.width += 2;
+        adjustedBbox.topLeft.x -= 1;
+        entity.assign<BoundingBox>(adjustedBbox);
+      }
+      break;
+
+    case 102: // dynamic wall: falls down, sinks into ground (when seen)
     case 116: // door, opened by blue key (slides into ground)
     case 137: // unknown dynamic geometry
     case 138: // dynamic wall: falls down, stays intact

--- a/src/game_logic/entity_factory.hpp
+++ b/src/game_logic/entity_factory.hpp
@@ -64,14 +64,6 @@ public:
 
 private:
   using IdAndFrameNr = std::pair<data::ActorID, std::size_t>;
-  using VisualsAndBounds = std::tuple<
-    boost::optional<engine::components::Sprite>,
-    engine::components::BoundingBox>;
-
-  VisualsAndBounds createVisualsAndBoundingBox(
-    const data::map::LevelData::Actor& actor,
-    data::map::Map& map
-  );
 
   engine::components::Sprite createSpriteForId(const data::ActorID actorID);
 

--- a/src/ingame_mode.cpp
+++ b/src/ingame_mode.cpp
@@ -243,8 +243,8 @@ void IngameMode::loadLevel(
   };
 
   mEntities.systems.add<PhysicsSystem>(
-    mLevelData.mMap,
-    mLevelData.mTileAttributes);
+    &mLevelData.mMap,
+    &mLevelData.mTileAttributes);
   mEntities.systems.add<game_logic::PlayerControlSystem>(
     mPlayerEntity,
     &mPlayerInputs,

--- a/src/ingame_mode.cpp
+++ b/src/ingame_mode.cpp
@@ -288,6 +288,7 @@ void IngameMode::loadLevel(
     mpServiceProvider);
   mEntities.systems.add<DamageInflictionSystem>(
     &mPlayerModel,
+    &mLevelData.mMap,
     mpServiceProvider);
   mEntities.systems.configure();
 


### PR DESCRIPTION
Implements shootable walls, like they are found in the very first level (L1). As a side-effect, all dynamic geometry is now part of the level, even if its behavior isn't implemented yet. This means the exit isn't reachable anymore in some levels, where it could only be reached because dynamic geometry like doors was being removed. This is not really a big deal though, since we want to focus on getting L1 playable first, and there is no dynamic geometry besides shootable walls in that level.

Closes #32 