### PR TITLE
Only exit if level exit trigger on screen

### DIFF
--- a/src/game_logic/entity_configuration.ipp
+++ b/src/game_logic/entity_configuration.ipp
@@ -834,6 +834,7 @@ void configureEntity(
 
     case 139: // level exit
       entity.assign<Trigger>(TriggerType::LevelExit);
+      entity.assign<BoundingBox>(BoundingBox{{0, 0}, {1, 1}});
       break;
 
     case 106: // shootable wall, explodes into small pieces

--- a/src/ingame_mode.cpp
+++ b/src/ingame_mode.cpp
@@ -373,14 +373,16 @@ void IngameMode::loadLevel(
 
 
 void IngameMode::handleLevelExit() {
+  using engine::components::Active;
   using game_logic::components::Trigger;
   using game_logic::components::TriggerType;
 
-  mEntities.entities.each<Trigger, WorldPosition>(
+  mEntities.entities.each<Trigger, WorldPosition, Active>(
     [this](
       entityx::Entity,
       const Trigger& trigger,
-      const WorldPosition& triggerPosition
+      const WorldPosition& triggerPosition,
+      const Active&
     ) {
       if (trigger.mType != TriggerType::LevelExit || mLevelFinished) {
         return;
@@ -395,9 +397,6 @@ void IngameMode::handleLevelExit() {
       const auto touchingTriggerOnXAxis =
         triggerPosition.x >= playerBBox.left() &&
         triggerPosition.x <= (playerBBox.right() + 1);
-
-      // TODO: Add check for trigger being visible on-screen to properly
-      // replicate the original game's behavior
 
       mLevelFinished = playerAboveOrAtTriggerHeight && touchingTriggerOnXAxis;
     });

--- a/src/ingame_mode.cpp
+++ b/src/ingame_mode.cpp
@@ -258,7 +258,7 @@ void IngameMode::updateAndRender(engine::TimeDelta dt) {
   }
 
   handlePlayerDeath();
-  checkForLevelExitReached();
+  handleLevelExit();
   handleTeleporter();
 }
 
@@ -372,7 +372,7 @@ void IngameMode::loadLevel(
 }
 
 
-void IngameMode::checkForLevelExitReached() {
+void IngameMode::handleLevelExit() {
   using game_logic::components::Trigger;
   using game_logic::components::TriggerType;
 

--- a/src/ingame_mode.cpp
+++ b/src/ingame_mode.cpp
@@ -257,7 +257,7 @@ void IngameMode::updateAndRender(engine::TimeDelta dt) {
     showDebugText();
   }
 
-  checkForPlayerDeath();
+  handlePlayerDeath();
   checkForLevelExitReached();
   handleTeleporter();
 }
@@ -404,7 +404,7 @@ void IngameMode::checkForLevelExitReached() {
 }
 
 
-void IngameMode::checkForPlayerDeath() {
+void IngameMode::handlePlayerDeath() {
   const auto& playerState =
     *mPlayerEntity.component<game_logic::components::PlayerControlled>();
 

--- a/src/ingame_mode.hpp
+++ b/src/ingame_mode.hpp
@@ -62,7 +62,7 @@ private:
   );
 
   void checkForLevelExitReached();
-  void checkForPlayerDeath();
+  void handlePlayerDeath();
   void restartLevel();
   void handleTeleporter();
 

--- a/src/ingame_mode.hpp
+++ b/src/ingame_mode.hpp
@@ -61,7 +61,7 @@ private:
     const loader::ResourceLoader& resources
   );
 
-  void checkForLevelExitReached();
+  void handleLevelExit();
   void handlePlayerDeath();
   void restartLevel();
   void handleTeleporter();


### PR DESCRIPTION
Prevents exiting the level in the wrong spot on e.g. L5.