### PR TITLE
Key-card force field

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,8 @@ set(core_sources
     game_logic/entity_configuration.ipp
     game_logic/entity_factory.cpp
     game_logic/entity_factory.hpp
+    game_logic/interaction/force_field.cpp
+    game_logic/interaction/force_field.hpp
     game_logic/map_scroll_system.cpp
     game_logic/map_scroll_system.hpp
     game_logic/player/animation_system.cpp

--- a/src/data/player_data.hpp
+++ b/src/data/player_data.hpp
@@ -88,6 +88,14 @@ struct PlayerModel {
     return mWeapon != WeaponType::Normal;
   }
 
+  bool hasItem(const InventoryItemType type) const {
+    return mInventory.count(type) != 0;
+  }
+
+  void removeItem(const InventoryItemType type) {
+    mInventory.erase(type);
+  }
+
   std::unordered_set<CollectableLetterType> mCollectedLetters;
   std::unordered_set<InventoryItemType> mInventory;
 };

--- a/src/game_logic/entity_configuration.ipp
+++ b/src/game_logic/entity_configuration.ipp
@@ -224,9 +224,11 @@ void configureEntity(
 
     // Circuit card force field
     case 119:
-      entity.assign<Animated>(Animated{{AnimationSequence(2, 2, 4, 2)}});
-      entity.assign<PlayerDamaging>(9, true);
-      entity.assign<BoundingBox>(BoundingBox{{0, -4}, {2, 10}});
+      interaction::configureForceField(entity);
+      break;
+
+    case 120: // Keyhole (circuit board)
+      interaction::configureKeyCardSlot(entity, boundingBox);
       break;
 
     // Keyhole (blue key)
@@ -754,7 +756,6 @@ void configureEntity(
       entity.assign<Animated>(Animated{{AnimationSequence(2)}});
       break;
 
-    case 120: // Keyhole (circuit board)
     case 188: // rotating floor spikes
     case 210: // Computer showing "Duke escaped"
     case 222: // Lava fall left
@@ -948,10 +949,6 @@ void configureSprite(Sprite& sprite, const ActorID actorID) {
 
     case 171:
       sprite.mFramesToRender = {6};
-      break;
-
-    case 119:
-      sprite.mFramesToRender = {0, 1, 2};
       break;
 
     case 200:

--- a/src/game_logic/entity_configuration.ipp
+++ b/src/game_logic/entity_configuration.ipp
@@ -548,7 +548,7 @@ void configureEntity(
     case 50: // teleporter
     case 51: // teleporter
       entity.assign<Animated>(Animated{{AnimationSequence(2)}});
-      entity.assign<Interactable>(Interactable{InteractableType::Teleporter});
+      entity.assign<Interactable>(InteractableType::Teleporter);
       addDefaultPhysical(entity, boundingBox);
       break;
 

--- a/src/game_logic/entity_factory.cpp
+++ b/src/game_logic/entity_factory.cpp
@@ -23,6 +23,7 @@
 #include "game_logic/collectable_components.hpp"
 #include "game_logic/damage_components.hpp"
 #include "game_logic/dynamic_geometry_components.hpp"
+#include "game_logic/interaction/force_field.hpp"
 #include "game_logic/player_movement_system.hpp"
 #include "game_logic/trigger_components.hpp"
 

--- a/src/game_logic/interaction/force_field.cpp
+++ b/src/game_logic/interaction/force_field.cpp
@@ -1,0 +1,88 @@
+/* Copyright (C) 2016, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "force_field.hpp"
+
+#include "data/player_data.hpp"
+#include "engine/base_components.hpp"
+#include "engine/visual_components.hpp"
+#include "game_logic/damage_components.hpp"
+#include "game_logic/player/components.hpp"
+
+
+namespace ex = entityx;
+
+namespace rigel { namespace game_logic { namespace interaction {
+
+using namespace engine::components;
+using namespace game_logic::components;
+
+void configureForceField(entityx::Entity entity) {
+  entity.assign<Animated>(Animated{{AnimationSequence(2, 2, 4, 2)}});
+  entity.assign<PlayerDamaging>(9, true);
+  entity.assign<BoundingBox>(BoundingBox{{0, -4}, {2, 10}});
+  entity.assign<CircuitCardForceField>();
+
+  // The first two render slots represent the static parts of the force field
+  // (the blue emitters on top and bottom), the third is for the force field/
+  // electricity itself.
+  entity.component<Sprite>()->mFramesToRender = {0, 1, 2};
+}
+
+
+void configureKeyCardSlot(
+  entityx::Entity entity,
+  const BoundingBox& boundingBox
+) {
+  entity.assign<Interactable>(InteractableType::ForceFieldCardReader);
+  entity.assign<Animated>(Animated{{AnimationSequence(2)}});
+  entity.assign<BoundingBox>(boundingBox);
+}
+
+
+bool disableForceField(
+  entityx::EntityManager& es,
+  entityx::Entity keyCardSlot,
+  data::PlayerModel* pPlayerModel
+) {
+  const auto canDisable =
+    pPlayerModel->hasItem(data::InventoryItemType::CircuitBoard);
+
+  if (canDisable) {
+    pPlayerModel->removeItem(data::InventoryItemType::CircuitBoard);
+
+    // TODO: Only turn off force fields that are visible on screen
+    es.each<CircuitCardForceField>(
+      [](ex::Entity entity, const CircuitCardForceField&) {
+        entity.remove<Animated>();
+        entity.remove<BoundingBox>();
+        entity.remove<CircuitCardForceField>();
+        entity.remove<PlayerDamaging>();
+
+        // Stop rendering the electricity/force field part, see
+        // configureForceField() above
+        entity.component<Sprite>()->mFramesToRender.pop_back();
+      });
+
+    keyCardSlot.remove<Interactable>();
+    keyCardSlot.remove<Animated>();
+    keyCardSlot.remove<BoundingBox>();
+  }
+
+  return canDisable;
+}
+
+}}}

--- a/src/game_logic/interaction/force_field.hpp
+++ b/src/game_logic/interaction/force_field.hpp
@@ -1,0 +1,51 @@
+/* Copyright (C) 2016, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "base/warnings.hpp"
+#include "engine/base_components.hpp"
+
+RIGEL_DISABLE_WARNINGS
+#include <entityx/entityx.h>
+RIGEL_RESTORE_WARNINGS
+
+namespace rigel { namespace data { struct PlayerModel; }}
+
+
+namespace rigel { namespace game_logic { namespace interaction {
+
+void configureForceField(entityx::Entity entity);
+void configureKeyCardSlot(
+  entityx::Entity entity,
+  const engine::components::BoundingBox& boundingBox);
+
+/** Disable force-field if possible
+ *
+ * To be called when the player tries to interact with a key-card slot.
+ * If they have the key-card in their inventory, corresponding force-fields
+ * will be disabled, and the card removed from their invenotry.
+ * Otherwise, nothing happens.
+ *
+ * @returns true if force field(s) were disabled, false otherwise (i.e. player
+ *   didn't have the key-card).
+ */
+bool disableForceField(
+  entityx::EntityManager& es,
+  entityx::Entity keyCardSlot,
+  data::PlayerModel* pPlayerModel);
+
+}}}

--- a/src/game_logic/player/components.hpp
+++ b/src/game_logic/player/components.hpp
@@ -96,7 +96,8 @@ struct PlayerControlled {
 
 
 enum class InteractableType {
-  Teleporter
+  Teleporter,
+  ForceFieldCardReader
 };
 
 
@@ -108,6 +109,9 @@ struct Interactable {
 
   InteractableType mType;
 };
+
+
+struct CircuitCardForceField {};
 
 }
 

--- a/src/game_logic/player/components.hpp
+++ b/src/game_logic/player/components.hpp
@@ -99,7 +99,13 @@ enum class InteractableType {
   Teleporter
 };
 
+
 struct Interactable {
+  explicit Interactable(const InteractableType type)
+    : mType(type)
+  {
+  }
+
   InteractableType mType;
 };
 

--- a/src/game_logic/player_interaction_system.cpp
+++ b/src/game_logic/player_interaction_system.cpp
@@ -3,14 +3,19 @@
 #include "data/player_data.hpp"
 #include "engine/base_components.hpp"
 #include "engine/physics_system.hpp"
+#include "engine/visual_components.hpp"
 #include "game_logic/collectable_components.hpp"
+#include "game_logic/damage_components.hpp"
+#include "game_logic/interaction/force_field.hpp"
 #include "game_mode.hpp"
 
 
 namespace rigel { namespace game_logic {
 
 using data::PlayerModel;
+using engine::components::Animated;
 using engine::components::BoundingBox;
+using engine::components::Sprite;
 using engine::components::WorldPosition;
 using player::PlayerState;
 
@@ -171,6 +176,10 @@ void PlayerInteractionSystem::performInteraction(
             }
           });
       }
+      break;
+
+    case InteractableType::ForceFieldCardReader:
+      interaction::disableForceField(es, interactable, mpPlayerModel);
       break;
   }
 }


### PR DESCRIPTION
This implements disabling the force field if the player is carrying the key-card (circuit board). It's functional, but there are still some parts missing: The player doesn't show the "interacting" animation, the message ("Access granted") is not displayed, and the player isn't temporarily locked in position.

Closes #30 

