### PR TITLE
Introduce an 'active region' for entities

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,9 @@ set(core_sources
     engine/entity_activation_system.cpp
     engine/entity_activation_system.hpp
     engine/entity_tools.hpp
+    engine/life_time_components.hpp
+    engine/life_time_system.cpp
+    engine/life_time_system.hpp
     engine/map_renderer.cpp
     engine/map_renderer.hpp
     engine/physical_components.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,9 +19,9 @@ set(core_sources
     data/unit_conversions.cpp
     data/unit_conversions.hpp
     engine/base_components.hpp
-    engine/entity_tools.hpp
     engine/debugging_system.cpp
     engine/debugging_system.hpp
+    engine/entity_tools.hpp
     engine/map_renderer.cpp
     engine/map_renderer.hpp
     engine/physical_components.hpp
@@ -63,10 +63,10 @@ set(core_sources
     game_logic/player/components.hpp
     game_logic/player/damage_system.cpp
     game_logic/player/damage_system.hpp
-    game_logic/player_movement_system.cpp
-    game_logic/player_movement_system.hpp
     game_logic/player_interaction_system.cpp
     game_logic/player_interaction_system.hpp
+    game_logic/player_movement_system.cpp
+    game_logic/player_movement_system.hpp
     game_logic/trigger_components.hpp
     loader/actor_image_package.cpp
     loader/actor_image_package.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,8 @@ set(core_sources
     engine/base_components.hpp
     engine/debugging_system.cpp
     engine/debugging_system.hpp
+    engine/entity_activation_system.cpp
+    engine/entity_activation_system.hpp
     engine/entity_tools.hpp
     engine/map_renderer.cpp
     engine/map_renderer.hpp

--- a/src/engine/base_components.hpp
+++ b/src/engine/base_components.hpp
@@ -24,6 +24,40 @@ namespace rigel { namespace engine { namespace components {
 using WorldPosition = base::Vector;
 using BoundingBox = base::Rect<int>;
 
+/** Marks entity as active
+ *
+ * Most systems should only operate on active entities. Entity activation
+ * depends on their ActivationSettings - by default, entities will only be
+ * active if their bounding box intersects the active region, i.e. they are
+ * visible on screen.
+ * */
+struct Active {};
+
+/** Specifies when to activate entity */
+struct ActivationSettings {
+  enum class Policy {
+    // Entity is always active
+    Always,
+
+    // Entity is inactive until it appeared on screen once, it remains
+    // active from then on
+    AlwaysAfterFirstActivation,
+
+    // Entity is only active while on screen. Specifically, its bounding box
+    // must intersect the active region.
+    WhenOnScreen
+  };
+
+  ActivationSettings() = default;
+  explicit ActivationSettings(const Policy policy)
+    : mPolicy(policy)
+  {
+  }
+
+  Policy mPolicy = Policy::WhenOnScreen;
+  bool mHasBeenActivated = false;
+};
+
 }
 
 

--- a/src/engine/entity_activation_system.cpp
+++ b/src/engine/entity_activation_system.cpp
@@ -1,0 +1,102 @@
+/* Copyright (C) 2016, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "entity_activation_system.hpp"
+
+#include "data/game_traits.hpp"
+#include "engine/base_components.hpp"
+#include "engine/entity_tools.hpp"
+#include "engine/physical_components.hpp"
+
+
+namespace rigel { namespace engine {
+
+using namespace components;
+
+
+namespace {
+
+bool determineActiveState(entityx::Entity entity, const bool inActiveRegion) {
+  using Policy = ActivationSettings::Policy;
+
+  if (entity.has_component<ActivationSettings>()) {
+    auto& settings = *entity.component<ActivationSettings>();
+
+    switch (settings.mPolicy) {
+      case Policy::Always:
+        return true;
+
+      case Policy::AlwaysAfterFirstActivation:
+        if (!settings.mHasBeenActivated && inActiveRegion) {
+          settings.mHasBeenActivated = true;
+        }
+
+        return settings.mHasBeenActivated;
+
+      default:
+        break;
+    }
+  }
+
+  // Default: Active when on screen
+  return inActiveRegion;
+}
+
+
+void markActiveEntites(
+  entityx::EntityManager& es,
+  const base::Vector& scrollOffset
+) {
+  const BoundingBox activeRegionBox{
+    scrollOffset,
+    data::GameTraits::mapViewPortSize};
+
+  es.each<WorldPosition, BoundingBox>([&activeRegionBox](
+    entityx::Entity entity,
+    const WorldPosition& position,
+    const BoundingBox& bbox
+  ) {
+    const auto worldSpaceBbox = toWorldSpace(bbox, position);
+    const auto inActiveRegion = worldSpaceBbox.intersects(activeRegionBox);
+    const auto active = determineActiveState(entity, inActiveRegion);
+    setTag<Active>(entity, active);
+  });
+}
+
+}
+
+
+EntityActivationSystem::EntityActivationSystem(
+  const base::Vector* pScrollOffset
+)
+  : mpScrollOffset(pScrollOffset)
+  , mPreviousScrollOffset(*pScrollOffset)
+{
+}
+
+
+void EntityActivationSystem::update(
+  entityx::EntityManager& es,
+  entityx::EventManager&,
+  entityx::TimeDelta
+) {
+  if (*mpScrollOffset != mPreviousScrollOffset) {
+    markActiveEntites(es, *mpScrollOffset);
+    mPreviousScrollOffset = *mpScrollOffset;
+  }
+}
+
+}}

--- a/src/engine/entity_activation_system.hpp
+++ b/src/engine/entity_activation_system.hpp
@@ -1,0 +1,43 @@
+/* Copyright (C) 2016, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "base/spatial_types.hpp"
+#include "base/warnings.hpp"
+
+RIGEL_DISABLE_WARNINGS
+#include <entityx/entityx.h>
+RIGEL_RESTORE_WARNINGS
+
+
+namespace rigel { namespace engine {
+
+class EntityActivationSystem : public entityx::System<EntityActivationSystem> {
+public:
+  explicit EntityActivationSystem(const base::Vector* pScrollOffset);
+
+  void update(
+    entityx::EntityManager& es,
+    entityx::EventManager& events,
+    entityx::TimeDelta dt) override;
+
+private:
+  const base::Vector* mpScrollOffset;
+  base::Vector mPreviousScrollOffset;
+};
+
+}}

--- a/src/engine/life_time_components.hpp
+++ b/src/engine/life_time_components.hpp
@@ -1,0 +1,49 @@
+/* Copyright (C) 2016, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "engine/base_components.hpp"
+
+#include <initializer_list>
+
+
+namespace rigel { namespace engine { namespace components {
+
+/** Marks entity to be destroyed when some condition is fulfilled */
+struct AutoDestroy {
+  enum class Condition {
+    OnWorldCollision = 1,
+    OnLeavingActiveRegion = 2
+  };
+
+  explicit AutoDestroy(const Condition condition)
+    : AutoDestroy({condition})
+  {
+  }
+
+  explicit AutoDestroy(std::initializer_list<Condition> conditions)
+  {
+    for (const auto condition : conditions) {
+      const auto conditionValue = static_cast<std::size_t>(condition);
+      mConditionFlags |= conditionValue;
+    }
+  }
+
+  int mConditionFlags;
+};
+
+}}}

--- a/src/engine/life_time_system.cpp
+++ b/src/engine/life_time_system.cpp
@@ -1,0 +1,54 @@
+/* Copyright (C) 2016, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "life_time_system.hpp"
+
+#include "engine/physical_components.hpp"
+
+
+namespace rigel { namespace engine {
+
+void LifeTimeSystem::update(
+  entityx::EntityManager& es,
+  entityx::EventManager& events,
+  entityx::TimeDelta dt
+) {
+  using Condition = components::AutoDestroy::Condition;
+  es.each<components::AutoDestroy>([](
+    entityx::Entity entity,
+    const components::AutoDestroy& autoDestroyProperties
+  ) {
+    const auto flags = autoDestroyProperties.mConditionFlags;
+
+    const auto conditionIsSet = [&flags](const Condition condition) {
+      const auto conditionValue = static_cast<int>(condition);
+      return (flags & conditionValue) != 0;
+    };
+
+    const auto mustDestroy =
+      (conditionIsSet(Condition::OnWorldCollision) &&
+        entity.has_component<components::CollidedWithWorld>()) ||
+      (conditionIsSet(Condition::OnLeavingActiveRegion) &&
+        !entity.has_component<components::Active>());
+
+    if (mustDestroy) {
+      entity.destroy();
+    }
+  });
+}
+
+}}
+

--- a/src/engine/life_time_system.hpp
+++ b/src/engine/life_time_system.hpp
@@ -1,0 +1,36 @@
+/* Copyright (C) 2016, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "engine/life_time_components.hpp"
+
+RIGEL_DISABLE_WARNINGS
+#include <entityx/entityx.h>
+RIGEL_RESTORE_WARNINGS
+
+
+namespace rigel { namespace engine {
+
+class LifeTimeSystem : public entityx::System<LifeTimeSystem> {
+public:
+  void update(
+    entityx::EntityManager& es,
+    entityx::EventManager& events,
+    entityx::TimeDelta dt) override;
+};
+
+}}

--- a/src/engine/physics_system.cpp
+++ b/src/engine/physics_system.cpp
@@ -79,12 +79,13 @@ void PhysicsSystem::update(
         std::make_tuple(entity, toWorldSpace(bbox, pos)));
     });
 
-  es.each<Physical, WorldPosition, BoundingBox>(
+  es.each<Physical, WorldPosition, BoundingBox, components::Active>(
     [this](
       ex::Entity entity,
       Physical& physical,
       WorldPosition& position,
-      const BoundingBox& collisionRect
+      const BoundingBox& collisionRect,
+      const components::Active&
     ) {
       const auto originalPosition = position;
 

--- a/src/game_logic/damage_infliction_system.cpp
+++ b/src/game_logic/damage_infliction_system.cpp
@@ -100,18 +100,6 @@ void DamageInflictionSystem::update(
         }
       }
     });
-
-  // TODO: Move this into a separate system once enemy projectiles are
-  // implemented. E.g., add a component to tag entities to be destroyed on
-  // collision, and a corresponding system
-  es.each<DamageInflicting, CollidedWithWorld>(
-    [](
-      ex::Entity inflictor,
-      const DamageInflicting&,
-      const CollidedWithWorld&
-    ) {
-      inflictor.destroy();
-    });
 }
 
 }}

--- a/src/game_logic/entity_configuration.ipp
+++ b/src/game_logic/entity_configuration.ipp
@@ -174,8 +174,9 @@ void configureProjectile(
     Physical{directionToVector(direction) * speed, false});
   entity.assign<DamageInflicting>(damageAmount);
 
-  entity.assign<engine::components::AutoDestroy>(
-    engine::components::AutoDestroy::Condition::OnWorldCollision);
+  entity.assign<AutoDestroy>(AutoDestroy{
+    AutoDestroy::Condition::OnWorldCollision,
+    AutoDestroy::Condition::OnLeavingActiveRegion});
 }
 
 

--- a/src/game_logic/entity_configuration.ipp
+++ b/src/game_logic/entity_configuration.ipp
@@ -173,6 +173,9 @@ void configureProjectile(
   entity.assign<Physical>(
     Physical{directionToVector(direction) * speed, false});
   entity.assign<DamageInflicting>(damageAmount);
+
+  entity.assign<engine::components::AutoDestroy>(
+    engine::components::AutoDestroy::Condition::OnWorldCollision);
 }
 
 

--- a/src/game_logic/entity_factory.cpp
+++ b/src/game_logic/entity_factory.cpp
@@ -42,14 +42,7 @@ using namespace std;
 
 using data::ActorID;
 
-using engine::components::Animated;
-using engine::components::AnimationSequence;
-using engine::components::BoundingBox;
-using engine::components::DrawTopMost;
-using engine::components::Physical;
-using engine::components::Sprite;
-using engine::components::SpriteFrame;
-using engine::components::WorldPosition;
+using namespace engine::components;
 using namespace game_logic::components;
 
 
@@ -82,6 +75,8 @@ void addDefaultPhysical(
 ) {
   entity.assign<Physical>(Physical{{0.0f, 0.0f}, true});
   entity.assign<BoundingBox>(boundingBox);
+  entity.assign<ActivationSettings>(
+    ActivationSettings::Policy::AlwaysAfterFirstActivation);
 }
 
 
@@ -162,6 +157,8 @@ entityx::Entity EntityFactory::createProjectile(
   sprite.mDrawOrder += PROJECTILE_DRAW_ORDER_ADJUSTMENT;
 
   const auto boundingBox = inferBoundingBox(sprite.mFrames[0]);
+
+  entity.assign<Active>();
   entity.assign<Sprite>(sprite);
   entity.assign<BoundingBox>(boundingBox);
 

--- a/src/game_logic/entity_factory.cpp
+++ b/src/game_logic/entity_factory.cpp
@@ -18,6 +18,7 @@
 
 #include "data/unit_conversions.hpp"
 #include "engine/base_components.hpp"
+#include "engine/life_time_components.hpp"
 #include "engine/physics_system.hpp"
 #include "game_logic/ai/security_camera.hpp"
 #include "game_logic/collectable_components.hpp"

--- a/src/game_logic/interaction/elevator.cpp
+++ b/src/game_logic/interaction/elevator.cpp
@@ -51,9 +51,12 @@ int determineMovementDirection(const PlayerInputState& inputState) {
 
 
 void configureElevator(entityx::Entity entity) {
+  using engine::components::ActivationSettings;
+
   entity.assign<components::Elevator>();
   entity.assign<BoundingBox>(BoundingBox{{0, 0}, {4, 3}});
   entity.assign<Physical>(base::Point<float>{0.0f, 0.0f}, true);
+  entity.assign<ActivationSettings>(ActivationSettings::Policy::Always);
   entity.assign<SolidBody>();
 }
 

--- a/src/ingame_mode.cpp
+++ b/src/ingame_mode.cpp
@@ -21,6 +21,7 @@
 #include "data/sound_ids.hpp"
 #include "engine/debugging_system.hpp"
 #include "engine/entity_activation_system.hpp"
+#include "engine/life_time_system.hpp"
 #include "engine/physics_system.hpp"
 #include "engine/rendering_system.hpp"
 #include "game_logic/ai/security_camera.hpp"
@@ -230,6 +231,8 @@ void IngameMode::updateAndRender(engine::TimeDelta dt) {
   mEntities.systems.update<player::AnimationSystem>(dt);
   mEntities.systems.update<MapScrollSystem>(dt);
 
+  mEntities.systems.update<engine::LifeTimeSystem>(dt);
+
   // **********************************************************************
   // Rendering
   // **********************************************************************
@@ -347,6 +350,7 @@ void IngameMode::loadLevel(
     &mLevelData.mMap,
     mpServiceProvider);
   mEntities.systems.add<ai::SecurityCameraSystem>(mPlayerEntity);
+  mEntities.systems.add<engine::LifeTimeSystem>();
   mEntities.systems.add<DebuggingSystem>(
     mpRenderer,
     &mScrollOffset,

--- a/src/ingame_mode.cpp
+++ b/src/ingame_mode.cpp
@@ -20,6 +20,7 @@
 #include "data/map.hpp"
 #include "data/sound_ids.hpp"
 #include "engine/debugging_system.hpp"
+#include "engine/entity_activation_system.hpp"
 #include "engine/physics_system.hpp"
 #include "engine/rendering_system.hpp"
 #include "game_logic/ai/security_camera.hpp"
@@ -202,6 +203,8 @@ void IngameMode::updateAndRender(engine::TimeDelta dt) {
   mEntities.systems.system<interaction::ElevatorSystem>()->setInputState(
     mPlayerInputs);
 
+  mEntities.systems.update<engine::EntityActivationSystem>(dt);
+
   // ----------------------------------------------------------------------
   // Player logic update
   // ----------------------------------------------------------------------
@@ -295,6 +298,7 @@ void IngameMode::loadLevel(
 
   mEntities.systems.add<PhysicsSystem>(
     &mLevelData.mMap);
+  mEntities.systems.add<engine::EntityActivationSystem>(&mScrollOffset);
   mEntities.systems.add<game_logic::PlayerMovementSystem>(
     mPlayerEntity,
     &mPlayerInputs,

--- a/test/test_elevator.cpp
+++ b/test/test_elevator.cpp
@@ -41,6 +41,7 @@ TEST_CASE("Rocket elevator") {
   ex::EntityX entityx;
   auto player = entityx.entities.create();
   player.assign<WorldPosition>(6, 100);
+  player.assign<Active>();
   initializePlayerEntity(player, true);
 
   auto& playerPosition = *player.component<WorldPosition>();
@@ -48,6 +49,7 @@ TEST_CASE("Rocket elevator") {
 
   auto elevator = entityx.entities.create();
   elevator.assign<WorldPosition>(2, 103);
+  elevator.assign<Active>();
   interaction::configureElevator(elevator);
 
   data::map::Map map{300, 300, data::map::TileAttributes{{0x0, 0xF}}};

--- a/test/test_physics_system.cpp
+++ b/test/test_physics_system.cpp
@@ -48,9 +48,117 @@ TEST_CASE("Physics system works as expected") {
   auto& physical = *physicalObject.component<Physical>();
   auto& position = *physicalObject.component<WorldPosition>();
 
-  const auto runOneFrame = [&physicsSystem, &entityx]() {
-    physicsSystem.update(entityx.entities, entityx.events, gameFramesToTime(1));
+  const auto update = [&physicsSystem, &entityx](const TimeDelta dt) {
+    physicsSystem.update(entityx.entities, entityx.events, dt);
   };
+  const auto runOneFrame = [&update]() {
+    update(gameFramesToTime(1));
+  };
+
+
+  SECTION("Objects move according to their velocity") {
+    physical.mGravityAffected = false;
+
+    SECTION("No movement when velocity is 0") {
+      const auto previousPosition = position;
+
+      physical.mVelocity.x = 0.0f;
+      runOneFrame();
+      CHECK(position == previousPosition);
+    }
+
+    physical.mVelocity.x = 4.0f;
+
+    SECTION("Object's position changes") {
+      SECTION("To the right") {
+        runOneFrame();
+        CHECK(position.x == 4);
+      }
+
+      position.x = 4;
+
+      SECTION("To the left") {
+        physical.mVelocity.x = -1.0f;
+        runOneFrame();
+        CHECK(position.x == 3);
+      }
+
+      physical.mVelocity.x = 0.0f;
+
+      SECTION("Movement stops when setting velocity to 0") {
+        runOneFrame();
+        CHECK(position.x == 4);
+      }
+
+      SECTION("Upwards") {
+        position.y = 10;
+        physical.mVelocity.y = -2.0f;
+        runOneFrame();
+        CHECK(position.x == 4);
+        CHECK(position.y == 8);
+      }
+
+      SECTION("Downwards") {
+        position.y = 5;
+        physical.mVelocity.y = 1.0f;
+        runOneFrame();
+        CHECK(position.x == 4);
+        CHECK(position.y == 6);
+      }
+    }
+
+    SECTION("Movement happens only if enough time has elapsed") {
+      const auto timeForOneFrame = gameFramesToTime(1);
+
+      update(0.0);
+      CHECK(position.x == 0);
+
+      update(timeForOneFrame / 2.0);
+      CHECK(position.x == 0);
+
+      update(timeForOneFrame / 2.0 + 0.0001);
+      CHECK(position.x == 4);
+    }
+  }
+
+
+  SECTION("Object's are pulled down by gravity") {
+    position.x = 10;
+    position.y = 5;
+
+    SECTION("Non-moving object") {
+      physical.mVelocity = base::Point<float>{0.0f, 0.0f};
+      runOneFrame();
+      CHECK(position.y > 5);
+      CHECK(physical.mVelocity.y > 0.0f);
+
+      SECTION("Falling speed increases until terminal velocity reached") {
+        const auto lastPosition = position.y;
+        const auto lastVelocity = physical.mVelocity.y;
+
+        runOneFrame();
+        CHECK(position.y > lastPosition);
+        CHECK(physical.mVelocity.y > lastVelocity);
+
+        for (int i = 0; i < 10; ++i) {
+          runOneFrame();
+        }
+
+        // Yes, in the world of Duke Nukem II, 'terminal velocity' has a
+        // value of 2...
+        CHECK(physical.mVelocity.y <= 2.0f);
+      }
+    }
+
+    SECTION("Moving object") {
+      physical.mVelocity.x = 2;
+      runOneFrame();
+      CHECK(position.x == 12);
+
+      CHECK(position.y > 5);
+      CHECK(physical.mVelocity.y > 0.0f);
+    }
+  }
 
 
   SECTION("Physical objects collide with solid bodies") {

--- a/test/test_physics_system.cpp
+++ b/test/test_physics_system.cpp
@@ -44,6 +44,7 @@ TEST_CASE("Physics system works as expected") {
   physicalObject.assign<BoundingBox>(BoundingBox{{0, 0}, {2, 2}});
   physicalObject.assign<Physical>(Physical{{0.0f, 0.0f}, true});
   physicalObject.assign<WorldPosition>(WorldPosition{0, 4});
+  physicalObject.assign<Active>();
 
   auto& physical = *physicalObject.component<Physical>();
   auto& position = *physicalObject.component<WorldPosition>();
@@ -68,6 +69,12 @@ TEST_CASE("Physics system works as expected") {
     }
 
     physical.mVelocity.x = 4.0f;
+
+    SECTION("Inactive objects's don't move") {
+      physicalObject.remove<Active>();
+      runOneFrame();
+      CHECK(position.x == 0);
+    }
 
     SECTION("Object's position changes") {
       SECTION("To the right") {
@@ -230,6 +237,7 @@ TEST_CASE("Physics system works as expected") {
 
     SECTION("SolidBody doesn't collide with itself") {
       solidBody.assign<Physical>(base::Point<float>{0, 2.0f}, false);
+      solidBody.assign<Active>();
       runOneFrame();
       CHECK(solidBody.component<WorldPosition>()->y == 10);
     }


### PR DESCRIPTION
Introduce a mechanism to activate/deactivate entities according to certain rules. Based on that, implement the following two features:

* Make projectiles disappear when they get off-screen
* Make collectable items only fall down once they come into view

Closes #82 