### PR TITLE
Framework additions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(core_sources
+    base/array_view.hpp
     base/boost_variant.hpp
     base/grid.hpp
     base/math_tools.hpp

--- a/src/base/array_view.hpp
+++ b/src/base/array_view.hpp
@@ -1,0 +1,124 @@
+/* Copyright (C) 2017, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+
+namespace rigel { namespace base {
+
+/** Read-only array view type
+ *
+ * This has almost the same interface as std::array, but doesn't store the data
+ * itself. Instead, it just holds a pointer plus the number of elements.
+ * This allows creating lightweight views into arrays, which are cheap to copy
+ * and store, but can be used like an array.
+ *
+ * Only allows read access.
+ */
+template<typename T>
+class ArrayView {
+public:
+  using value_type = T;
+  using size_type = std::uint32_t;
+  using difference_type = std::int32_t;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using pointer = value_type*;
+  using const_pointer = const value_type*;
+  using iterator = pointer;
+  using const_iterator = const_pointer;
+
+  ArrayView() = default;
+  ArrayView(const T* pData, const size_type size)
+    : mpData(pData)
+    , mSize(size)
+  {
+  }
+
+  template <std::size_t N>
+  ArrayView(const std::array<T, N>& array) // implicit on purpose
+    : mpData(array.data())
+    , mSize(static_cast<size_type>(size))
+  {
+  }
+
+  template <std::size_t N>
+  ArrayView(const T (&array)[N]) // implicit on purpose
+    : mpData(array)
+    , mSize(static_cast<size_type>(N))
+  {
+  }
+
+  const_iterator begin() const {
+    return mpData;
+  }
+
+  const_iterator end() const {
+    return mpData + mSize;
+  }
+
+  const_iterator cbegin() const {
+    return mpData;
+  }
+
+  const_iterator cend() const {
+    return mpData + mSize;
+  }
+
+  size_type size() const {
+    return mSize;
+  }
+
+  bool empty() const {
+    return mSize == 0;
+  }
+
+  const_reference operator[](const size_type index) const {
+    return mpData[index];
+  }
+
+  const_reference at(const size_type index) const {
+    using namespace std::string_literals;
+    if (index >= mSize) {
+      throw std::range_error("Index out of range: "s + std::to_string(index));
+    }
+
+    return mpData[index];
+  }
+
+  const_reference front() const {
+    return *begin();
+  }
+
+  const_reference back() const {
+    return *end();
+  }
+
+  const T* data() const {
+    return mpData;
+  }
+
+private:
+  const T* mpData = nullptr;
+  size_type mSize = 0;
+};
+
+}}

--- a/src/base/math_tools.hpp
+++ b/src/base/math_tools.hpp
@@ -34,6 +34,12 @@ T integerDivCeil(const T value, const T divisor) {
 
 
 template<typename T>
+auto lerp(const T a, const T b, const float factor) {
+  return a * (1.0f - factor) + b * factor;
+}
+
+
+template<typename T>
 bool inRange(const T value, const T min, const T max) {
   return value >= min && value <= max;
 }

--- a/src/engine/base_components.hpp
+++ b/src/engine/base_components.hpp
@@ -31,7 +31,9 @@ using BoundingBox = base::Rect<int>;
  * active if their bounding box intersects the active region, i.e. they are
  * visible on screen.
  * */
-struct Active {};
+struct Active {
+  bool mIsOnScreen = true;
+};
 
 /** Specifies when to activate entity */
 struct ActivationSettings {

--- a/src/engine/debugging_system.cpp
+++ b/src/engine/debugging_system.cpp
@@ -81,6 +81,11 @@ void DebuggingSystem::toggleWorldCollisionDataDisplay() {
 }
 
 
+void DebuggingSystem::toggleGridDisplay() {
+  mShowGrid = !mShowGrid;
+}
+
+
 void DebuggingSystem::update(
   ex::EntityManager& es,
   ex::EventManager& events,
@@ -139,6 +144,24 @@ void DebuggingSystem::update(
 
         mpRenderer->drawRectangle(boxInPixels, colorForEntity(entity));
       });
+  }
+
+  if (mShowGrid) {
+    const auto drawColor = base::Color{255, 255, 255, 190};
+    const auto maxX = tilesToPixels(GameTraits::mapViewPortWidthTiles);
+    const auto maxY = tilesToPixels(GameTraits::mapViewPortHeightTiles);
+
+    // Horizontal lines
+    for (int y=0; y<GameTraits::mapViewPortHeightTiles; ++y) {
+      const auto pxY = tilesToPixels(y);
+      mpRenderer->drawLine(0, pxY, maxX, pxY, drawColor);
+    }
+
+    // Vertical lines
+    for (int x=0; x<GameTraits::mapViewPortWidthTiles; ++x) {
+      const auto pxX = tilesToPixels(x);
+      mpRenderer->drawLine(pxX, 0, pxX, maxY, drawColor);
+    }
   }
 }
 

--- a/src/engine/debugging_system.hpp
+++ b/src/engine/debugging_system.hpp
@@ -37,6 +37,7 @@ public:
 
   void toggleBoundingBoxDisplay();
   void toggleWorldCollisionDataDisplay();
+  void toggleGridDisplay();
 
   void update(
     entityx::EntityManager& es,
@@ -50,6 +51,7 @@ private:
 
   bool mShowBoundingBoxes = false;
   bool mShowWorldCollisionData = false;
+  bool mShowGrid = false;
 };
 
 }}

--- a/src/engine/entity_activation_system.cpp
+++ b/src/engine/entity_activation_system.cpp
@@ -75,6 +75,9 @@ void markActiveEntities(
     const auto inActiveRegion = worldSpaceBbox.intersects(activeRegionBox);
     const auto active = determineActiveState(entity, inActiveRegion);
     setTag<Active>(entity, active);
+    if (active) {
+      entity.component<Active>()->mIsOnScreen = inActiveRegion;
+    }
   });
 }
 

