### PR TITLE
Music playback overhaul

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,8 @@ set(core_sources
     engine/entity_activation_system.cpp
     engine/entity_activation_system.hpp
     engine/entity_tools.hpp
+    engine/imf_player.cpp
+    engine/imf_player.hpp
     engine/life_time_components.hpp
     engine/life_time_system.cpp
     engine/life_time_system.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,6 +113,7 @@ set(core_sources
     game_logic/trigger_components.hpp
     loader/actor_image_package.cpp
     loader/actor_image_package.hpp
+    loader/adlib_emulator.hpp
     loader/audio_package.cpp
     loader/audio_package.hpp
     loader/bitwise_iter.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ set(core_sources
     data/map.cpp
     data/map.hpp
     data/player_data.hpp
+    data/song.hpp
     data/sound_ids.hpp
     data/tile_attributes.cpp
     data/tile_attributes.hpp

--- a/src/data/game_traits.hpp
+++ b/src/data/game_traits.hpp
@@ -96,6 +96,8 @@ struct GameTraits {
     static const std::size_t attributeBytesTotal =
       attributeBytes*numSolidTiles + attributeBytes*5*numMaskedTiles;
   };
+
+  static const auto musicPlaybackRate = 280;
 };
 
 

--- a/src/data/song.hpp
+++ b/src/data/song.hpp
@@ -1,0 +1,33 @@
+/* Copyright (C) 2016, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace rigel { namespace data {
+
+struct ImfCommand {
+  std::uint8_t reg;
+  std::uint8_t value;
+  std::uint16_t delay;
+};
+
+
+using Song = std::vector<ImfCommand>;
+
+}}

--- a/src/engine/imf_player.cpp
+++ b/src/engine/imf_player.cpp
@@ -1,0 +1,93 @@
+/* Copyright (C) 2016, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "imf_player.hpp"
+
+#include "data/game_traits.hpp"
+
+#include <cmath>
+
+
+namespace rigel { namespace engine {
+
+namespace {
+
+int imfDelayToSamples(const int delay, const int sampleRate) {
+  const auto samplesPerImfTick =
+    static_cast<double>(sampleRate) / data::GameTraits::musicPlaybackRate;
+  return static_cast<int>(std::round(delay * samplesPerImfTick));
+}
+
+}
+
+
+ImfPlayer::ImfPlayer(const int sampleRate)
+  : mEmulator(sampleRate)
+  , mSampleRate(sampleRate)
+  , mSongSwitchPending(false)
+{
+}
+
+
+void ImfPlayer::playSong(data::Song&& song) {
+  {
+    std::lock_guard<std::mutex> takeLock{mAudioLock};
+    mNextSongData = std::move(song);
+  }
+  mSongSwitchPending = true;
+}
+
+
+void ImfPlayer::render(std::int16_t* pBuffer, std::size_t samplesRequired) {
+  if (mSongSwitchPending && mAudioLock.try_lock()) {
+    mSongData = std::move(mNextSongData);
+    mSongSwitchPending = false;
+    mAudioLock.unlock();
+
+    miNextCommand = mSongData.cbegin();
+    mSamplesAvailable = 0;
+  }
+
+  if (mSongData.empty()) {
+    std::fill(pBuffer, pBuffer + samplesRequired, 0);
+    return;
+  }
+
+  while (samplesRequired > mSamplesAvailable) {
+    mEmulator.render(mSamplesAvailable, pBuffer);
+    pBuffer += mSamplesAvailable;
+    samplesRequired -= mSamplesAvailable;
+
+    auto commandDelay = 0;
+    do {
+      const auto& command = *miNextCommand;
+      commandDelay = command.delay;
+      mEmulator.writeRegister(command.reg, command.value);
+      ++miNextCommand;
+      if (miNextCommand == mSongData.cend()) {
+        miNextCommand = mSongData.cbegin();
+      }
+    } while (commandDelay == 0);
+
+    mSamplesAvailable = imfDelayToSamples(commandDelay, mSampleRate);
+  }
+
+  mEmulator.render(samplesRequired, pBuffer);
+  mSamplesAvailable -= samplesRequired;
+}
+
+
+}}

--- a/src/engine/imf_player.hpp
+++ b/src/engine/imf_player.hpp
@@ -1,0 +1,54 @@
+/* Copyright (C) 2016, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "data/song.hpp"
+#include "loader/adlib_emulator.hpp"
+
+#include <atomic>
+#include <mutex>
+
+
+namespace rigel { namespace engine {
+
+class ImfPlayer {
+public:
+  explicit ImfPlayer(int sampleRate);
+  ImfPlayer(const ImfPlayer&) = delete;
+  ImfPlayer(ImfPlayer&&) = delete;
+
+  ImfPlayer& operator=(const ImfPlayer&) = delete;
+  ImfPlayer& operator=(ImfPlayer&&) = delete;
+
+  void playSong(data::Song&& song);
+
+  void render(std::int16_t* pBuffer, std::size_t samplesRequired);
+
+private:
+  loader::AdlibEmulator mEmulator;
+  std::mutex mAudioLock;
+  data::Song mNextSongData;
+
+  data::Song mSongData;
+  data::Song::const_iterator miNextCommand;
+  std::size_t mSamplesAvailable = 0;
+  int mSampleRate;
+
+  std::atomic<bool> mSongSwitchPending;
+};
+
+}}

--- a/src/engine/sound_system.cpp
+++ b/src/engine/sound_system.cpp
@@ -103,7 +103,7 @@ SoundSystem::SoundSystem() {
     return Mix_OpenAudio(
       SAMPLE_RATE,
       MIX_DEFAULT_FORMAT,
-      1, // stereo
+      1, // mono
       BUFFER_SIZE);
   });
 }

--- a/src/engine/sound_system.cpp
+++ b/src/engine/sound_system.cpp
@@ -211,11 +211,7 @@ void SoundSystem::stopMusic() const {
 }
 
 
-void SoundSystem::playSound(
-  const SoundHandle handle,
-  float volume,
-  float pan
-) const {
+void SoundSystem::playSound(const SoundHandle handle) const {
   const auto it = mLoadedChunks.find(handle);
   assert(it != mLoadedChunks.end());
   Mix_PlayChannel(1, it->second.get(), 0);

--- a/src/engine/sound_system.hpp
+++ b/src/engine/sound_system.hpp
@@ -40,15 +40,7 @@ public:
   void playSong(SoundHandle handle) const;
   void stopMusic() const;
 
-  /** Play sound with specified volume and panning
-   *
-   * volume range is 0.0 (silent) to 1.0 (max volume)
-   * pan range is -1.0 (left) to (1.0) right, 0.0 is center
-   */
-  void playSound(
-    SoundHandle handle,
-    float volume = 1.0f,
-    float pan = 0.0f) const;
+  void playSound(SoundHandle handle) const;
 
   void clearAll();
 

--- a/src/engine/sound_system.hpp
+++ b/src/engine/sound_system.hpp
@@ -17,13 +17,18 @@
 #pragma once
 
 #include "data/audio_buffer.hpp"
+#include "data/song.hpp"
 #include "sdl_utils/ptr.hpp"
 
+#include <memory>
 #include <unordered_map>
 #include <vector>
 
 
 namespace rigel { namespace engine {
+
+class ImfPlayer;
+
 
 class SoundSystem {
 public:
@@ -32,12 +37,11 @@ public:
   SoundSystem();
   ~SoundSystem();
 
-  SoundHandle addSong(data::AudioBuffer buffer);
   SoundHandle addSound(const data::AudioBuffer& buffer);
 
   void reportMemoryUsage() const;
 
-  void playSong(SoundHandle handle) const;
+  void playSong(data::Song&& song);
   void stopMusic() const;
 
   void playSound(SoundHandle handle) const;
@@ -45,10 +49,12 @@ public:
   void clearAll();
 
 private:
+  SoundHandle addConvertedSound(data::AudioBuffer buffer);
+
+  std::unique_ptr<ImfPlayer> mpMusicPlayer;
   std::vector<data::AudioBuffer> mAudioBuffers;
   std::unordered_map<SoundHandle, sdl_utils::Ptr<Mix_Chunk>> mLoadedChunks;
   SoundHandle mNextHandle = 0;
-  mutable int mCurrentSongChannel = -1;
   mutable int mCurrentSoundChannel = -1;
 };
 

--- a/src/engine/sound_system.hpp
+++ b/src/engine/sound_system.hpp
@@ -17,8 +17,10 @@
 #pragma once
 
 #include "data/audio_buffer.hpp"
+#include "sdl_utils/ptr.hpp"
 
-#include <memory>
+#include <unordered_map>
+#include <vector>
 
 
 namespace rigel { namespace engine {
@@ -51,8 +53,11 @@ public:
   void clearAll();
 
 private:
-  struct SoundSystemImpl;
-  std::unique_ptr<SoundSystemImpl> mpImpl;
+  std::vector<data::AudioBuffer> mAudioBuffers;
+  std::unordered_map<SoundHandle, sdl_utils::Ptr<Mix_Chunk>> mLoadedChunks;
+  SoundHandle mNextHandle = 0;
+  mutable int mCurrentSongChannel = -1;
+  mutable int mCurrentSoundChannel = -1;
 };
 
 }}

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -76,18 +76,6 @@ void Game::run(const GameOptions& options) {
     mSoundsById.emplace_back(mSoundSystem.addSound(mResources.loadSound(id)));
   });
 
-  const auto preLoadSong = [this](const auto songFile) {
-    mLoadedSongs.emplace(
-      songFile,
-      mSoundSystem.addSong(mResources.loadMusic(songFile)));
-  };
-
-  preLoadSong("DUKEIIA.IMF");
-  preLoadSong("FANFAREA.IMF");
-  preLoadSong("MENUSNG2.IMF");
-  preLoadSong("OPNGATEA.IMF");
-  preLoadSong("RANGEA.IMF");
-
   mSoundSystem.reportMemoryUsage();
 
 
@@ -283,13 +271,7 @@ void Game::playMusic(const std::string& name) {
     return;
   }
 
-  auto loadedSongIter = mLoadedSongs.find(name);
-  if (loadedSongIter == mLoadedSongs.end()) {
-    const auto handle = mSoundSystem.addSong(mResources.loadMusic(name));
-    loadedSongIter = mLoadedSongs.emplace(name, handle).first;
-  }
-
-  mSoundSystem.playSong(loadedSongIter->second);
+  mSoundSystem.playSong(mResources.loadMusic(name));
 }
 
 

--- a/src/game_main.ipp
+++ b/src/game_main.ipp
@@ -83,9 +83,6 @@ private:
 
   std::vector<engine::SoundSystem::SoundHandle> mSoundsById;
 
-  std::unordered_map<std::string, engine::SoundSystem::SoundHandle>
-    mLoadedSongs;
-
   bool mMusicEnabled = true;
 
   bool mIsRunning;

--- a/src/loader/adlib_emulator.hpp
+++ b/src/loader/adlib_emulator.hpp
@@ -1,0 +1,78 @@
+/* Copyright (C) 2016, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "base/math_tools.hpp"
+
+#include <dbopl.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+
+
+namespace rigel { namespace loader {
+
+class AdlibEmulator {
+public:
+  explicit AdlibEmulator(int sampleRate)
+    : mEmulator(sampleRate)
+  {
+    // This is normally done by the game to select the right type of wave forms.
+    // It's not part of the IMF files.
+    mEmulator.WriteReg(1, 32);
+  }
+
+  void writeRegister(const std::uint32_t reg, const std::uint8_t value) {
+    mEmulator.WriteReg(reg, value);
+  }
+
+  template<typename OutputIt>
+  void render(
+    std::size_t numSamples,
+    OutputIt destination,
+    const int volumeScale = 1
+  ) {
+    // DBOPL outputs 32 bit samples, but they never exceed the 16 bit range
+    // (compare source code comment in MixerChannel::AddSamples() in mixer.cpp
+    // in the DosBox source). Still, this means we cannot render directly into
+    // the output buffer.
+
+    while (numSamples > 0) {
+      const auto samplesForIteration = std::min(mTempBuffer.size(), numSamples);
+
+      mEmulator.GenerateBlock2(
+        static_cast<DBOPL::Bitu>(samplesForIteration), mTempBuffer.data());
+      destination = std::transform(
+        mTempBuffer.cbegin(),
+        mTempBuffer.cbegin() + samplesForIteration,
+        destination,
+        [volumeScale](const auto sample32Bit) {
+          return static_cast<std::int16_t>(
+            base::clamp(sample32Bit * volumeScale, -16384, 16384));
+        });
+
+      numSamples -= samplesForIteration;
+    }
+  }
+
+private:
+  DBOPL::Chip mEmulator;
+  std::array<std::int32_t, 256> mTempBuffer;
+};
+
+}}

--- a/src/loader/music_loader.cpp
+++ b/src/loader/music_loader.cpp
@@ -16,22 +16,10 @@
 
 #include "music_loader.hpp"
 
-#include "data/game_traits.hpp"
-#include "loader/adlib_emulator.hpp"
 #include "loader/file_utils.hpp"
-
-#include <algorithm>
-#include <cassert>
-#include <cmath>
-#include <cstdint>
-#include <iterator>
-#include <vector>
 
 
 namespace rigel { namespace loader {
-
-using namespace std;
-
 
 namespace {
 
@@ -54,35 +42,5 @@ data::Song loadSong(const ByteBuffer& imfData) {
 
   return song;
 }
-
-
-data::AudioBuffer renderImf(const ByteBuffer& imfData, const int sampleRate) {
-  assert(sampleRate > 0);
-
-  data::AudioBuffer renderedAudio{sampleRate, {}};
-  // Allocate enough for 30 seconds of audio, to reduce the number of
-  // reallocations during rendering
-  renderedAudio.mSamples.reserve(30 * sampleRate);
-
-  AdlibEmulator emulator{sampleRate};
-
-  const auto outputSamplesPerImfTick =
-    static_cast<double>(sampleRate) / data::GameTraits::musicPlaybackRate;
-
-  const auto song = loadSong(imfData);
-  for (const auto& entry : song) {
-    emulator.writeRegister(entry.reg, entry.value);
-
-    if (entry.delay > 0) {
-      const auto numSamplesToCompute = static_cast<size_t>(round(
-        entry.delay * outputSamplesPerImfTick));
-      emulator.render(
-        numSamplesToCompute, back_inserter(renderedAudio.mSamples));
-    }
-  }
-
-  return renderedAudio;
-}
-
 
 }}

--- a/src/loader/music_loader.cpp
+++ b/src/loader/music_loader.cpp
@@ -65,10 +65,10 @@ data::AudioBuffer renderImf(const ByteBuffer& imfData, const int sampleRate) {
     emulator.writeRegister(entry.reg, entry.value);
 
     if (entry.delay > 0) {
-      const auto numSamplesToCompute = static_cast<size_t>(std::round(
+      const auto numSamplesToCompute = static_cast<size_t>(round(
         entry.delay * outputSamplesPerImfTick));
       emulator.render(
-        numSamplesToCompute, std::back_inserter(renderedAudio.mSamples));
+        numSamplesToCompute, back_inserter(renderedAudio.mSamples));
     }
   }
 

--- a/src/loader/music_loader.cpp
+++ b/src/loader/music_loader.cpp
@@ -16,6 +16,7 @@
 
 #include "music_loader.hpp"
 
+#include "data/game_traits.hpp"
 #include "data/song.hpp"
 #include "loader/adlib_emulator.hpp"
 #include "loader/file_utils.hpp"
@@ -34,9 +35,6 @@ using namespace std;
 
 
 namespace {
-
-const auto DUKE2_IMF_RATE = 280;
-
 
 data::ImfCommand readCommand(LeStreamReader& reader) {
   return {
@@ -59,7 +57,7 @@ data::AudioBuffer renderImf(const ByteBuffer& imfData, const int sampleRate) {
   AdlibEmulator emulator{sampleRate};
 
   const auto outputSamplesPerImfTick =
-    static_cast<double>(sampleRate) / DUKE2_IMF_RATE;
+    static_cast<double>(sampleRate) / data::GameTraits::musicPlaybackRate;
 
   LeStreamReader reader(imfData);
   while (reader.hasData()) {

--- a/src/loader/music_loader.cpp
+++ b/src/loader/music_loader.cpp
@@ -16,6 +16,7 @@
 
 #include "music_loader.hpp"
 
+#include "data/song.hpp"
 #include "loader/adlib_emulator.hpp"
 #include "loader/file_utils.hpp"
 
@@ -37,20 +38,15 @@ namespace {
 const auto DUKE2_IMF_RATE = 280;
 
 
-struct ImfEntry {
-  explicit ImfEntry(LeStreamReader& reader)
-    : reg(reader.readU8())
-    , value(reader.readU8())
-    , delay(reader.readU16())
-  {
-  }
-
-  const std::uint8_t reg;
-  const std::uint8_t value;
-  const std::uint16_t delay;
-};
+data::ImfCommand readCommand(LeStreamReader& reader) {
+  return {
+    reader.readU8(),
+    reader.readU8(),
+    reader.readU16()};
+}
 
 }
+
 
 data::AudioBuffer renderImf(const ByteBuffer& imfData, const int sampleRate) {
   assert(sampleRate > 0);
@@ -67,7 +63,7 @@ data::AudioBuffer renderImf(const ByteBuffer& imfData, const int sampleRate) {
 
   LeStreamReader reader(imfData);
   while (reader.hasData()) {
-    ImfEntry entry(reader);
+    const auto entry = readCommand(reader);
     emulator.writeRegister(entry.reg, entry.value);
 
     if (entry.delay > 0) {

--- a/src/loader/music_loader.hpp
+++ b/src/loader/music_loader.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include "data/audio_buffer.hpp"
 #include "data/song.hpp"
 #include "loader/byte_buffer.hpp"
 
@@ -24,8 +23,5 @@
 namespace rigel { namespace loader {
 
 data::Song loadSong(const ByteBuffer& imfData);
-
-data::AudioBuffer renderImf(const ByteBuffer& imfData, int sampleRate);
-
 
 }}

--- a/src/loader/music_loader.hpp
+++ b/src/loader/music_loader.hpp
@@ -17,10 +17,13 @@
 #pragma once
 
 #include "data/audio_buffer.hpp"
+#include "data/song.hpp"
 #include "loader/byte_buffer.hpp"
 
 
 namespace rigel { namespace loader {
+
+data::Song loadSong(const ByteBuffer& imfData);
 
 data::AudioBuffer renderImf(const ByteBuffer& imfData, int sampleRate);
 

--- a/src/loader/resource_loader.cpp
+++ b/src/loader/resource_loader.cpp
@@ -157,18 +157,8 @@ data::Movie ResourceLoader::loadMovie(const std::string& name) const {
 }
 
 
-data::AudioBuffer ResourceLoader::loadMusic(const std::string& name) const {
-  using namespace chrono;
-
-  const auto before = high_resolution_clock::now();
-  const auto buffer = loader::renderImf(mFilePackage.file(name), 44100);
-  const auto after = high_resolution_clock::now();
-
-  std::cout
-    << "Song rendering time for '" << name << "': "
-    << duration_cast<milliseconds>(after - before).count() << " ms\n";
-
-  return buffer;
+data::Song ResourceLoader::loadMusic(const std::string& name) const {
+  return loader::loadSong(mFilePackage.file(name));
 }
 
 

--- a/src/loader/resource_loader.hpp
+++ b/src/loader/resource_loader.hpp
@@ -19,6 +19,7 @@
 #include "data/audio_buffer.hpp"
 #include "data/image.hpp"
 #include "data/movie.hpp"
+#include "data/song.hpp"
 #include "data/sound_ids.hpp"
 #include "data/tile_attributes.hpp"
 #include "loader/actor_image_package.hpp"
@@ -53,7 +54,7 @@ public:
 
   TileSet loadCZone(const std::string& name) const;
   data::Movie loadMovie(const std::string& name) const;
-  data::AudioBuffer loadMusic(const std::string& name) const;
+  data::Song loadMusic(const std::string& name) const;
 
   data::AudioBuffer loadSound(const std::string& name) const;
 


### PR DESCRIPTION
Render music data (AdLib commands from IMF files) on the fly instead of doing an up-front rendering. This reduces loading times and memory usage.

closes #4 