### PR TITLE
Fix interaction anim

### DIFF
--- a/src/game_logic/player.cpp
+++ b/src/game_logic/player.cpp
@@ -65,7 +65,6 @@ constexpr auto LADDER_CLIMB_ANIMATION = AnimationConfig{35, 36};
 constexpr auto WALK_ANIMATION = AnimationConfig{1, 4};
 constexpr auto CLIMB_ON_PIPE_ANIMATION = AnimationConfig{21, 24};
 
-constexpr auto INTERACTION_LOCK_DURATION = 8;
 constexpr auto INITIAL_MERCY_FRAMES = 20;
 
 constexpr auto TEMPORARY_ITEM_EXPIRATION_TIME = 700;

--- a/src/game_logic/player.cpp
+++ b/src/game_logic/player.cpp
@@ -810,9 +810,8 @@ void Player::updateMovement(
     [this](Interacting& state) {
       setVisualState(VisualState::Interacting);
 
-      if (state.mFramesElapsed >= state.mDuration) {
+      if (state.mFramesElapsed == state.mDuration - 1) {
         mState = OnGround{};
-        setVisualState(VisualState::Standing);
       } else {
         ++state.mFramesElapsed;
       }

--- a/src/game_logic/player.hpp
+++ b/src/game_logic/player.hpp
@@ -177,6 +177,9 @@ enum class SpiderClingPosition {
 };
 
 
+constexpr auto INTERACTION_LOCK_DURATION = 8;
+
+
 class Player : public entityx::Receiver<Player> {
 public:
   Player(

--- a/test/test_player.cpp
+++ b/test/test_player.cpp
@@ -1250,8 +1250,7 @@ TEST_CASE("Player movement") {
   //
 
   auto finishInteractionAnimation = [&]() {
-    // TODO: Use shared constant here instead of magic number?
-    for (int i = 0; i < 8; ++i) {
+    for (int i = 0; i < INTERACTION_LOCK_DURATION; ++i) {
       player.update({});
     }
 

--- a/test/test_player.cpp
+++ b/test/test_player.cpp
@@ -1316,6 +1316,22 @@ TEST_CASE("Player movement") {
 
       CHECK(position != previousPosition);
     }
+
+    SECTION("Can move immediately after interaction animation finished") {
+      const auto previousPosition = position;
+
+      for (int i = 0; i < INTERACTION_LOCK_DURATION - 1; ++i) {
+        player.update(pressingLeft);
+      }
+
+      CHECK(position == previousPosition);
+      CHECK(animationFrame == 33);
+
+      player.update(pressingLeft);
+
+      CHECK(position != previousPosition);
+      CHECK(animationFrame != 33);
+    }
   }
 
 


### PR DESCRIPTION
In the original, movement is possible immediately after the interaction animation has ended. RigelEngine had one additional frame where the player couldn't move. This fixes it.