### PR TITLE
Prevent jump button presses getting lost

### DIFF
--- a/src/game_logic/player.hpp
+++ b/src/game_logic/player.hpp
@@ -264,6 +264,7 @@ private:
   void updateTemporaryItemExpiration();
   void updateAnimation();
   void updateMovement(const base::Vector& movementVector, const Button& jumpButton);
+  void updateJumpButtonStateTracking(const Button& jumpButton);
   void updateShooting(const Button& fireButton);
   void updateLadderAttachment(const base::Vector& movementVector);
   bool updateElevatorMovement(int movement);
@@ -317,6 +318,7 @@ private:
   bool mIsOddFrame = false;
   bool mRecoilAnimationActive = false;
   bool mIsRidingElevator = false;
+  bool mJumpRequested = false;
 };
 
 }}

--- a/test/test_player.cpp
+++ b/test/test_player.cpp
@@ -243,6 +243,7 @@ TEST_CASE("Player movement") {
   pressingFire.mFire.mIsPressed = true;
 
   PlayerInput jumpButtonTriggered;
+  jumpButtonTriggered.mJump.mIsPressed = true;
   jumpButtonTriggered.mJump.mWasTriggered = true;
 
   PlayerInput fireButtonTriggered;


### PR DESCRIPTION
Sometimes, jump button presses would be ignored, especially noticeable when walking down downward slopes. This fixes it.