### PR TITLE
Cleanup, refactor and fix collision detection

### DIFF
--- a/src/base/spatial_types.hpp
+++ b/src/base/spatial_types.hpp
@@ -194,6 +194,18 @@ Rect<ValueT> operator+(
 }
 
 
+template<typename ValueT>
+bool operator==(const Rect<ValueT>& lhs, const Rect<ValueT>& rhs) {
+  return std::tie(lhs.topLeft, lhs.size) == std::tie(rhs.topLeft, rhs.size);
+}
+
+
+template<typename ValueT>
+bool operator!=(const Rect<ValueT>& lhs, const Rect<ValueT>& rhs) {
+  return !(lhs == rhs);
+}
+
+
 using Vector = Point<int>;
 using Extents = Size<int>;
 

--- a/src/data/tile_attributes.cpp
+++ b/src/data/tile_attributes.cpp
@@ -37,6 +37,26 @@ bool isBitSet(uint16_t bitPack, uint16_t bitMask) {
 }
 
 
+SolidEdge SolidEdge::top() {
+  return SolidEdge{0x01};
+}
+
+
+SolidEdge SolidEdge::bottom() {
+  return SolidEdge{0x02};
+}
+
+
+SolidEdge SolidEdge::left() {
+  return SolidEdge{0x08};
+}
+
+
+SolidEdge SolidEdge::right() {
+  return SolidEdge{0x04};
+}
+
+
 CollisionData CollisionData::fullySolid() {
   return CollisionData{0xFF};
 }

