### PR TITLE
Remove loading screen

### DIFF
--- a/src/engine/rendering_system.cpp
+++ b/src/engine/rendering_system.cpp
@@ -43,11 +43,9 @@ namespace {
 
 
 void advanceAnimation(Sprite& sprite, Animated& animated) {
-  const auto& spriteFrames = sprite.mpDrawData->mFrames;
-  const auto endFrame = animated.mEndFrame
-    ? *animated.mEndFrame
-    : static_cast<int>(spriteFrames.size()) - 1;
-  assert(endFrame >= 0 && endFrame < int(spriteFrames.size()));
+  const auto numFrames = static_cast<int>(sprite.mpDrawData->mFrames.size());
+  const auto endFrame = animated.mEndFrame ? *animated.mEndFrame : numFrames-1;
+  assert(endFrame >= 0 && endFrame < numFrames);
   assert(endFrame > animated.mStartFrame);
   //Animations must have at least two frames
   assert(
@@ -59,7 +57,7 @@ void advanceAnimation(Sprite& sprite, Animated& animated) {
     newFrameNr = animated.mStartFrame;
   }
 
-  assert(newFrameNr >= 0 && newFrameNr < int(spriteFrames.size()));
+  assert(newFrameNr >= 0 && newFrameNr < numFrames);
   sprite.mFramesToRender[animated.mRenderSlot] = newFrameNr;
 }
 

--- a/src/engine/sprite_tools.hpp
+++ b/src/engine/sprite_tools.hpp
@@ -28,11 +28,14 @@ RIGEL_RESTORE_WARNINGS
 
 namespace rigel { namespace engine {
 
-inline components::BoundingBox inferBoundingBox(const SpriteFrame& sprite) {
+inline components::BoundingBox inferBoundingBox(
+  const components::Sprite& sprite
+) {
+  const auto& frame = sprite.mpDrawData->mFrames[0];
   const auto dimensionsInTiles = data::pixelExtentsToTileExtents(
-    sprite.mImage.extents());
+    frame.mImage.extents());
 
-  return {sprite.mDrawOffset, dimensionsInTiles};
+  return {frame.mDrawOffset, dimensionsInTiles};
 }
 
 
@@ -40,8 +43,7 @@ inline void synchronizeBoundingBoxToSprite(entityx::Entity& entity) {
   auto& sprite = *entity.component<components::Sprite>();
   auto& bbox = *entity.component<components::BoundingBox>();
 
-  bbox = inferBoundingBox(
-    sprite.mpDrawData->mFrames[sprite.mFramesToRender[0]]);
+  bbox = inferBoundingBox(sprite);
 }
 
 

--- a/src/game_logic/entity_configuration.ipp
+++ b/src/game_logic/entity_configuration.ipp
@@ -388,8 +388,7 @@ void EntityFactory::configureItemContainer(
   entity.assign<Sprite>(boxSprite);
   entity.assign<components::ItemContainer>(container);
   entity.assign<Shootable>(1, givenScore);
-  addDefaultPhysical(entity, engine::inferBoundingBox(
-    boxSprite.mpDrawData->mFrames[0]));
+  addDefaultPhysical(entity, engine::inferBoundingBox(boxSprite));
 }
 
 

--- a/src/game_logic/entity_factory.cpp
+++ b/src/game_logic/entity_factory.cpp
@@ -157,7 +157,7 @@ entityx::Entity EntityFactory::createSprite(
   entity.assign<Sprite>(sprite);
 
   if (assignBoundingBox) {
-    entity.assign<BoundingBox>(engine::inferBoundingBox(sprite.mpDrawData->mFrames[0]));
+    entity.assign<BoundingBox>(engine::inferBoundingBox(sprite));
   }
   return entity;
 }
@@ -181,7 +181,7 @@ entityx::Entity EntityFactory::createProjectile(
   auto entity = mpEntityManager->create();
   auto sprite = createSpriteForId(actorIdForProjectile(type, direction));
 
-  const auto boundingBox = engine::inferBoundingBox(sprite.mpDrawData->mFrames[0]);
+  const auto boundingBox = engine::inferBoundingBox(sprite);
 
   // TODO: Player projectiles shouldn't move on the frame they were created
   entity.assign<Active>();
@@ -200,7 +200,7 @@ entityx::Entity EntityFactory::createActor(
 ) {
   auto entity = createSprite(id, position);
   auto& sprite = *entity.component<Sprite>();
-  const auto boundingBox = engine::inferBoundingBox(sprite.mpDrawData->mFrames[0]);
+  const auto boundingBox = engine::inferBoundingBox(sprite);
 
   configureEntity(entity, id, boundingBox);
 
@@ -298,7 +298,7 @@ entityx::Entity EntityFactory::createEntitiesForLevel(
       boundingBox.topLeft = {0, 0};
     } else if (hasAssociatedSprite(actor.mID)) {
       const auto sprite = createSpriteForId(actor.mID);
-      boundingBox = engine::inferBoundingBox(sprite.mpDrawData->mFrames[0]);
+      boundingBox = engine::inferBoundingBox(sprite);
       entity.assign<Sprite>(sprite);
     }
 

--- a/src/ingame_mode.cpp
+++ b/src/ingame_mode.cpp
@@ -85,16 +85,6 @@ std::string levelFileName(const int episode, const int level) {
 }
 
 
-std::string loadingScreenFileName(const int episode) {
-  assert(episode >=0 && episode < 4);
-
-  std::string fileName("LOAD");
-  fileName += std::to_string(episode + 1);
-  fileName += ".MNI";
-  return fileName;
-}
-
-
 template<typename ValueT>
 std::string vec2String(const base::Point<ValueT>& vec, const int width) {
   std::stringstream stream;
@@ -192,8 +182,6 @@ IngameMode::IngameMode(
       data::GameTraits::inGameViewPortSize.width,
       data::GameTraits::inGameViewPortSize.height)
 {
-  showLoadingScreen(episode, *context.mpResources);
-
   using namespace std::chrono;
   auto before = high_resolution_clock::now();
 
@@ -393,24 +381,6 @@ void IngameMode::updateGameLogic(const engine::TimeDelta dt) {
 
 bool IngameMode::levelFinished() const {
   return mLevelFinished;
-}
-
-
-void IngameMode::showLoadingScreen(
-  const int episode,
-  const loader::ResourceLoader& resources
-) {
-  mpServiceProvider->fadeOutScreen();
-  mpServiceProvider->playMusic("MENUSNG2.IMF");
-  {
-    const auto loadingScreenTexture = ui::fullScreenImageAsTexture(
-      mpRenderer,
-      resources,
-      loadingScreenFileName(episode));
-    loadingScreenTexture.render(mpRenderer, 0, 0);
-    mpRenderer->submitBatch();
-  }
-  mpServiceProvider->fadeInScreen();
 }
 
 

--- a/src/ingame_mode.hpp
+++ b/src/ingame_mode.hpp
@@ -55,8 +55,6 @@ public:
   bool levelFinished() const;
 
 private:
-  void showLoadingScreen(int episode, const loader::ResourceLoader& resources);
-
   void loadLevel(
     int episode,
     int levelNumber,


### PR DESCRIPTION
The time required to show the loading screen with fade-in and fade-out is now longer than the time required to actually load the level.