### PR TITLE
Fix: Re-enable cooked turkey animation

### DIFF
--- a/src/game_logic/entity_configuration.ipp
+++ b/src/game_logic/entity_configuration.ipp
@@ -850,7 +850,8 @@ void EntityFactory::configureEntity(
         // the cooked turkey.
         auto cookedTurkeyContainer = makeContainer(
           cookedTurkeyCollectable,
-          cookedTurkeySprite);
+          cookedTurkeySprite,
+          AnimationLoop{1, 4, 7});
         addDefaultMovingBody(cookedTurkeyContainer, boundingBox);
 
         auto livingTurkeyContainer = makeContainer(


### PR DESCRIPTION
This got accidentally deleted in ff7f1dfc.