### PR TITLE
More accurate game speed

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,7 +61,6 @@ set(core_sources
     engine/texture.hpp
     engine/tile_renderer.cpp
     engine/tile_renderer.hpp
-    engine/timing.cpp
     engine/timing.hpp
     engine/visual_components.hpp
     game_logic/ai/blue_guard.cpp

--- a/src/engine/rendering_system.cpp
+++ b/src/engine/rendering_system.cpp
@@ -109,6 +109,10 @@ void updateAnimatedSprites(ex::EntityManager& es) {
       engine::synchronizeBoundingBoxToSprite(entity);
     }
   });
+
+  es.each<Sprite>([](ex::Entity entity, Sprite& sprite) {
+     sprite.mFlashingWhite = false;
+  });
 }
 
 
@@ -211,14 +215,7 @@ void RenderingSystem::renderSprite(const SpriteData& data) const {
       assert(frameIndex < int(sprite.mpDrawData->mFrames.size()));
 
       // White flash effect
-      const auto maxFlashWhiteTime = engine::gameFramesToTime(1);
-      const auto elapsedFlashWhiteTime =
-        engine::currentGlobalTime() - sprite.mFlashWhiteTime;
-      const auto flashWhite =
-        sprite.mFlashWhiteTime != 0.0 &&
-        elapsedFlashWhiteTime <= maxFlashWhiteTime;
-
-      if (flashWhite) {
+      if (sprite.mFlashingWhite) {
         mpRenderer->setOverlayColor(base::Color(255, 255, 255, 255));
       }
 

--- a/src/engine/timing.cpp
+++ b/src/engine/timing.cpp
@@ -23,15 +23,11 @@ static_assert(fastTicksToTime(280) == 1.0, "");
 static_assert(fastTicksToTime(280 * 2) == 2.0, "");
 static_assert(slowTicksToTime(140) == 1.0, "");
 static_assert(slowTicksToTime(70) == 0.5, "");
-static_assert(gameFramesToTime(70) == 4.0, "");
-static_assert(gameFramesToTime(35) == 2.0, "");
 
 constexpr auto EPSILON = 0.0000001;
 static_assert(timeToFastTicks(4.0) - 280.0*4 < EPSILON, "");
 static_assert(timeToFastTicks(1.0) - 280.0 < EPSILON, "");
 static_assert(timeToSlowTicks(2.0) - 140.0*2 < EPSILON, "");
 static_assert(timeToSlowTicks(1.0) - 140.0 < EPSILON, "");
-static_assert(timeToGameFrames(4.0) - 70.0 < EPSILON, "");
-static_assert(timeToGameFrames(1.0) - 17.5 < EPSILON, "");
 
 }}

--- a/src/engine/timing.cpp
+++ b/src/engine/timing.cpp
@@ -16,28 +16,8 @@
 
 #include "timing.hpp"
 
-#include <chrono>
-
 
 namespace rigel { namespace engine {
-
-namespace {
-
-std::chrono::high_resolution_clock::time_point globalTimeStart;
-
-}
-
-
-void initGlobalTimer() {
-  globalTimeStart = std::chrono::high_resolution_clock::now();
-}
-
-
-TimePoint currentGlobalTime() {
-  const auto now = std::chrono::high_resolution_clock::now();
-  return std::chrono::duration<double>(now - globalTimeStart).count();
-}
-
 
 static_assert(fastTicksToTime(280) == 1.0, "");
 static_assert(fastTicksToTime(280 * 2) == 2.0, "");

--- a/src/engine/timing.hpp
+++ b/src/engine/timing.hpp
@@ -76,8 +76,4 @@ constexpr double timeToGameFrames(const TimeDelta time) {
 }
 
 
-void initGlobalTimer();
-
-TimePoint currentGlobalTime();
-
 }}

--- a/src/engine/timing.hpp
+++ b/src/engine/timing.hpp
@@ -37,7 +37,6 @@ namespace detail {
 
 constexpr auto FAST_TICK_RATE = 280.0;
 constexpr auto SLOW_TICK_RATE = FAST_TICK_RATE / 2.0;
-constexpr auto GAME_FRAME_RATE = FAST_TICK_RATE / 16.0;
 
 }
 