--- a/src/engine/physical_components.hpp
+++ b/src/engine/physical_components.hpp
@@ -25,8 +25,8 @@ namespace rigel { namespace engine {
 
 namespace components {
 
-struct Physical {
-  Physical(
+struct MovingBody {
+  MovingBody(
     const base::Point<float> velocity,
     const bool gravityAffected,
     const bool canStepUpStairs = false
@@ -51,7 +51,7 @@ struct CollidedWithWorld {};
 
 /** Marks an entity to participate in world collision
  *
- * Other Physical entities will collide against the bounding box of any
+ * Other MovingBody entities will collide against the bounding box of any
  * SolidBody entity as if it were part of the world.
  * */
 struct SolidBody {};

--- a/src/engine/physics_system.cpp
+++ b/src/engine/physics_system.cpp
@@ -27,7 +27,7 @@ namespace rigel { namespace engine {
 using namespace std;
 
 using components::BoundingBox;
-using components::Physical;
+using components::MovingBody;
 using components::SolidBody;
 using components::WorldPosition;
 
@@ -53,23 +53,23 @@ PhysicsSystem::PhysicsSystem(const engine::CollisionChecker* pCollisionChecker)
 void PhysicsSystem::update(ex::EntityManager& es) {
   using components::CollidedWithWorld;
 
-  es.each<Physical, WorldPosition, BoundingBox, components::Active>(
+  es.each<MovingBody, WorldPosition, BoundingBox, components::Active>(
     [this](
       ex::Entity entity,
-      Physical& physical,
+      MovingBody& body,
       WorldPosition& position,
       const BoundingBox& collisionRect,
       const components::Active&
     ) {
       const auto originalPosition = position;
 
-      const auto movementX = static_cast<int16_t>(physical.mVelocity.x);
+      const auto movementX = static_cast<int16_t>(body.mVelocity.x);
       if (movementX != 0) {
         position= applyHorizontalMovement(
           toWorldSpace(collisionRect, position),
           position,
           movementX,
-          physical.mCanStepUpStairs);
+          body.mCanStepUpStairs);
       }
 
       // Cache new world space BBox after applying horizontal movement
@@ -82,18 +82,18 @@ void PhysicsSystem::update(ex::EntityManager& es) {
       // frame where we applied the horizontal movement. Changing the velocity
       // here will automatically move the entity down when doing the vertical
       // movement.
-      if (physical.mGravityAffected) {
-        physical.mVelocity.y = applyGravity(bbox, physical.mVelocity.y);
+      if (body.mGravityAffected) {
+        body.mVelocity.y = applyGravity(bbox, body.mVelocity.y);
       }
 
-      const auto movementY = static_cast<std::int16_t>(physical.mVelocity.y);
+      const auto movementY = static_cast<std::int16_t>(body.mVelocity.y);
       if (movementY != 0) {
-        std::tie(position, physical.mVelocity.y) = applyVerticalMovement(
+        std::tie(position, body.mVelocity.y) = applyVerticalMovement(
           bbox,
           position,
-          physical.mVelocity.y,
+          body.mVelocity.y,
           movementY,
-          physical.mGravityAffected);
+          body.mGravityAffected);
       }
 
       const auto collisionOccured =

--- a/src/engine/rendering_system.cpp
+++ b/src/engine/rendering_system.cpp
@@ -34,6 +34,7 @@ namespace ex = entityx;
 namespace rigel { namespace engine {
 
 using components::AnimationLoop;
+using components::AnimationSequence;
 using components::CustomRenderFunc;
 using components::DrawTopMost;
 using components::Sprite;
@@ -79,6 +80,29 @@ void updateAnimatedSprites(ex::EntityManager& es) {
       if (entity.has_component<components::BoundingBox>()) {
         engine::synchronizeBoundingBoxToSprite(entity, animated.mRenderSlot);
       }
+    }
+  });
+
+  es.each<Sprite, AnimationSequence>([](
+    ex::Entity entity,
+    Sprite& sprite,
+    AnimationSequence& sequence
+  ) {
+    ++sequence.mCurrentFrame;
+    if (sequence.mCurrentFrame >= sequence.mFrames.size()) {
+      if (sequence.mRepeat) {
+        sequence.mCurrentFrame = 0;
+      } else {
+        entity.remove<AnimationSequence>();
+        return;
+      }
+    }
+
+    sprite.mFramesToRender[sequence.mRenderSlot] =
+      sequence.mFrames[sequence.mCurrentFrame];
+
+    if (entity.has_component<components::BoundingBox>()) {
+      engine::synchronizeBoundingBoxToSprite(entity, sequence.mRenderSlot);
     }
   });
 }

--- a/src/engine/rendering_system.cpp
+++ b/src/engine/rendering_system.cpp
@@ -33,7 +33,7 @@ namespace ex = entityx;
 
 namespace rigel { namespace engine {
 
-using components::Animated;
+using components::AnimationLoop;
 using components::CustomRenderFunc;
 using components::DrawTopMost;
 using components::Sprite;
@@ -43,7 +43,7 @@ using components::WorldPosition;
 namespace {
 
 
-void advanceAnimation(Sprite& sprite, Animated& animated) {
+void advanceAnimation(Sprite& sprite, AnimationLoop& animated) {
   const auto numFrames = static_cast<int>(sprite.mpDrawData->mFrames.size());
   const auto endFrame = animated.mEndFrame ? *animated.mEndFrame : numFrames-1;
   assert(endFrame >= 0 && endFrame < numFrames);
@@ -66,10 +66,10 @@ void advanceAnimation(Sprite& sprite, Animated& animated) {
 
 
 void updateAnimatedSprites(ex::EntityManager& es) {
-  es.each<Sprite, Animated>([](
+  es.each<Sprite, AnimationLoop>([](
     ex::Entity entity,
     Sprite& sprite,
-    Animated& animated
+    AnimationLoop& animated
   ) {
     ++animated.mFramesElapsed;
     if (animated.mFramesElapsed >= animated.mDelayInFrames) {

--- a/src/engine/rendering_system.cpp
+++ b/src/engine/rendering_system.cpp
@@ -77,8 +77,11 @@ void updateAnimatedSprites(ex::EntityManager& es) {
       animated.mFramesElapsed = 0;
       advanceAnimation(sprite, animated);
 
-      if (entity.has_component<components::BoundingBox>()) {
-        engine::synchronizeBoundingBoxToSprite(entity, animated.mRenderSlot);
+      if (
+        entity.has_component<components::BoundingBox>() &&
+        animated.mRenderSlot == 0
+      ) {
+        engine::synchronizeBoundingBoxToSprite(entity);
       }
     }
   });
@@ -101,8 +104,11 @@ void updateAnimatedSprites(ex::EntityManager& es) {
     sprite.mFramesToRender[sequence.mRenderSlot] =
       sequence.mFrames[sequence.mCurrentFrame];
 
-    if (entity.has_component<components::BoundingBox>()) {
-      engine::synchronizeBoundingBoxToSprite(entity, sequence.mRenderSlot);
+    if (
+      entity.has_component<components::BoundingBox>() &&
+      sequence.mRenderSlot == 0
+    ) {
+      engine::synchronizeBoundingBoxToSprite(entity);
     }
   });
 }

--- a/src/engine/rendering_system.hpp
+++ b/src/engine/rendering_system.hpp
@@ -32,10 +32,10 @@
 
 namespace rigel { namespace engine {
 
-/** Animates sprites with an Animated component
+/** Animates sprites with an AnimationLoop component
  *
  * Should be called at game-logic rate. Works on all entities that have a
- * Sprite and an Animated component. Adjusts the sprite's animation frame
+ * Sprite and an AnimationLoop component. Adjusts the sprite's animation frame
  * based on the animation.
  */
 void updateAnimatedSprites(entityx::EntityManager& es);

--- a/src/engine/sprite_tools.hpp
+++ b/src/engine/sprite_tools.hpp
@@ -74,4 +74,20 @@ inline void startAnimationLoop(
     delayInFrames, startFrame, endFrame, renderSlot);
 }
 
+
+inline void startAnimationSequence(
+  entityx::Entity& entity,
+  const base::ArrayView<int>& frames,
+  const int renderSlot = 0
+) {
+  if (entity.has_component<components::AnimationSequence>()) {
+    entity.remove<components::AnimationSequence>();
+  }
+
+  auto& sprite = *entity.component<components::Sprite>();
+  sprite.mFramesToRender[renderSlot] = frames.front();
+  entity.assign<components::AnimationSequence>(frames, renderSlot);
+}
+
+
 }}

--- a/src/engine/sprite_tools.hpp
+++ b/src/engine/sprite_tools.hpp
@@ -57,7 +57,7 @@ inline void synchronizeBoundingBoxToSprite(
 }
 
 
-inline void startAnimation(
+inline void startAnimationLoop(
   entityx::Entity& entity,
   const int delayInFrames,
   const int startFrame,

--- a/src/engine/sprite_tools.hpp
+++ b/src/engine/sprite_tools.hpp
@@ -64,13 +64,13 @@ inline void startAnimation(
   boost::optional<int> endFrame,
   const int renderSlot = 0
 ) {
-  if (entity.has_component<components::Animated>()) {
-    entity.remove<components::Animated>();
+  if (entity.has_component<components::AnimationLoop>()) {
+    entity.remove<components::AnimationLoop>();
   }
 
   auto& sprite = *entity.component<components::Sprite>();
   sprite.mFramesToRender[renderSlot] = startFrame;
-  entity.assign<components::Animated>(
+  entity.assign<components::AnimationLoop>(
     delayInFrames, startFrame, endFrame, renderSlot);
 }
 

--- a/src/engine/visual_components.hpp
+++ b/src/engine/visual_components.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "base/array_view.hpp"
 #include "base/warnings.hpp"
 #include "base/spatial_types.hpp"
 #include "engine/base_components.hpp"
@@ -137,6 +138,26 @@ struct AnimationLoop {
   int mStartFrame = 0;
   boost::optional<int> mEndFrame;
   int mRenderSlot = 0;
+};
+
+
+struct AnimationSequence {
+  AnimationSequence(
+    const base::ArrayView<int>& frames,
+    const int renderSlot = 0,
+    const bool repeat = false,
+    const int startFrame = 0)
+    : mFrames(frames)
+    , mCurrentFrame(startFrame)
+    , mRenderSlot(renderSlot)
+    , mRepeat(repeat)
+  {
+  }
+
+  base::ArrayView<int> mFrames;
+  decltype(mFrames)::size_type mCurrentFrame = 0;
+  int mRenderSlot = 0;
+  bool mRepeat = false;
 };
 
 }}}

--- a/src/engine/visual_components.hpp
+++ b/src/engine/visual_components.hpp
@@ -109,17 +109,17 @@ struct OverrideDrawOrder {
 };
 
 
-struct Animated {
-  Animated() = default;
-  explicit Animated(
+struct AnimationLoop {
+  AnimationLoop() = default;
+  explicit AnimationLoop(
     const int delayInFrames,
     boost::optional<int> endFrame = boost::none
   )
-    : Animated(delayInFrames, 0, endFrame)
+    : AnimationLoop(delayInFrames, 0, endFrame)
   {
   }
 
-  Animated(
+  AnimationLoop(
     const int delayInFrames,
     const int startFrame,
     boost::optional<int> endFrame,

--- a/src/game_logic/ai/hover_bot.cpp
+++ b/src/game_logic/ai/hover_bot.cpp
@@ -100,7 +100,7 @@ void HoverBotSystem::update(entityx::EntityManager& es) {
           if (state.mFramesElapsed == 1) {
             // start teleport animation
             sprite.mShow = true;
-            engine::startAnimation(
+            engine::startAnimationLoop(
               entity,
               1,
               TELEPORT_ANIMATION_START_FRAME,
@@ -109,7 +109,7 @@ void HoverBotSystem::update(entityx::EntityManager& es) {
           } else if (state.mFramesElapsed == 8) {
             // stop teleport animation, draw the robot's body with a looping
             // animation
-            engine::startAnimation(entity, 1, 0, 5);
+            engine::startAnimationLoop(entity, 1, 0, 5);
 
             // draw the robot's eye
             sprite.mFramesToRender.push_back(6);

--- a/src/game_logic/ai/messenger_drone.cpp
+++ b/src/game_logic/ai/messenger_drone.cpp
@@ -145,7 +145,7 @@ void MessengerDroneSystem::update(
           exhaustStartFrame // horizontal engine exhaust/flame
         };
 
-        entity.assign<Animated>(
+        entity.assign<AnimationLoop>(
           1, exhaustStartFrame, exhaustStartFrame + 1, 3);
 
         state.mState = State::FlyIn;
@@ -161,8 +161,8 @@ void MessengerDroneSystem::update(
           // Switch from horizontal engine to vertical engine (suspension in
           // mid-air instead of propulsion)
           sprite.mFramesToRender[3] = 4;
-          entity.remove<Animated>();
-          entity.assign<Animated>(1, 4, 5, 3);
+          entity.remove<AnimationLoop>();
+          entity.assign<AnimationLoop>(1, 4, 5, 3);
 
           // Start showing message on screen, use 5th render slot (index 4)
           sprite.mFramesToRender.push_back(10);
@@ -193,8 +193,8 @@ void MessengerDroneSystem::update(
             const auto exhaustStartFrame =
               state.mOrientation == Orientation::Left ? 8 : 6;
             sprite.mFramesToRender[3] = exhaustStartFrame;
-            entity.remove<Animated>();
-            entity.assign<Animated>(
+            entity.remove<AnimationLoop>();
+            entity.assign<AnimationLoop>(
               1, exhaustStartFrame, exhaustStartFrame + 1, 3);
 
             entity.assign<AutoDestroy>(

--- a/src/game_logic/ai/messenger_drone.cpp
+++ b/src/game_logic/ai/messenger_drone.cpp
@@ -16,6 +16,7 @@
 
 #include "messenger_drone.hpp"
 
+#include "base/array_view.hpp"
 #include "engine/life_time_components.hpp"
 #include "engine/visual_components.hpp"
 
@@ -85,33 +86,7 @@ const MessageFrame CANT_ESCAPE[] = {
 };
 
 
-template <typename T>
-struct ArrayRef {
-  template <std::size_t N>
-  ArrayRef(const T (&array)[N]) // implicit on purpose
-    : mpItems(array)
-    , mSize(N)
-  {
-  }
-
-  std::size_t size() const {
-    return mSize;
-  }
-
-  const T& operator[](const std::size_t index) const {
-    return mpItems[index];
-  }
-
-  T& operator[](const std::size_t index) {
-    return mpItems[index];
-  }
-
-  const T* mpItems;
-  std::size_t mSize;
-};
-
-
-const ArrayRef<MessageFrame> MESSAGE_SEQUENCES[] = {
+const base::ArrayView<MessageFrame> MESSAGE_SEQUENCES[] = {
   YOUR_BRAIN_IS_OURS,
   BRING_BACK_THE_BRAIN,
   LIVE_FROM_RIGEL,

--- a/src/game_logic/ai/messenger_drone.hpp
+++ b/src/game_logic/ai/messenger_drone.hpp
@@ -57,7 +57,7 @@ struct MessengerDrone {
     engine::components::Orientation::Left;
   Message mMessage;
 
-  std::size_t mMessageStep = 0;
+  std::uint32_t mMessageStep = 0;
   int mElapsedFrames = 0;
 };
 

--- a/src/game_logic/ai/prisoner.hpp
+++ b/src/game_logic/ai/prisoner.hpp
@@ -35,20 +35,14 @@ namespace rigel { namespace game_logic { namespace ai {
 namespace components {
 
 struct Prisoner {
-  enum class State {
-    Idle,
-    Grabbing,
-    Dieing
-  };
-
   explicit Prisoner(const bool isAggressive)
     : mIsAggressive(isAggressive)
   {
   }
 
-  bool mIsAggressive;
-  State mState = State::Idle;
   int mGrabStep = 0;
+  bool mIsAggressive;
+  bool mIsGrabbing = false;
 };
 
 }

--- a/src/game_logic/ai/prisoner.hpp
+++ b/src/game_logic/ai/prisoner.hpp
@@ -49,7 +49,6 @@ struct Prisoner {
   bool mIsAggressive;
   State mState = State::Idle;
   int mGrabStep = 0;
-  int mDeathAnimationStep = 0;
 };
 
 }

--- a/src/game_logic/ai/rocket_turret.cpp
+++ b/src/game_logic/ai/rocket_turret.cpp
@@ -124,7 +124,7 @@ void RocketTurretSystem::fireRocket(
 
   projectile.assign<game_logic::components::Shootable>(1, 10);
   projectile.component<Sprite>()->mFramesToRender.push_back(0);
-  projectile.assign<Animated>(1, 1, 2, 0);
+  projectile.assign<AnimationLoop>(1, 1, 2, 0);
 
   mpServiceProvider->playSound(data::SoundId::FlameThrowerShot);
 }

--- a/src/game_logic/ai/skeleton.cpp
+++ b/src/game_logic/ai/skeleton.cpp
@@ -31,7 +31,7 @@ using namespace engine::orientation;
 void updateAnimation(entityx::Entity entity, const Orientation orientation) {
   const auto startFrame = orientation == Orientation::Left ? 0 : 4;
   const auto endFrame = startFrame + 3;
-  engine::startAnimation(entity, 2, startFrame, endFrame);
+  engine::startAnimationLoop(entity, 2, startFrame, endFrame);
 }
 
 } // namespace

--- a/src/game_logic/ai/slime_pipe.cpp
+++ b/src/game_logic/ai/slime_pipe.cpp
@@ -79,7 +79,7 @@ void SlimePipeSystem::createSlimeDrop(const base::Vector& position) {
     position + DROP_OFFSET,
     true);
   // Gravity handles the drop's movement, so velocity is initally 0.
-  entity.assign<Physical>(base::Point<float>{0.0f, 0.0f}, true);
+  entity.assign<MovingBody>(base::Point<float>{0.0f, 0.0f}, true);
 
   entity.assign<game_logic::components::PlayerDamaging>(1);
   entity.assign<AutoDestroy>(AutoDestroy{

--- a/src/game_logic/entity_configuration.ipp
+++ b/src/game_logic/entity_configuration.ipp
@@ -416,7 +416,7 @@ void EntityFactory::configureEntity(
   switch (actorID) {
     // Bonus globes
     case 45:
-      entity.assign<Animated>(1, 0, 3, 0);
+      entity.assign<AnimationLoop>(1, 0, 3, 0);
       entity.assign<Shootable>(1, 100);
       addDefaultPhysical(entity, boundingBox);
       {
@@ -427,7 +427,7 @@ void EntityFactory::configureEntity(
       break;
 
     case 46:
-      entity.assign<Animated>(1, 0, 3, 0);
+      entity.assign<AnimationLoop>(1, 0, 3, 0);
       entity.assign<Shootable>(1, 100);
       addDefaultPhysical(entity, boundingBox);
       {
@@ -438,7 +438,7 @@ void EntityFactory::configureEntity(
       break;
 
     case 47:
-      entity.assign<Animated>(1, 0, 3, 0);
+      entity.assign<AnimationLoop>(1, 0, 3, 0);
       entity.assign<Shootable>(1, 100);
       addDefaultPhysical(entity, boundingBox);
       {
@@ -449,7 +449,7 @@ void EntityFactory::configureEntity(
       break;
 
     case 48:
-      entity.assign<Animated>(1, 0, 3, 0);
+      entity.assign<AnimationLoop>(1, 0, 3, 0);
       entity.assign<Shootable>(1, 100);
       addDefaultPhysical(entity, boundingBox);
       {
@@ -470,7 +470,7 @@ void EntityFactory::configureEntity(
 
     // Keyhole (blue key)
     case 122:
-      entity.assign<Animated>(1, 4);
+      entity.assign<AnimationLoop>(1, 4);
       break;
 
     // ----------------------------------------------------------------------
@@ -521,7 +521,7 @@ void EntityFactory::configureEntity(
         item.mGivenScore = 500;
         item.mGivenItem = InventoryItemType::RapidFire;
         item.mGivenPlayerBuff = PlayerBuff::RapidFire;
-        auto animation = Animated{1};
+        auto animation = AnimationLoop{1};
         configureItemContainer(
           entity,
           ContainerColor::White,
@@ -538,7 +538,7 @@ void EntityFactory::configureEntity(
         item.mGivenScore = 500;
         item.mGivenItem = InventoryItemType::CloakingDevice;
         item.mGivenPlayerBuff = PlayerBuff::Cloak;
-        auto animation = Animated{1};
+        auto animation = AnimationLoop{1};
         configureItemContainer(
           entity,
           ContainerColor::White,
@@ -560,7 +560,7 @@ void EntityFactory::configureEntity(
           entity,
           ContainerColor::Red,
           0,
-          Animated{1},
+          AnimationLoop{1},
           boundingBox);
         entity.assign<OverrideDrawOrder>(originalDrawOrder);
       }
@@ -576,7 +576,7 @@ void EntityFactory::configureEntity(
           ContainerColor::Red,
           100,
           item,
-          Animated{1, 0, 5},
+          AnimationLoop{1, 0, 5},
           boundingBox);
       }
       break;
@@ -683,7 +683,7 @@ void EntityFactory::configureEntity(
           ContainerColor::Blue,
           0,
           item,
-          Animated{1},
+          AnimationLoop{1},
           boundingBox);
       }
       break;
@@ -903,14 +903,14 @@ void EntityFactory::configureEntity(
 
     case 50: // teleporter
     case 51: // teleporter
-      entity.assign<Animated>(1);
+      entity.assign<AnimationLoop>(1);
       entity.assign<Interactable>(InteractableType::Teleporter);
       entity.assign<BoundingBox>(BoundingBox{{2, 0}, {2, 5}});
       break;
 
     case 239: // Special hint globe
       entity.assign<Shootable>(3, 100);
-      entity.assign<Animated>(1);
+      entity.assign<AnimationLoop>(1);
       addDefaultPhysical(entity, boundingBox);
       {
         CollectableItem item;
@@ -950,7 +950,7 @@ void EntityFactory::configureEntity(
       // Not player damaging, only the bombs are
       entity.assign<Shootable>(6 + difficultyOffset, 5000);
       entity.assign<BoundingBox>(boundingBox);
-      entity.assign<Animated>(1, 1, 2);
+      entity.assign<AnimationLoop>(1, 1, 2);
       break;
 
     case 64: // Bouncing spike ball
@@ -998,7 +998,7 @@ void EntityFactory::configureEntity(
       break;
 
     case 115: // hover bot generator
-      entity.assign<Animated>(1, 0, 3);
+      entity.assign<AnimationLoop>(1, 0, 3);
       entity.assign<Shootable>(20, 2500);
       entity.assign<BoundingBox>(boundingBox);
       entity.assign<ai::components::HoverBotSpawnMachine>();
@@ -1094,7 +1094,7 @@ void EntityFactory::configureEntity(
           14,
           200,
           PlayerDamaging{1},
-          Animated{1},
+          AnimationLoop{1},
           AutoDestroy::afterTimeout(numAnimationFrames),
           boundingBox);
       }
@@ -1104,7 +1104,7 @@ void EntityFactory::configureEntity(
       entity.assign<Shootable>(10, 20000);
       entity.assign<PlayerDamaging>(9, true);
       entity.assign<BoundingBox>(boundingBox);
-      entity.assign<Animated>(1);
+      entity.assign<AnimationLoop>(1);
       break;
 
     case 93: // Blue force field (disabled by cloak)
@@ -1135,11 +1135,11 @@ void EntityFactory::configureEntity(
     case 263: // Fire (variant 2)
       entity.assign<PlayerDamaging>(1);
       entity.assign<BoundingBox>(boundingBox);
-      entity.assign<Animated>(1);
+      entity.assign<AnimationLoop>(1);
       break;
 
     case 117: // Pipe dripping green stuff
-      entity.assign<Animated>(1);
+      entity.assign<AnimationLoop>(1);
       entity.assign<DrawTopMost>();
       entity.assign<BoundingBox>(boundingBox);
       entity.assign<ai::components::SlimePipe>();
@@ -1149,19 +1149,19 @@ void EntityFactory::configureEntity(
     case 252: // floating exit sign to left
       entity.assign<Shootable>(5, 10000);
       entity.assign<BoundingBox>(boundingBox);
-      entity.assign<Animated>(1);
+      entity.assign<AnimationLoop>(1);
       break;
 
     case 296: // floating arrow
       entity.assign<Shootable>(5, 500);
       entity.assign<BoundingBox>(boundingBox);
-      entity.assign<Animated>(1);
+      entity.assign<AnimationLoop>(1);
       break;
 
     case 236: // Radar dish
       entity.assign<Shootable>(4, 2000);
       entity.assign<BoundingBox>(boundingBox);
-      entity.assign<Animated>(1);
+      entity.assign<AnimationLoop>(1);
       break;
 
     case 188: // rotating floor spikes
@@ -1175,7 +1175,7 @@ void EntityFactory::configureEntity(
     case 230: // Water surface splash right
     case 257: // Shallow water (variant 1)
     case 258: // Shallow water (variant 2)
-      entity.assign<Animated>(1);
+      entity.assign<AnimationLoop>(1);
       break;
 
     // Flying message ships
@@ -1205,14 +1205,14 @@ void EntityFactory::configureEntity(
       break;
 
     case 231: // Lava riser
-      entity.assign<Animated>(1, 3, 5);
+      entity.assign<AnimationLoop>(1, 3, 5);
       break;
 
     case 246: // Rocket exhaust flame left
     case 247: // Rocket exhaust flame right
     case 248: // Small rocket exhaust flame left
     case 249: // Small rocket exhaust flame right
-      entity.assign<Animated>(2);
+      entity.assign<AnimationLoop>(2);
       break;
 
     case 139: // level exit

--- a/src/game_logic/entity_configuration.ipp
+++ b/src/game_logic/entity_configuration.ipp
@@ -375,7 +375,7 @@ void EntityFactory::configureItemContainer(
   const int givenScore,
   Args&&... components
 ) {
-  auto physicalProperties = Physical{{0.0f, 0.0f}, true};
+  auto physicalProperties = MovingBody{{0.0f, 0.0f}, true};
   auto activation = ActivationSettings{
     ActivationSettings::Policy::AlwaysAfterFirstActivation};
 
@@ -400,7 +400,7 @@ void EntityFactory::configureItemContainer(
   entity.assign<Sprite>(containerSprite);
   entity.assign<components::ItemContainer>(container);
   entity.assign<Shootable>(1, givenScore);
-  addDefaultPhysical(entity, engine::inferBoundingBox(containerSprite));
+  addDefaultMovingBody(entity, engine::inferBoundingBox(containerSprite));
 }
 
 
@@ -418,7 +418,7 @@ void EntityFactory::configureEntity(
     case 45:
       entity.assign<AnimationLoop>(1, 0, 3, 0);
       entity.assign<Shootable>(1, 100);
-      addDefaultPhysical(entity, boundingBox);
+      addDefaultMovingBody(entity, boundingBox);
       {
         CollectableItem item;
         item.mGivenScore = 500;
@@ -429,7 +429,7 @@ void EntityFactory::configureEntity(
     case 46:
       entity.assign<AnimationLoop>(1, 0, 3, 0);
       entity.assign<Shootable>(1, 100);
-      addDefaultPhysical(entity, boundingBox);
+      addDefaultMovingBody(entity, boundingBox);
       {
         CollectableItem item;
         item.mGivenScore = 1000;
@@ -440,7 +440,7 @@ void EntityFactory::configureEntity(
     case 47:
       entity.assign<AnimationLoop>(1, 0, 3, 0);
       entity.assign<Shootable>(1, 100);
-      addDefaultPhysical(entity, boundingBox);
+      addDefaultMovingBody(entity, boundingBox);
       {
         CollectableItem item;
         item.mGivenScore = 5000;
@@ -451,7 +451,7 @@ void EntityFactory::configureEntity(
     case 48:
       entity.assign<AnimationLoop>(1, 0, 3, 0);
       entity.assign<Shootable>(1, 100);
-      addDefaultPhysical(entity, boundingBox);
+      addDefaultMovingBody(entity, boundingBox);
       {
         CollectableItem item;
         item.mGivenScore = 1000;
@@ -481,7 +481,7 @@ void EntityFactory::configureEntity(
     case 164: // Empty blue box
     case 161: // Empty white box
       entity.assign<Shootable>(1, 100);
-      addDefaultPhysical(entity, boundingBox);
+      addDefaultMovingBody(entity, boundingBox);
       break;
 
     // ----------------------------------------------------------------------
@@ -911,7 +911,7 @@ void EntityFactory::configureEntity(
     case 239: // Special hint globe
       entity.assign<Shootable>(3, 100);
       entity.assign<AnimationLoop>(1);
-      addDefaultPhysical(entity, boundingBox);
+      addDefaultMovingBody(entity, boundingBox);
       {
         CollectableItem item;
         item.mGivenScore = 10000;
@@ -927,7 +927,7 @@ void EntityFactory::configureEntity(
 
     case 0: // Cylindrical robot with blinking 'head', aka hover-bot
       entity.assign<Shootable>(1 + difficultyOffset, 150);
-      addDefaultPhysical(entity, boundingBox);
+      addDefaultMovingBody(entity, boundingBox);
       entity.component<Sprite>()->mShow = false;
       entity.assign<ai::components::HoverBot>();
       break;
@@ -963,8 +963,8 @@ void EntityFactory::configureEntity(
       entity.assign<Shootable>(6 + difficultyOffset, 1500);
       entity.assign<PlayerDamaging>(1);
       entity.assign<ai::components::SlimeBlob>();
-      addDefaultPhysical(entity, boundingBox);
-      entity.component<Physical>()->mGravityAffected = false;
+      addDefaultMovingBody(entity, boundingBox);
+      entity.component<MovingBody>()->mGravityAffected = false;
       break;
 
     case 68: // Green slime container
@@ -1008,7 +1008,7 @@ void EntityFactory::configureEntity(
       entity.assign<Shootable>(2 + difficultyOffset, 100);
       entity.assign<PlayerDamaging>(1);
       entity.assign<ai::components::Skeleton>();
-      addDefaultPhysical(entity, boundingBox);
+      addDefaultMovingBody(entity, boundingBox);
       break;
 
     case 151: // Floating ball, opens up and shoots lasers

--- a/src/game_logic/entity_configuration.ipp
+++ b/src/game_logic/entity_configuration.ipp
@@ -245,7 +245,7 @@ void configureSprite(Sprite& sprite, const ActorID actorID) {
       break;
 
     case 62:
-      sprite.mFramesToRender = {1, 0};
+      sprite.mFramesToRender = {0, 1};
       break;
 
     case 67:
@@ -950,7 +950,7 @@ void EntityFactory::configureEntity(
       // Not player damaging, only the bombs are
       entity.assign<Shootable>(6 + difficultyOffset, 5000);
       entity.assign<BoundingBox>(boundingBox);
-      entity.assign<AnimationLoop>(1, 1, 2);
+      entity.assign<AnimationLoop>(1, 1, 2, 1);
       break;
 
     case 64: // Bouncing spike ball

--- a/src/game_logic/entity_factory.cpp
+++ b/src/game_logic/entity_factory.cpp
@@ -68,11 +68,11 @@ using namespace game_logic::components;
 namespace {
 
 // Assign gravity affected physical component
-void addDefaultPhysical(
+void addDefaultMovingBody(
   ex::Entity entity,
   const BoundingBox& boundingBox
 ) {
-  entity.assign<Physical>(Physical{{0.0f, 0.0f}, true});
+  entity.assign<MovingBody>(MovingBody{{0.0f, 0.0f}, true});
   entity.assign<BoundingBox>(boundingBox);
   entity.assign<ActivationSettings>(
     ActivationSettings::Policy::AlwaysAfterFirstActivation);
@@ -241,8 +241,8 @@ void EntityFactory::configureProjectile(
   const auto speed = speedForProjectileType(type);
   const auto damageAmount = damageForProjectileType(type);
   entity.assign<WorldPosition>(position);
-  entity.assign<Physical>(
-    Physical{directionToVector(direction) * speed, false});
+  entity.assign<MovingBody>(
+    MovingBody{directionToVector(direction) * speed, false});
   if (isPlayerProjectile(type)) {
     entity.assign<DamageInflicting>(damageAmount);
   } else {

--- a/src/game_logic/interaction/elevator.hpp
+++ b/src/game_logic/interaction/elevator.hpp
@@ -24,7 +24,7 @@ RIGEL_DISABLE_WARNINGS
 RIGEL_RESTORE_WARNINGS
 
 namespace rigel { struct IGameServiceProvider; }
-namespace rigel { namespace engine { namespace components { struct Physical; }}}
+namespace rigel { namespace engine { namespace components { struct MovingBody; }}}
 namespace rigel { namespace game_logic { namespace components {
   struct PlayerControlled;
 }}}
@@ -61,7 +61,7 @@ private:
 
   void updateElevatorMovement(
     int movement,
-   engine::components::Physical& playerPhysical);
+    engine::components::MovingBody& playerMovingBody);
 
 private:
   entityx::Entity mPlayer;

--- a/src/game_logic/interaction/force_field.cpp
+++ b/src/game_logic/interaction/force_field.cpp
@@ -31,7 +31,7 @@ using namespace engine::components;
 using namespace game_logic::components;
 
 void configureForceField(entityx::Entity entity) {
-  entity.assign<Animated>(1, 2, 4, 2);
+  entity.assign<AnimationLoop>(1, 2, 4, 2);
   entity.assign<PlayerDamaging>(9, true);
   entity.assign<BoundingBox>(BoundingBox{{0, -4}, {2, 10}});
   entity.assign<CircuitCardForceField>();
@@ -48,7 +48,7 @@ void configureKeyCardSlot(
   const BoundingBox& boundingBox
 ) {
   entity.assign<Interactable>(InteractableType::ForceFieldCardReader);
-  entity.assign<Animated>(1);
+  entity.assign<AnimationLoop>(1);
   entity.assign<BoundingBox>(boundingBox);
 }
 
@@ -67,7 +67,7 @@ bool disableForceField(
     // TODO: Only turn off force fields that are visible on screen
     es.each<CircuitCardForceField>(
       [](ex::Entity entity, const CircuitCardForceField&) {
-        entity.remove<Animated>();
+        entity.remove<AnimationLoop>();
         entity.remove<BoundingBox>();
         entity.remove<CircuitCardForceField>();
         entity.remove<PlayerDamaging>();
@@ -78,7 +78,7 @@ bool disableForceField(
       });
 
     keyCardSlot.remove<Interactable>();
-    keyCardSlot.remove<Animated>();
+    keyCardSlot.remove<AnimationLoop>();
     keyCardSlot.remove<BoundingBox>();
   }
 

--- a/src/game_logic/player/animation_system.cpp
+++ b/src/game_logic/player/animation_system.cpp
@@ -261,7 +261,7 @@ int AnimationSystem::movementAnimationFrame(
       state, playerPosition.y, NUM_LADDER_ANIM_STATES);
   } else if (state.mState == PlayerState::Airborne) {
     const auto verticalVelocity =
-      mPlayer.component<engine::components::Physical>()->mVelocity.y;
+      mPlayer.component<engine::components::MovingBody>()->mVelocity.y;
     if (verticalVelocity != 0.0f) {
       if (verticalVelocity <= 0.0f) {
         newAnimationFrame = 6;

--- a/src/game_logic/player/damage_system.cpp
+++ b/src/game_logic/player/damage_system.cpp
@@ -53,7 +53,7 @@ int mercyFramesForDifficulty(const data::Difficulty difficulty) {
 
 
 using engine::components::BoundingBox;
-using engine::components::Physical;
+using engine::components::MovingBody;
 using engine::components::WorldPosition;
 using engine::toWorldSpace;
 using game_logic::components::PlayerControlled;
@@ -84,7 +84,7 @@ void DamageSystem::update(
   }
 
   assert(mPlayer.has_component<BoundingBox>());
-  assert(mPlayer.has_component<Physical>());
+  assert(mPlayer.has_component<MovingBody>());
   assert(mPlayer.has_component<PlayerControlled>());
   assert(mPlayer.has_component<WorldPosition>());
 
@@ -113,8 +113,8 @@ void DamageSystem::update(
           playerState.mMercyFramesRemaining = mNumMercyFrames;
           mpServiceProvider->playSound(data::SoundId::DukePain);
         } else {
-          auto& physical = *mPlayer.component<Physical>();
-          physical.mVelocity = {0.0f, DEATH_JUMP_IMPULSE};
+          auto& body = *mPlayer.component<MovingBody>();
+          body.mVelocity = {0.0f, DEATH_JUMP_IMPULSE};
 
           playerState.mState = PlayerState::Dieing;
           mpServiceProvider->playSound(data::SoundId::DukeDeath);

--- a/src/game_logic/player_interaction_system.cpp
+++ b/src/game_logic/player_interaction_system.cpp
@@ -30,7 +30,7 @@
 namespace rigel { namespace game_logic {
 
 using data::PlayerModel;
-using engine::components::Animated;
+using engine::components::AnimationLoop;
 using engine::components::BoundingBox;
 using engine::components::Sprite;
 using engine::components::WorldPosition;

--- a/src/ingame_mode.cpp
+++ b/src/ingame_mode.cpp
@@ -271,6 +271,10 @@ void IngameMode::handleEvent(const SDL_Event& event) {
       mShowDebugText = !mShowDebugText;
       break;
 
+    case SDLK_g:
+      debuggingSystem.toggleGridDisplay();
+      break;
+
     case SDLK_s:
       mSingleStepping = !mSingleStepping;
       break;

--- a/src/ingame_mode.cpp
+++ b/src/ingame_mode.cpp
@@ -65,7 +65,7 @@ using namespace std;
 
 using data::PlayerModel;
 using engine::components::BoundingBox;
-using engine::components::Physical;
+using engine::components::MovingBody;
 using engine::components::WorldPosition;
 
 
@@ -591,7 +591,7 @@ void IngameMode::handleTeleporter() {
 
 void IngameMode::showDebugText() {
   const auto& playerPos = *mPlayerEntity.component<WorldPosition>();
-  const auto& playerVel = mPlayerEntity.component<Physical>()->mVelocity;
+  const auto& playerVel = mPlayerEntity.component<MovingBody>()->mVelocity;
   std::stringstream infoText;
   infoText
     << "Scroll: " << vec2String(mScrollOffset, 4) << '\n'

--- a/src/ingame_mode.hpp
+++ b/src/ingame_mode.hpp
@@ -87,6 +87,8 @@ private:
   engine::TimeDelta mAccumulatedTime;
 
   bool mShowDebugText;
+  bool mSingleStepping = false;
+  bool mCanAdvanceSingleStep = false;
 
   struct LevelData {
     data::map::Map mMap;

--- a/test/test_elevator.cpp
+++ b/test/test_elevator.cpp
@@ -75,8 +75,8 @@ TEST_CASE("Rocket elevator") {
     CHECK(elevator.has_component<SolidBody>());
     CHECK(elevator.has_component<BoundingBox>());
 
-    REQUIRE(elevator.has_component<Physical>());
-    CHECK(elevator.component<Physical>()->mGravityAffected == true);
+    REQUIRE(elevator.has_component<MovingBody>());
+    CHECK(elevator.component<MovingBody>()->mGravityAffected == true);
   }
 
   auto& elevatorPosition = *elevator.component<WorldPosition>();
@@ -199,14 +199,14 @@ TEST_CASE("Rocket elevator") {
       const auto originalPos = playerPosition;
       const auto originalElevatorPos = elevatorPosition;
 
-      player.component<Physical>()->mVelocity.y = -3.6f;
-      player.component<Physical>()->mGravityAffected = true;
+      player.component<MovingBody>()->mVelocity.y = -3.6f;
+      player.component<MovingBody>()->mGravityAffected = true;
       player.component<PlayerControlled>()->mPerformedJump = true;
       runOneFrame(idleState);
 
       CHECK(!elevatorSystem.isPlayerAttached());
       CHECK(playerPosition.y < originalPos.y);
-      CHECK(elevator.component<Physical>()->mVelocity.y == 2.0f);
+      CHECK(elevator.component<MovingBody>()->mVelocity.y == 2.0f);
       CHECK(elevatorPosition.y > originalElevatorPos.y);
       CHECK(elevator.has_component<SolidBody>());
     }
@@ -225,7 +225,7 @@ TEST_CASE("Rocket elevator") {
       runOneFrame(idleState);
 
       CHECK(!elevatorSystem.isPlayerAttached());
-      CHECK(player.component<Physical>()->mGravityAffected);
+      CHECK(player.component<MovingBody>()->mGravityAffected);
       CHECK(playerPosition.y >= originalPlayerY);
       CHECK(elevatorPosition.y > originalElevatorY);
       CHECK(elevator.has_component<SolidBody>());


### PR DESCRIPTION
Adds:

* `ArrayView`
* animation sequences (animations that can't be expressed with a contiguous range of values)
* `Active` entities can now check if they are on screen
* Grid overlay for debugging
* Frame single-stepping for debugging

Also fixes a bug that was introduced by defa3fd20a4309cc03369dbe688a63f897844708: Messenger drones didn't have the right bounding box, because the synchronization would synchronize to the secondary "flame" animation, thus overriding the whole entitiy's bounding box.

From now on, only animations that work in render slot `0` are synchronized.