--- a/src/data/tile_attributes.hpp
+++ b/src/data/tile_attributes.hpp
@@ -27,6 +27,25 @@ namespace rigel { namespace data { namespace map {
 using TileIndex = std::uint32_t;
 
 
+class SolidEdge {
+public:
+  static SolidEdge top();
+  static SolidEdge bottom();
+  static SolidEdge left();
+  static SolidEdge right();
+
+  friend class CollisionData;
+
+private:
+  explicit SolidEdge(const std::uint8_t bitPack)
+    : mFlagsBitPack(bitPack)
+  {
+  }
+
+  std::uint8_t mFlagsBitPack;
+};
+
+
 class CollisionData {
 public:
   static CollisionData fullySolid();
@@ -40,6 +59,10 @@ public:
   bool isSolidLeft() const;
   bool isSolidRight() const;
   bool isClear() const;
+
+  bool isSolidOn(const SolidEdge& edge) const {
+    return (mCollisionFlagsBitPack & edge.mFlagsBitPack) != 0;
+  }
 
 private:
   std::uint8_t mCollisionFlagsBitPack = 0;

--- a/src/engine/collision_checker.cpp
+++ b/src/engine/collision_checker.cpp
@@ -22,6 +22,8 @@
 
 namespace rigel { namespace engine {
 
+namespace ex = entityx;
+
 using namespace engine::components;
 
 
@@ -31,7 +33,7 @@ CollisionChecker::CollisionChecker(const data::map::Map* pMap)
 }
 
 
-bool CollisionChecker::walkEntity(entityx::Entity entity, const int amount) const {
+bool CollisionChecker::walkEntity(ex::Entity entity, const int amount) const {
   auto& position = *entity.component<WorldPosition>();
   const auto& bbox = *entity.component<BoundingBox>();
 
@@ -62,7 +64,7 @@ bool CollisionChecker::walkEntity(entityx::Entity entity, const int amount) cons
 
 
 bool CollisionChecker::walkEntityOnCeiling(
-  entityx::Entity entity,
+  ex::Entity entity,
   const int amount
 ) const {
   // TODO: Eliminate duplication with the regular walkEntity()

--- a/src/engine/collision_checker.cpp
+++ b/src/engine/collision_checker.cpp
@@ -16,7 +16,6 @@
 
 #include "collision_checker.hpp"
 
-#include "data/map.hpp"
 #include "engine/physical_components.hpp"
 
 
@@ -24,6 +23,8 @@ namespace rigel { namespace engine {
 
 namespace ex = entityx;
 
+using data::map::CollisionData;
+using data::map::SolidEdge;
 using namespace engine::components;
 
 
@@ -38,21 +39,15 @@ bool CollisionChecker::walkEntity(ex::Entity entity, const int amount) const {
   const auto& bbox = *entity.component<BoundingBox>();
 
   const auto newPosition = position + base::Vector{amount, 0};
-
   const auto movingLeft = amount < 0;
+
   const auto xToTest = newPosition.x + (movingLeft ? 0 : bbox.size.width - 1);
-
   const auto stillOnSolidGround =
-    mpMap->collisionData(xToTest, newPosition.y + 1).isSolidTop();
+    isOnSolidGround({{xToTest, newPosition.y}, {1, 1}});
 
-  // TODO: Unify this with the code in the physics system
-  bool collidingWithWorld = false;
-  for (int i = 0; i < bbox.size.height; ++i) {
-    if (!mpMap->collisionData(xToTest, newPosition.y - i).isClear()) {
-      collidingWithWorld = true;
-      break;
-    }
-  }
+  const auto collidingWithWorld = movingLeft
+    ? isTouchingLeftWall(position, bbox)
+    : isTouchingRightWall(position, bbox);
 
   if (stillOnSolidGround && !collidingWithWorld) {
     position = newPosition;
@@ -72,29 +67,15 @@ bool CollisionChecker::walkEntityOnCeiling(
   const auto& bbox = *entity.component<BoundingBox>();
 
   const auto newPosition = position + base::Vector{amount, 0};
-
   const auto movingLeft = amount < 0;
-  const auto xToTest =
-    newPosition.x +
-    (movingLeft ? 0 : bbox.size.width - 1) +
-    bbox.topLeft.x;
-  const auto yToTest =
-    newPosition.y +
-    bbox.topLeft.y -
-    (bbox.size.height - 1);
 
   const auto xOffset = bbox.size.width * amount;
   const auto offset = base::Vector{xOffset, 0};
   const auto stillOnCeiling = isTouchingCeiling(position + offset, bbox);
 
-  // TODO: Unify this with the code in the physics system
-  bool collidingWithWorld = false;
-  for (int i = 0; i < bbox.size.height; ++i) {
-    if (!mpMap->collisionData(xToTest, yToTest + i).isClear()) {
-      collidingWithWorld = true;
-      break;
-    }
-  }
+  const auto collidingWithWorld = movingLeft
+    ? isTouchingLeftWall(position, bbox)
+    : isTouchingRightWall(position, bbox);
 
   if (stillOnCeiling && !collidingWithWorld) {
     position = newPosition;
@@ -104,17 +85,69 @@ bool CollisionChecker::walkEntityOnCeiling(
   return false;
 }
 
+
 bool CollisionChecker::isOnSolidGround(
   const WorldPosition& position,
   const BoundingBox& bbox
 ) const {
   const auto worldSpaceBbox = engine::toWorldSpace(bbox, position);
+  return isOnSolidGround(worldSpaceBbox);
+}
 
-  const auto y = worldSpaceBbox.bottom() + 1;
-  const auto startX = worldSpaceBbox.left();
-  const auto endX = worldSpaceBbox.right();
+
+bool CollisionChecker::isTouchingCeiling(
+  const WorldPosition& position,
+  const BoundingBox& bbox
+) const {
+  const auto worldSpaceBbox = engine::toWorldSpace(bbox, position);
+  return isTouchingCeiling(worldSpaceBbox);
+}
+
+
+bool CollisionChecker::isTouchingLeftWall(
+  const WorldPosition& position,
+  const BoundingBox& bbox
+) const {
+  const auto worldSpaceBbox = engine::toWorldSpace(bbox, position);
+  return isTouchingLeftWall(worldSpaceBbox);
+}
+
+
+bool CollisionChecker::isTouchingRightWall(
+  const WorldPosition& position,
+  const BoundingBox& bbox
+) const {
+  const auto worldSpaceBbox = engine::toWorldSpace(bbox, position);
+  return isTouchingRightWall(worldSpaceBbox);
+}
+
+
+bool CollisionChecker::testHorizontalSpan(
+  const BoundingBox& bbox,
+  const int y,
+  const SolidEdge edge
+) const {
+  const auto startX = bbox.left();
+  const auto endX = bbox.right();
   for (int x = startX; x <= endX; ++x) {
-    if (mpMap->collisionData(x, y).isSolidTop()) {
+    if (mpMap->collisionData(x, y).isSolidOn(edge)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+
+bool CollisionChecker::testVerticalSpan(
+  const BoundingBox& bbox,
+  const int x,
+  const SolidEdge edge
+) const {
+  const auto startY = bbox.top();
+  const auto endY = bbox.bottom();
+  for (int y = startY; y <= endY; ++y) {
+    if (mpMap->collisionData(x, y).isSolidOn(edge)) {
       return true;
     }
   }
@@ -124,21 +157,34 @@ bool CollisionChecker::isOnSolidGround(
 
 
 bool CollisionChecker::isTouchingCeiling(
-  const WorldPosition& position,
-  const BoundingBox& bbox
+  const BoundingBox& worldSpaceBbox
 ) const {
-  const auto worldSpaceBbox = engine::toWorldSpace(bbox, position);
-
   const auto y = worldSpaceBbox.top() - 1;
-  const auto startX = worldSpaceBbox.left();
-  const auto endX = worldSpaceBbox.right();
-  for (int x = startX; x <= endX; ++x) {
-    if (mpMap->collisionData(x, y).isSolidBottom()) {
-      return true;
-    }
-  }
+  return testHorizontalSpan(worldSpaceBbox, y, SolidEdge::bottom());
+}
 
-  return false;
+
+bool CollisionChecker::isOnSolidGround(
+  const BoundingBox& worldSpaceBbox
+) const {
+  const auto y = worldSpaceBbox.bottom() + 1;
+  return testHorizontalSpan(worldSpaceBbox, y, SolidEdge::top());
+}
+
+
+bool CollisionChecker::isTouchingLeftWall(
+  const BoundingBox& worldSpaceBbox
+) const {
+  const auto x = worldSpaceBbox.left() - 1;
+  return testVerticalSpan(worldSpaceBbox, x, SolidEdge::right());
+}
+
+
+bool CollisionChecker::isTouchingRightWall(
+  const BoundingBox& worldSpaceBbox
+) const {
+  const auto x = worldSpaceBbox.right() + 1;
+  return testVerticalSpan(worldSpaceBbox, x, SolidEdge::left());
 }
 
 }}

--- a/src/engine/collision_checker.hpp
+++ b/src/engine/collision_checker.hpp
@@ -19,6 +19,9 @@
 #include "base/warnings.hpp"
 #include "data/map.hpp"
 #include "engine/base_components.hpp"
+#include "engine/physical_components.hpp"
+
+#include <vector>
 
 RIGEL_DISABLE_WARNINGS
 #include <entityx/entityx.h>
@@ -27,9 +30,12 @@ RIGEL_RESTORE_WARNINGS
 
 namespace rigel { namespace engine {
 
-class CollisionChecker {
+class CollisionChecker : public entityx::Receiver<CollisionChecker> {
 public:
-  CollisionChecker(const data::map::Map* pMap);
+  CollisionChecker(
+    const data::map::Map* pMap,
+    entityx::EntityManager& entities,
+    entityx::EventManager& eventManager);
 
   /** Walk entity by the given amount if possible.
    *
@@ -66,6 +72,11 @@ public:
   bool isTouchingLeftWall(const engine::components::BoundingBox& bbox) const;
   bool isTouchingRightWall(const engine::components::BoundingBox& bbox) const;
 
+  void receive(
+    const entityx::ComponentAddedEvent<components::SolidBody>& event);
+  void receive(
+    const entityx::ComponentRemovedEvent<components::SolidBody>& event);
+
 private:
   bool testHorizontalSpan(
     const engine::components::BoundingBox& bbox,
@@ -75,7 +86,10 @@ private:
     const engine::components::BoundingBox& bbox,
     int x,
     data::map::SolidEdge edge) const;
+  bool testSolidBodyCollision(
+    const engine::components::BoundingBox& bbox) const;
 
+  std::vector<entityx::Entity> mSolidBodies;
   const data::map::Map* mpMap;
 };
 

--- a/src/engine/collision_checker.hpp
+++ b/src/engine/collision_checker.hpp
@@ -17,14 +17,13 @@
 #pragma once
 
 #include "base/warnings.hpp"
+#include "data/map.hpp"
 #include "engine/base_components.hpp"
 
 RIGEL_DISABLE_WARNINGS
 #include <entityx/entityx.h>
 RIGEL_RESTORE_WARNINGS
 
-
-namespace rigel { namespace data { namespace map { class Map; }}}
 
 namespace rigel { namespace engine {
 
@@ -54,7 +53,29 @@ public:
     const engine::components::WorldPosition& position,
     const engine::components::BoundingBox& bbox) const;
 
+  bool isTouchingLeftWall(
+    const engine::components::WorldPosition& position,
+    const engine::components::BoundingBox& bbox) const;
+
+  bool isTouchingRightWall(
+    const engine::components::WorldPosition& position,
+    const engine::components::BoundingBox& bbox) const;
+
+  bool isOnSolidGround(const engine::components::BoundingBox& bbox) const;
+  bool isTouchingCeiling(const engine::components::BoundingBox& bbox) const;
+  bool isTouchingLeftWall(const engine::components::BoundingBox& bbox) const;
+  bool isTouchingRightWall(const engine::components::BoundingBox& bbox) const;
+
 private:
+  bool testHorizontalSpan(
+    const engine::components::BoundingBox& bbox,
+    int y,
+    data::map::SolidEdge edge) const;
+  bool testVerticalSpan(
+    const engine::components::BoundingBox& bbox,
+    int x,
+    data::map::SolidEdge edge) const;
+
   const data::map::Map* mpMap;
 };
 

--- a/src/engine/debugging_system.cpp
+++ b/src/engine/debugging_system.cpp
@@ -97,6 +97,8 @@ void DebuggingSystem::update(
         const auto right = bottomRight.x;
         const auto bottom = bottomRight.y;
 
+        // TODO: Implement this using SolidEdge matching,
+        // then remove these functions (isSolidXXX) from CollisionData
         if (collisionData.isSolidTop()) {
           mpRenderer->drawLine(left, top, right, top, drawColor);
         }

--- a/src/engine/physics_system.hpp
+++ b/src/engine/physics_system.hpp
@@ -16,10 +16,8 @@
 
 #pragma once
 
-#include "base/grid.hpp"
 #include "base/spatial_types.hpp"
 #include "base/warnings.hpp"
-#include "data/tile_attributes.hpp"
 #include "engine/base_components.hpp"
 #include "engine/physical_components.hpp"
 
@@ -29,12 +27,12 @@ RIGEL_RESTORE_WARNINGS
 
 #include <cstdint>
 #include <tuple>
-#include <vector>
 
-
-namespace rigel { namespace data { namespace map { class Map; }}}
 
 namespace rigel { namespace engine {
+
+class CollisionChecker;
+
 
 /** Implements game physics/world interaction
  *
@@ -53,20 +51,14 @@ namespace rigel { namespace engine {
  * movement. The system can't perform any corrections to entities which are
  * already positioned so that they collide with the world.
  */
-class PhysicsSystem : public entityx::System<PhysicsSystem> {
+class PhysicsSystem {
 public:
-  explicit PhysicsSystem(const data::map::Map* pMap);
+  explicit PhysicsSystem(const engine::CollisionChecker* pCollisionChecker);
 
-  void update(
-    entityx::EntityManager& es,
-    entityx::EventManager& events,
-    entityx::TimeDelta dt) override;
+  void update(entityx::EntityManager& es);
 
 private:
-  data::map::CollisionData worldAt(int x, int y) const;
-
   base::Vector applyHorizontalMovement(
-    entityx::Entity entity,
     const components::BoundingBox& bbox,
     const base::Vector& currentPosition,
     std::int16_t movementX,
@@ -74,7 +66,6 @@ private:
   ) const;
 
   std::tuple<base::Vector, float> applyVerticalMovement(
-    entityx::Entity entity,
     const components::BoundingBox& bbox,
     const base::Vector& currentPosition,
     float currentVelocity,
@@ -86,15 +77,8 @@ private:
     const components::BoundingBox& bbox,
     float currentVelocity);
 
-  bool hasSolidBodyCollision(
-    entityx::Entity,
-    const components::BoundingBox& bbox) const;
-
 private:
-  const data::map::Map* mpMap;
-
-  using SolidBodyInfo = std::tuple<entityx::Entity, components::BoundingBox>;
-  std::vector<SolidBodyInfo> mSolidBodies;
+  const CollisionChecker* mpCollisionChecker;
 };
 
 }}

--- a/src/game_logic/ai/sliding_door.hpp
+++ b/src/game_logic/ai/sliding_door.hpp
@@ -41,6 +41,7 @@ struct HorizontalSlidingDoor {
 
   State mState = State::Closed;
   bool mPlayerWasInRange = false;
+  entityx::Entity mCollisionHelper;
 };
 
 

--- a/src/ingame_mode.cpp
+++ b/src/ingame_mode.cpp
@@ -108,9 +108,11 @@ struct IngameMode::Systems {
     EntityFactory* pEntityFactory,
     RandomNumberGenerator* pRandomGenerator,
     const data::map::Map& map,
-    FireShotFuncT fireShotFunc
+    FireShotFuncT fireShotFunc,
+    entityx::EntityManager& entities,
+    entityx::EventManager& eventManager
   )
-    : mCollisionChecker(pMap)
+    : mCollisionChecker(pMap, entities, eventManager)
     , mMapScrollSystem(pScrollOffset, playerEntity, map)
     , mPlayerMovementSystem(playerEntity, map)
     , mPlayerAttackSystem(
@@ -471,7 +473,9 @@ void IngameMode::loadLevel(
       const game_logic::ProjectileDirection direction
     ) {
       mEntityFactory.createProjectile(type, pos, direction);
-    });
+    },
+    mEntities.entities,
+    mEntities.events);
 
   mEntities.systems.system<DamageInflictionSystem>()->entityHitSignal().connect(
     [this](entityx::Entity entity) {

--- a/src/ingame_mode.cpp
+++ b/src/ingame_mode.cpp
@@ -113,6 +113,7 @@ struct IngameMode::Systems {
     entityx::EventManager& eventManager
   )
     : mCollisionChecker(pMap, entities, eventManager)
+    , mPhysicsSystem(&mCollisionChecker)
     , mMapScrollSystem(pScrollOffset, playerEntity, map)
     , mPlayerMovementSystem(playerEntity, map)
     , mPlayerAttackSystem(
@@ -143,6 +144,7 @@ struct IngameMode::Systems {
   }
 
   engine::CollisionChecker mCollisionChecker;
+  engine::PhysicsSystem mPhysicsSystem;
 
   game_logic::MapScrollSystem mMapScrollSystem;
   game_logic::PlayerMovementSystem mPlayerMovementSystem;
@@ -364,7 +366,7 @@ void IngameMode::updateGameLogic(const engine::TimeDelta dt) {
   // ----------------------------------------------------------------------
   // Physics and other updates
   // ----------------------------------------------------------------------
-  mEntities.systems.update<PhysicsSystem>(dt);
+  mpSystems->mPhysicsSystem.update(mEntities.entities);
 
   // Player attacks have to be processed after physics, because:
   //  1. Player projectiles should spawn at the player's location
@@ -403,8 +405,6 @@ void IngameMode::loadLevel(
   };
   mMapAtLevelStart = mLevelData.mMap;
 
-  mEntities.systems.add<PhysicsSystem>(
-    &mLevelData.mMap);
   mEntities.systems.add<game_logic::player::AnimationSystem>(
     mPlayerEntity,
     mpServiceProvider,

--- a/test/test_elevator.cpp
+++ b/test/test_elevator.cpp
@@ -19,6 +19,7 @@
 
 #include <base/spatial_types_printing.hpp>
 #include <data/map.hpp>
+#include <engine/collision_checker.hpp>
 #include <engine/physical_components.hpp>
 #include <engine/physics_system.hpp>
 #include <engine/timing.hpp>
@@ -65,7 +66,8 @@ TEST_CASE("Rocket elevator") {
     map.setTileAt(0, i, 90, 1);
   }
 
-  PhysicsSystem physicsSystem{&map};
+  CollisionChecker collisionChecker{&map, entityx.entities, entityx.events};
+  PhysicsSystem physicsSystem{&collisionChecker};
 
 
   SECTION("Elevator is setup correctly") {
@@ -86,7 +88,7 @@ TEST_CASE("Rocket elevator") {
       const PlayerInputState& inputState
     ) {
       elevatorSystem.update(entityx.entities, inputState);
-      physicsSystem.update(entityx.entities, entityx.events, 0);
+      physicsSystem.update(entityx.entities);
     };
 
   const auto verifyPositions = [&playerPosition, &elevatorPosition](

--- a/test/test_physics_system.cpp
+++ b/test/test_physics_system.cpp
@@ -19,6 +19,7 @@
 #include <base/warnings.hpp>
 
 #include <data/map.hpp>
+#include <engine/collision_checker.hpp>
 #include <engine/physical_components.hpp>
 #include <engine/physics_system.hpp>
 #include <engine/timing.hpp>
@@ -38,7 +39,8 @@ TEST_CASE("Physics system works as expected") {
 
   data::map::Map map{100, 100, data::map::TileAttributes{{0x0, 0xF}}};
 
-  PhysicsSystem physicsSystem{&map};
+  CollisionChecker collisionChecker{&map, entityx.entities, entityx.events};
+  PhysicsSystem physicsSystem{&collisionChecker};
 
   auto physicalObject = entities.create();
   physicalObject.assign<BoundingBox>(BoundingBox{{0, 0}, {2, 2}});
@@ -50,7 +52,7 @@ TEST_CASE("Physics system works as expected") {
   auto& position = *physicalObject.component<WorldPosition>();
 
   const auto runOneFrame = [&physicsSystem, &entityx]() {
-    physicsSystem.update(entityx.entities, entityx.events, 0);
+    physicsSystem.update(entityx.entities);
   };
 
 


### PR DESCRIPTION
Previously, there was a lot of duplication between `CollisionChecker` and `PhysicsSystem`, with each of them having different capabilities - most notably, the `CollisionChecker` was lacking collisions against solid bodies and behaving incorrectly with tiles that aren't completely solid. This branch moves all collision checking logic into `CollisionChecker`, giving it all of the capabilities the `PhysicsSystem` has, and implements the latter in terms of the former.

This greatly improves code quality, and also fixes a bunch of issues:

Fixes #174 
Fixes #112 
Closes #169 
Closes #168  