@@ -63,16 +62,6 @@ constexpr TimeDelta fastTicksToTime(const int ticks) {
 
 constexpr double timeToFastTicks(const TimeDelta time) {
   return time * detail::FAST_TICK_RATE;
-}
-
-
-constexpr TimeDelta gameFramesToTime(const int frames) {
-  return frames / detail::GAME_FRAME_RATE;
-}
-
-
-constexpr double timeToGameFrames(const TimeDelta time) {
-  return time * detail::GAME_FRAME_RATE;
 }
 
 

--- a/src/engine/visual_components.hpp
+++ b/src/engine/visual_components.hpp
@@ -67,12 +67,12 @@ struct Sprite {
   }
 
   void flashWhite() {
-    mFlashWhiteTime = currentGlobalTime();
+    mFlashingWhite = true;
   }
 
   std::vector<int> mFramesToRender;
-  engine::TimePoint mFlashWhiteTime = 0.0;
   const SpriteDrawData* mpDrawData = nullptr;
+  bool mFlashingWhite = false;
   bool mShow = true;
 };
 

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -80,8 +80,6 @@ void Game::run(const GameOptions& options) {
   mRenderer.clear();
   mRenderer.swapBuffers();
 
-  engine::initGlobalTimer();
-
   data::forEachSoundId([this](const auto id) {
     mSoundsById.emplace_back(mSoundSystem.addSound(mResources.loadSound(id)));
   });

--- a/src/game_runner.cpp
+++ b/src/game_runner.cpp
@@ -202,7 +202,7 @@ void GameRunner::handleEvent(const SDL_Event& event) {
 
     case SDLK_SPACE:
       if (mSingleStepping) {
-        mCanAdvanceSingleStep = true;
+        mDoNextSingleStep = true;
       }
       break;
   }
@@ -236,9 +236,9 @@ void GameRunner::updateAndRender(engine::TimeDelta dt) {
 
   constexpr auto timeForOneFrame = engine::gameFramesToTime(1);
   if (mSingleStepping) {
-    if (mCanAdvanceSingleStep) {
+    if (mDoNextSingleStep) {
       doTimeStep();
-      mCanAdvanceSingleStep = false;
+      mDoNextSingleStep = false;
     }
   } else {
     mAccumulatedTime += dt;

--- a/src/game_runner.cpp
+++ b/src/game_runner.cpp
@@ -45,6 +45,17 @@ using engine::components::WorldPosition;
 
 namespace {
 
+// Update game logic at 15 FPS. This is not exactly the speed at which the
+// game runs on period-appropriate hardware, but it's very close, and it nicely
+// fits into 60 FPS, giving us 4 render frames for 1 logic update.
+//
+// On a 486 with a fast graphics card, the game runs at roughly 15.5 FPS, with
+// a slower (non-VLB) graphics card, it's roughly 14 FPS. On a fast 386 (40 MHz),
+// it's roughly 13 FPS. With 15 FPS, the feel should therefore be very close to
+// playing the game on a 486 at the default game speed setting.
+constexpr auto GAME_LOGIC_UPDATE_DELAY = 1.0/15.0;
+
+
 char EPISODE_PREFIXES[] = {'L', 'M', 'N', 'O'};
 
 std::string levelFileName(const int episode, const int level) {
@@ -234,7 +245,6 @@ void GameRunner::updateAndRender(engine::TimeDelta dt) {
     }
   };
 
-  constexpr auto timeForOneFrame = engine::gameFramesToTime(1);
   if (mSingleStepping) {
     if (mDoNextSingleStep) {
       doTimeStep();
@@ -243,8 +253,8 @@ void GameRunner::updateAndRender(engine::TimeDelta dt) {
   } else {
     mAccumulatedTime += dt;
     for (;
-      mAccumulatedTime >= timeForOneFrame;
-      mAccumulatedTime -= timeForOneFrame
+      mAccumulatedTime >= GAME_LOGIC_UPDATE_DELAY;
+      mAccumulatedTime -= GAME_LOGIC_UPDATE_DELAY
     ) {
       doTimeStep();
     }

--- a/src/game_runner.hpp
+++ b/src/game_runner.hpp
@@ -96,7 +96,7 @@ private:
 
   bool mShowDebugText;
   bool mSingleStepping = false;
-  bool mCanAdvanceSingleStep = false;
+  bool mDoNextSingleStep = false;
 
   struct LevelData {
     data::map::Map mMap;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(test_sources
     test_player_animation_system.cpp
     test_player_attack_system.cpp
     test_spike_ball.cpp
+    test_timing.cpp
 )
 
 

--- a/test/test_timing.cpp
+++ b/test/test_timing.cpp
@@ -14,10 +14,10 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "timing.hpp"
+#include <engine/timing.hpp>
 
 
-namespace rigel { namespace engine {
+using namespace rigel::engine;
 
 static_assert(fastTicksToTime(280) == 1.0, "");
 static_assert(fastTicksToTime(280 * 2) == 2.0, "");
@@ -29,5 +29,3 @@ static_assert(timeToFastTicks(4.0) - 280.0*4 < EPSILON, "");
 static_assert(timeToFastTicks(1.0) - 280.0 < EPSILON, "");
 static_assert(timeToSlowTicks(2.0) - 140.0*2 < EPSILON, "");
 static_assert(timeToSlowTicks(1.0) - 140.0 < EPSILON, "");
-
-}}


### PR DESCRIPTION
Make the game run roughly as fast as if playing the original on a 486 PC: At 15 FPS. Before, it was running at 17.5, which is the theoretical maximum speed the original game could run at when set to the default game speed, and updating/rendering would take 0 time. That's not the case on a period-appropriate system, and measurements have shown that the game runs at roughly 14 to 15.5 FPS on 486-class machines.

While 15 FPS doesn't exactly match the speed on real hardware, it's much closer than before, and also has the added benefit of nicely fitting into the rendering frame rate of 60 FPS RigelEngine usually runs at.