### PR TITLE
Sprite data reorg

### DIFF
--- a/src/engine/rendering_system.cpp
+++ b/src/engine/rendering_system.cpp
@@ -89,6 +89,10 @@ struct RenderingSystem::SpriteData {
   )
     : mEntity(entity)
     , mpSprite(pSprite)
+    , mDrawOrder(
+        entity.has_component<components::OverrideDrawOrder>()
+        ? entity.component<const components::OverrideDrawOrder>()->mDrawOrder
+        : pSprite->mDrawOrder)
     , mDrawTopMost(drawTopMost)
     , mPosition(position)
   {
@@ -96,12 +100,13 @@ struct RenderingSystem::SpriteData {
 
   bool operator<(const SpriteData& rhs) const {
     return
-      std::tie(mDrawTopMost, mpSprite->mDrawOrder) <
-      std::tie(rhs.mDrawTopMost, rhs.mpSprite->mDrawOrder);
+      std::tie(mDrawTopMost, mDrawOrder) <
+      std::tie(rhs.mDrawTopMost, rhs.mDrawOrder);
   }
 
   entityx::Entity mEntity;
   const Sprite* mpSprite;
+  int mDrawOrder;
   bool mDrawTopMost;
   WorldPosition mPosition;
 };

--- a/src/engine/rendering_system.cpp
+++ b/src/engine/rendering_system.cpp
@@ -43,10 +43,11 @@ namespace {
 
 
 void advanceAnimation(Sprite& sprite, Animated& animated) {
+  const auto& spriteFrames = sprite.mpDrawData->mFrames;
   const auto endFrame = animated.mEndFrame
     ? *animated.mEndFrame
-    : static_cast<int>(sprite.mFrames.size()) - 1;
-  assert(endFrame >= 0 && endFrame < int(sprite.mFrames.size()));
+    : static_cast<int>(spriteFrames.size()) - 1;
+  assert(endFrame >= 0 && endFrame < int(spriteFrames.size()));
   assert(endFrame > animated.mStartFrame);
   //Animations must have at least two frames
   assert(
@@ -58,7 +59,7 @@ void advanceAnimation(Sprite& sprite, Animated& animated) {
     newFrameNr = animated.mStartFrame;
   }
 
-  assert(newFrameNr >= 0 && newFrameNr < int(sprite.mFrames.size()));
+  assert(newFrameNr >= 0 && newFrameNr < int(spriteFrames.size()));
   sprite.mFramesToRender[animated.mRenderSlot] = newFrameNr;
 }
 
@@ -93,7 +94,7 @@ struct RenderingSystem::SpriteData {
     , mDrawOrder(
         entity.has_component<components::OverrideDrawOrder>()
         ? entity.component<const components::OverrideDrawOrder>()->mDrawOrder
-        : pSprite->mDrawOrder)
+        : pSprite->mpDrawData->mDrawOrder)
     , mDrawTopMost(drawTopMost)
   {
   }
@@ -170,7 +171,7 @@ void RenderingSystem::renderSprite(const SpriteData& data) const {
     renderFunc(mpRenderer, data.mEntity, sprite, screenPos);
   } else {
     for (const auto frameIndex : sprite.mFramesToRender) {
-      assert(frameIndex < int(sprite.mFrames.size()));
+      assert(frameIndex < int(sprite.mpDrawData->mFrames.size()));
 
       // White flash effect
       const auto maxFlashWhiteTime = engine::gameFramesToTime(1);
@@ -184,7 +185,7 @@ void RenderingSystem::renderSprite(const SpriteData& data) const {
         mpRenderer->setOverlayColor(base::Color(255, 255, 255, 255));
       }
 
-      auto& frame = sprite.mFrames[frameIndex];
+      auto& frame = sprite.mpDrawData->mFrames[frameIndex];
 
       // World-space tile positions refer to a sprite's bottom left tile,
       // but we need its top left corner for drawing.

--- a/src/engine/rendering_system.cpp
+++ b/src/engine/rendering_system.cpp
@@ -88,13 +88,13 @@ struct RenderingSystem::SpriteData {
     const WorldPosition& position
   )
     : mEntity(entity)
+    , mPosition(position)
     , mpSprite(pSprite)
     , mDrawOrder(
         entity.has_component<components::OverrideDrawOrder>()
         ? entity.component<const components::OverrideDrawOrder>()->mDrawOrder
         : pSprite->mDrawOrder)
     , mDrawTopMost(drawTopMost)
-    , mPosition(position)
   {
   }
 
@@ -105,10 +105,10 @@ struct RenderingSystem::SpriteData {
   }
 
   entityx::Entity mEntity;
+  WorldPosition mPosition;
   const Sprite* mpSprite;
   int mDrawOrder;
   bool mDrawTopMost;
-  WorldPosition mPosition;
 };
 
 

--- a/src/engine/sprite_tools.hpp
+++ b/src/engine/sprite_tools.hpp
@@ -28,9 +28,7 @@ RIGEL_RESTORE_WARNINGS
 
 namespace rigel { namespace engine {
 
-inline components::BoundingBox inferBoundingBox(
-  const components::SpriteFrame& sprite
-) {
+inline components::BoundingBox inferBoundingBox(const SpriteFrame& sprite) {
   const auto dimensionsInTiles = data::pixelExtentsToTileExtents(
     sprite.mImage.extents());
 
@@ -42,7 +40,8 @@ inline void synchronizeBoundingBoxToSprite(entityx::Entity& entity) {
   auto& sprite = *entity.component<components::Sprite>();
   auto& bbox = *entity.component<components::BoundingBox>();
 
-  bbox = inferBoundingBox(sprite.mFrames[sprite.mFramesToRender[0]]);
+  bbox = inferBoundingBox(
+    sprite.mpDrawData->mFrames[sprite.mFramesToRender[0]]);
 }
 
 

--- a/src/engine/texture.hpp
+++ b/src/engine/texture.hpp
@@ -113,7 +113,7 @@ public:
   OwningTexture(engine::Renderer* renderer, const data::Image& image);
   ~OwningTexture();
 
-  OwningTexture(OwningTexture&& other)
+  OwningTexture(OwningTexture&& other) noexcept
     : TextureBase(other.mData)
   {
     other.mData.mHandle = 0;
@@ -122,7 +122,7 @@ public:
   OwningTexture(const OwningTexture&) = delete;
   OwningTexture& operator=(const OwningTexture&) = delete;
 
-  OwningTexture& operator=(OwningTexture&& other) {
+  OwningTexture& operator=(OwningTexture&& other) noexcept {
     mData = other.mData;
     other.mData.mHandle = 0;
     return *this;

--- a/src/engine/visual_components.hpp
+++ b/src/engine/visual_components.hpp
@@ -31,12 +31,12 @@ RIGEL_RESTORE_WARNINGS
 #include <vector>
 
 
-namespace rigel { namespace engine { namespace components {
+namespace rigel { namespace engine {
 
 struct SpriteFrame {
   SpriteFrame() = default;
   SpriteFrame(
-    engine::NonOwningTexture image,
+    engine::OwningTexture image,
     base::Vector drawOffset
   )
     : mImage(std::move(image))
@@ -44,22 +44,35 @@ struct SpriteFrame {
   {
   }
 
-  engine::NonOwningTexture mImage;
+  engine::OwningTexture mImage;
   base::Vector mDrawOffset;
 };
 
 
-struct Sprite {
+struct SpriteDrawData {
   std::vector<SpriteFrame> mFrames;
   int mDrawOrder;
+};
+
+
+namespace components {
+
+struct Sprite {
+  Sprite() = default;
+  Sprite(const SpriteDrawData* pDrawData, std::vector<int> framesToRender)
+    : mFramesToRender(std::move(framesToRender))
+    , mpDrawData(pDrawData)
+  {
+  }
 
   void flashWhite() {
     mFlashWhiteTime = currentGlobalTime();
   }
 
   std::vector<int> mFramesToRender;
-  bool mShow = true;
   engine::TimePoint mFlashWhiteTime = 0.0;
+  const SpriteDrawData* mpDrawData = nullptr;
+  bool mShow = true;
 };
 
 

--- a/src/engine/visual_components.hpp
+++ b/src/engine/visual_components.hpp
@@ -86,6 +86,16 @@ using CustomRenderFunc = void(*)(
 struct DrawTopMost {};
 
 
+struct OverrideDrawOrder {
+  explicit OverrideDrawOrder(const int drawOrder)
+    : mDrawOrder(drawOrder)
+  {
+  }
+
+  int mDrawOrder;
+};
+
+
 struct Animated {
   Animated() = default;
   explicit Animated(

--- a/src/game_logic/ai/sliding_door.cpp
+++ b/src/game_logic/ai/sliding_door.cpp
@@ -243,7 +243,7 @@ void renderVerticalSlidingDoor(
     const auto segmentIndex = 8 - i - state.mSlideStep;
     const auto x = topLeftScreenPos.x;
     const auto y = topLeftScreenPos.y + yStep * i;
-    sprite.mFrames[segmentIndex].mImage.render(pRenderer, x, y);
+    sprite.mpDrawData->mFrames[segmentIndex].mImage.render(pRenderer, x, y);
   }
 }
 

--- a/src/game_logic/entity_configuration.ipp
+++ b/src/game_logic/entity_configuration.ipp
@@ -19,6 +19,16 @@
 
 namespace {
 
+// The game draws player projectiles after drawing all regular actors, which
+// makes them appear on top of everything. But in our case, they are rendered
+// using the same mechanism as the other sprites, so we have to explicitly
+// assign an order (which is higher than all regular actors' draw order).
+const auto PLAYER_PROJECTILE_DRAW_ORDER = data::GameTraits::maxDrawOrder + 1;
+
+// Same thing as for player projectiles
+const auto MUZZLE_FLASH_DRAW_ORDER = 12;
+
+
 base::Point<float> directionToVector(const ProjectileDirection direction) {
   const auto isNegative =
     direction == ProjectileDirection::Left ||
@@ -331,6 +341,22 @@ ActorID actorIdForBoxColor(const ContainerColor color) {
 
   assert(false);
   return 161;
+}
+
+
+int adjustedDrawOrder(const ActorID id, const int baseDrawOrder) {
+  switch (id) {
+    case 7: case 8: case 9: case 10:
+    case 24: case 25: case 26: case 27:
+    case 21: case 204: case 205: case 206:
+      return PLAYER_PROJECTILE_DRAW_ORDER;
+
+    case 33: case 34: case 35: case 36:
+      return MUZZLE_FLASH_DRAW_ORDER;
+
+    default:
+      return baseDrawOrder;
+  }
 }
 
 } // namespace

--- a/src/game_logic/entity_configuration.ipp
+++ b/src/game_logic/entity_configuration.ipp
@@ -239,12 +239,6 @@ auto actorIDListForActor(const ActorID ID) {
 
 
 void configureSprite(Sprite& sprite, const ActorID actorID) {
-  if (actorID == 5 || actorID == 6) {
-    for (int i=0; i<39; ++i) {
-      sprite.mFrames[i].mDrawOffset.x -= 1;
-    }
-  }
-
   switch (actorID) {
     case 0:
       sprite.mFramesToRender = {0};
@@ -394,7 +388,8 @@ void EntityFactory::configureItemContainer(
   entity.assign<Sprite>(boxSprite);
   entity.assign<components::ItemContainer>(container);
   entity.assign<Shootable>(1, givenScore);
-  addDefaultPhysical(entity, engine::inferBoundingBox(boxSprite.mFrames[0]));
+  addDefaultPhysical(entity, engine::inferBoundingBox(
+    boxSprite.mpDrawData->mFrames[0]));
 }
 
 
@@ -548,7 +543,8 @@ void EntityFactory::configureEntity(
     // ----------------------------------------------------------------------
     case 42: // Napalm Bomb
       {
-        const auto originalDrawOrder = entity.component<Sprite>()->mDrawOrder;
+        const auto originalDrawOrder =
+          entity.component<Sprite>()->mpDrawData->mDrawOrder;
         configureItemContainer(
           entity,
           ContainerColor::Red,

--- a/src/game_logic/entity_configuration.ipp
+++ b/src/game_logic/entity_configuration.ipp
@@ -555,7 +555,7 @@ void EntityFactory::configureEntity(
           0,
           Animated{1},
           boundingBox);
-        entity.component<Sprite>()->mDrawOrder = originalDrawOrder;
+        entity.assign<OverrideDrawOrder>(originalDrawOrder);
       }
       break;
 

--- a/src/game_logic/entity_factory.cpp
+++ b/src/game_logic/entity_factory.cpp
@@ -98,51 +98,53 @@ EntityFactory::EntityFactory(
 
 
 Sprite EntityFactory::createSpriteForId(const ActorID actorID) {
-  const auto actorParts = actorIDListForActor(actorID);
-  auto sprite = makeSpriteFromActorIDs(actorID, actorParts);
+  auto sprite = createSpriteComponent(actorID);
   configureSprite(sprite, actorID);
   return sprite;
 }
 
 
-const engine::OwningTexture& EntityFactory::getOrCreateTexture(
-  const IdAndFrameNr& textureId
-) {
-  auto it = mTextureCache.find(textureId);
-  if (it == mTextureCache.end()) {
-    const auto& actorData = mpSpritePackage->loadActor(textureId.first);
-    const auto& frameData = actorData.mFrames[textureId.second];
-    auto texture = engine::OwningTexture(
-      mpRenderer, frameData.mFrameImage);
-    it = mTextureCache.emplace(textureId, std::move(texture)).first;
-  }
-  return it->second;
-}
+Sprite EntityFactory::createSpriteComponent(const ActorID mainId) {
+  auto iData = mSpriteDataCache.find(mainId);
+  if (iData == mSpriteDataCache.end()) {
+    engine::SpriteDrawData drawData;
 
+    int lastDrawOrder = 0;
+    int lastFrameCount = 0;
+    std::vector<int> framesToRender;
 
-Sprite EntityFactory::makeSpriteFromActorIDs(
-  data::ActorID mainId,
-  const vector<ActorID>& actorIDs
-) {
-  Sprite sprite;
-  int lastFrameCount = 0;
-  int lastDrawOrder = 0;
+    const auto actorParts = actorIDListForActor(mainId);
+    for (const auto part : actorParts) {
+        const auto& actorData = mpSpritePackage->loadActor(part);
+        lastDrawOrder = actorData.mDrawIndex;
 
-  for (const auto ID : actorIDs) {
-    const auto& actorData = mpSpritePackage->loadActor(ID);
-    for (auto i=0u; i<actorData.mFrames.size(); ++i) {
-      const auto& frameData = actorData.mFrames[i];
-      const auto& texture = getOrCreateTexture(make_pair(ID, i));
-      const auto textureRef = engine::NonOwningTexture(texture);
-      sprite.mFrames.emplace_back(textureRef, frameData.mDrawOffset);
+        for (const auto& frameData : actorData.mFrames) {
+          auto texture = engine::OwningTexture{
+            mpRenderer, frameData.mFrameImage};
+          drawData.mFrames.emplace_back(
+            std::move(texture), frameData.mDrawOffset);
+        }
+
+        framesToRender.push_back(lastFrameCount);
+        lastFrameCount = int(actorData.mFrames.size());
     }
-    lastDrawOrder = actorData.mDrawIndex;
-    sprite.mFramesToRender.push_back(lastFrameCount);
-    lastFrameCount += static_cast<int>(actorData.mFrames.size());
+
+    drawData.mDrawOrder = adjustedDrawOrder(mainId, lastDrawOrder);
+
+    if (mainId == 5 || mainId == 6) {
+      for (int i=0; i<39; ++i) {
+        drawData.mFrames[i].mDrawOffset.x -= 1;
+      }
+    }
+
+    iData = mSpriteDataCache.emplace(
+      mainId,
+      SpriteData{std::move(drawData), std::move(framesToRender)}
+    ).first;
   }
 
-  sprite.mDrawOrder = adjustedDrawOrder(mainId, lastDrawOrder);
-  return sprite;
+  const auto& data = iData->second;
+  return {&data.mDrawData, data.mInitialFramesToRender};
 }
 
 
@@ -155,7 +157,7 @@ entityx::Entity EntityFactory::createSprite(
   entity.assign<Sprite>(sprite);
 
   if (assignBoundingBox) {
-    entity.assign<BoundingBox>(engine::inferBoundingBox(sprite.mFrames[0]));
+    entity.assign<BoundingBox>(engine::inferBoundingBox(sprite.mpDrawData->mFrames[0]));
   }
   return entity;
 }
@@ -179,7 +181,7 @@ entityx::Entity EntityFactory::createProjectile(
   auto entity = mpEntityManager->create();
   auto sprite = createSpriteForId(actorIdForProjectile(type, direction));
 
-  const auto boundingBox = engine::inferBoundingBox(sprite.mFrames[0]);
+  const auto boundingBox = engine::inferBoundingBox(sprite.mpDrawData->mFrames[0]);
 
   // TODO: Player projectiles shouldn't move on the frame they were created
   entity.assign<Active>();
@@ -198,7 +200,7 @@ entityx::Entity EntityFactory::createActor(
 ) {
   auto entity = createSprite(id, position);
   auto& sprite = *entity.component<Sprite>();
-  const auto boundingBox = engine::inferBoundingBox(sprite.mFrames[0]);
+  const auto boundingBox = engine::inferBoundingBox(sprite.mpDrawData->mFrames[0]);
 
   configureEntity(entity, id, boundingBox);
 
@@ -296,7 +298,7 @@ entityx::Entity EntityFactory::createEntitiesForLevel(
       boundingBox.topLeft = {0, 0};
     } else if (hasAssociatedSprite(actor.mID)) {
       const auto sprite = createSpriteForId(actor.mID);
-      boundingBox = engine::inferBoundingBox(sprite.mFrames[0]);
+      boundingBox = engine::inferBoundingBox(sprite.mpDrawData->mFrames[0]);
       entity.assign<Sprite>(sprite);
     }
 

--- a/src/game_logic/entity_factory.hpp
+++ b/src/game_logic/entity_factory.hpp
@@ -29,8 +29,7 @@ RIGEL_DISABLE_WARNINGS
 #include <SDL.h>
 RIGEL_RESTORE_WARNINGS
 
-#include <map>
-#include <tuple>
+#include <unordered_map>
 #include <vector>
 
 
@@ -105,8 +104,6 @@ public:
     const base::Vector& position);
 
 private:
-  using IdAndFrameNr = std::pair<data::ActorID, std::size_t>;
-
   engine::components::Sprite createSpriteForId(const data::ActorID actorID);
 
   void configureEntity(
@@ -121,11 +118,7 @@ private:
     int givenScore,
     Args&&... components);
 
-  const engine::OwningTexture& getOrCreateTexture(
-    const IdAndFrameNr& textureId);
-  engine::components::Sprite makeSpriteFromActorIDs(
-    data::ActorID mainId,
-    const std::vector<data::ActorID>& actorIDs);
+  engine::components::Sprite createSpriteComponent(data::ActorID mainId);
 
   void configureProjectile(
     entityx::Entity entity,
@@ -140,7 +133,12 @@ private:
   const loader::ActorImagePackage* mpSpritePackage;
   data::Difficulty mDifficulty;
 
-  std::map<IdAndFrameNr, engine::OwningTexture> mTextureCache;
+  struct SpriteData {
+    engine::SpriteDrawData mDrawData;
+    std::vector<int> mInitialFramesToRender;
+  };
+
+  std::unordered_map<data::ActorID, SpriteData> mSpriteDataCache;
 };
 
 }}

--- a/src/game_logic/entity_factory.hpp
+++ b/src/game_logic/entity_factory.hpp
@@ -124,6 +124,7 @@ private:
   const engine::OwningTexture& getOrCreateTexture(
     const IdAndFrameNr& textureId);
   engine::components::Sprite makeSpriteFromActorIDs(
+    data::ActorID mainId,
     const std::vector<data::ActorID>& actorIDs);
 
   void configureProjectile(

--- a/src/game_logic/player/animation_system.cpp
+++ b/src/game_logic/player/animation_system.cpp
@@ -45,7 +45,6 @@ namespace {
 const auto DEATH_ANIM_BASE_FRAME = 29;
 const auto FRAMES_PER_ORIENTATION = 39;
 const auto MOVEMENT_BASED_ANIM_SPEED_SCALE = 2;
-const auto MUZZLE_FLASH_DRAW_ORDER = 12;
 const auto NUM_LADDER_ANIM_STATES = 2;
 const auto NUM_WALK_ANIM_STATES = 4;
 
@@ -308,8 +307,6 @@ int AnimationSystem::attackAnimationFrame(
     const auto spriteId = muzzleFlashActorId(shotDirection);
 
     auto muzzleFlashEntity = mpEntityFactory->createSprite(spriteId);
-    muzzleFlashEntity.component<Sprite>()->mDrawOrder =
-      MUZZLE_FLASH_DRAW_ORDER;
     muzzleFlashEntity.assign<WorldPosition>(
        playerPosition + muzzleFlashOffset(state.mState, state.mOrientation));
     muzzleFlashEntity.assign<AutoDestroy>(AutoDestroy::afterTimeout(1));


### PR DESCRIPTION
Performance and memory usage optimization. Data structures for sprites are reorganized to only include a single pointer to the required data (`SpriteDrawData`), instead of a `vector` of `SpriteFrame` objects which have pointers to the textures. The list of `SpriteFrames` is the same for all sprites based on the same actor ID, but previously, each instance of a sprite would contain its own copy of that information. By getting rid of this redundant information, `sizeof(Sprite)` goes down from `72` to `48`, plus all the memory required for the `SpriteFrame` lists isn't needed anymore. 

More importantly, this reorganization allows caching the data on a coarser granularity, by mapping from actor ID to `SpriteDrawData*`, therefore reducing the amount of work required to create a sprite in the `EntityFactory` class. Previously, only the textures were cached, but each time a sprite was created, its frame data had to be loaded and processed, which means creating a sprite was an `O(N)` operation. Now, it's constant time after the first time a sprite for a particular ID was created. 

The change improves level load times for L1 on medium difficulty like follows:

| System | Compiler | Before | After | Speed gain |
| -------- | ------ | ------- | -------- | ------ |
| Desktop (Windows) | MSVC 2015 | 150 ms | 19 ms | 789 % |
| Desktop (Linnux) | Clang 3.9 | 23 ms | 8 ms | 288 % |
| Laptop (OS X) | Apple Clang 8.0.0 | 54 ms | 22 ms | 245 % |
| Raspberry Pi 1 (Model B) | GCC 5.4 | 1074 ms | 550 ms | 195 % |

Systems used for testing:

| Name | CPU | Memory |
| ------ | ---- | -------- |
| Desktop | Core i7 4770, 3.4 GHz | 16 GB DDR3 |
| Laptop | Core i5 4308U, 2.8 GHz | 8 GB DDR3 |
| Raspberry Pi | ARM 1176/BCM2835, 700 MHz | 512 MB |

Closes #147 