### PR TITLE
Lower down the minimum required OpenGL version

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -139,7 +139,7 @@ void initAndRunGame(const string& gamePath, const GameOptions& gameOptions) {
 #else
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
 #endif
   SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,7 +72,8 @@ struct SdlInitializer {
 class OpenGlContext {
 public:
   explicit OpenGlContext(SDL_Window* pWindow)
-    : mpOpenGLContext(SDL_GL_CreateContext(pWindow))
+    : mpOpenGLContext(
+        throwIfCreationFailed([=]() { return SDL_GL_CreateContext(pWindow); }))
   {
   }
   ~OpenGlContext() {
@@ -81,6 +82,7 @@ public:
 
   OpenGlContext(const OpenGlContext&) = delete;
   OpenGlContext& operator=(const OpenGlContext&) = delete;
+
 private:
   SDL_GLContext mpOpenGLContext;
 };


### PR DESCRIPTION
We don't need any features from 3.2, so we can just ask for version 3.0 instead. This makes the game work on Intel integrated chipsets.

closes #172 
closes #171 