### PR TITLE
Fix: Always update entity activation

### DIFF
--- a/src/engine/entity_activation_system.cpp
+++ b/src/engine/entity_activation_system.cpp
@@ -55,8 +55,10 @@ bool determineActiveState(entityx::Entity entity, const bool inActiveRegion) {
   return inActiveRegion;
 }
 
+}
 
-void markActiveEntites(
+
+void markActiveEntities(
   entityx::EntityManager& es,
   const base::Vector& scrollOffset
 ) {
@@ -74,29 +76,6 @@ void markActiveEntites(
     const auto active = determineActiveState(entity, inActiveRegion);
     setTag<Active>(entity, active);
   });
-}
-
-}
-
-
-EntityActivationSystem::EntityActivationSystem(
-  const base::Vector* pScrollOffset
-)
-  : mpScrollOffset(pScrollOffset)
-  , mPreviousScrollOffset(*pScrollOffset)
-{
-}
-
-
-void EntityActivationSystem::update(
-  entityx::EntityManager& es,
-  entityx::EventManager&,
-  entityx::TimeDelta
-) {
-  if (*mpScrollOffset != mPreviousScrollOffset) {
-    markActiveEntites(es, *mpScrollOffset);
-    mPreviousScrollOffset = *mpScrollOffset;
-  }
 }
 
 }}

--- a/src/engine/entity_activation_system.hpp
+++ b/src/engine/entity_activation_system.hpp
@@ -26,18 +26,8 @@ RIGEL_RESTORE_WARNINGS
 
 namespace rigel { namespace engine {
 
-class EntityActivationSystem : public entityx::System<EntityActivationSystem> {
-public:
-  explicit EntityActivationSystem(const base::Vector* pScrollOffset);
-
-  void update(
-    entityx::EntityManager& es,
-    entityx::EventManager& events,
-    entityx::TimeDelta dt) override;
-
-private:
-  const base::Vector* mpScrollOffset;
-  base::Vector mPreviousScrollOffset;
-};
+void markActiveEntities(
+  entityx::EntityManager& es,
+  const base::Vector& scrollOffset);
 
 }}

--- a/src/ingame_mode.cpp
+++ b/src/ingame_mode.cpp
@@ -205,7 +205,7 @@ void IngameMode::updateAndRender(engine::TimeDelta dt) {
   mEntities.systems.system<interaction::ElevatorSystem>()->setInputState(
     mPlayerInputs);
 
-  mEntities.systems.update<engine::EntityActivationSystem>(dt);
+  engine::markActiveEntities(mEntities.entities, mScrollOffset);
 
   // ----------------------------------------------------------------------
   // Player logic update
@@ -303,7 +303,6 @@ void IngameMode::loadLevel(
 
   mEntities.systems.add<PhysicsSystem>(
     &mLevelData.mMap);
-  mEntities.systems.add<engine::EntityActivationSystem>(&mScrollOffset);
   mEntities.systems.add<game_logic::PlayerMovementSystem>(
     mPlayerEntity,
     &mPlayerInputs,


### PR DESCRIPTION
Even if the scroll offset doesn't change, entities might change their
positions, which should be reflected in their activation state.

This commit returns the activation system's implementation to its original
design. The 'mPreviousScrollOffset' was an erroneous optimization attempt.