### PR TITLE
Implement subtle blue guard behavior

### DIFF
--- a/src/game_logic/ai/blue_guard.hpp
+++ b/src/game_logic/ai/blue_guard.hpp
@@ -58,10 +58,11 @@ struct BlueGuard {
     return instance;
   }
 
-  bool mTypingOnTerminal = false;
   Orientation mOrientation = Orientation::Left;
   int mStanceChangeCountdown = 0;
   int mStepsWalked = 0;
+  bool mTypingOnTerminal = false;
+  bool mOneStepWalkedSinceTypingStop = true;
   bool mIsCrouched = false;
 };
 


### PR DESCRIPTION
When a blue guard stops using a terminal, it won't attack the player
until it has walked at least one step, even if all other conditions
for attack are fulfilled.

closes #161 