### PR TITLE
Add a 3rd party ignore flag for ;;

### DIFF
--- a/src/base/warnings.hpp
+++ b/src/base/warnings.hpp
@@ -57,6 +57,7 @@
     _Pragma("clang diagnostic ignored \"-Wfloat-equal\"") \
     _Pragma("clang diagnostic ignored \"-Wgnu-anonymous-struct\"") \
     _Pragma("clang diagnostic ignored \"-Wnested-anon-types\"") \
+    _Pragma("clang diagnostic ignored \"-Wextra-semi-stmt\"") \
     /**/
 
   #define RIGEL_RESTORE_WARNINGS _Pragma("clang diagnostic pop")


### PR DESCRIPTION
"Fixes" a 3rd party error at 10% and 17%.

```
error: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Werror,-Wextra-semi-stmt]
```