### PR TITLE
Fix building on newer versions of Clang

### DIFF
--- a/src/base/warnings.hpp
+++ b/src/base/warnings.hpp
@@ -57,6 +57,7 @@
     _Pragma("clang diagnostic ignored \"-Wfloat-equal\"") \
     _Pragma("clang diagnostic ignored \"-Wgnu-anonymous-struct\"") \
     _Pragma("clang diagnostic ignored \"-Wnested-anon-types\"") \
+    _Pragma("clang diagnostic ignored \"-Wextra-semi-stmt\"") \
     /**/
 
   #define RIGEL_RESTORE_WARNINGS _Pragma("clang diagnostic pop")

--- a/src/data/movie.hpp
+++ b/src/data/movie.hpp
@@ -24,7 +24,6 @@
 namespace rigel { namespace data {
 
 struct MovieFrame {
-  MovieFrame() = default;
   MovieFrame(Image&& replacementImage, const int startRow)
     : mReplacementImage(std::move(replacementImage))
     , mStartRow(startRow)

--- a/src/game_logic/player.cpp
+++ b/src/game_logic/player.cpp
@@ -188,7 +188,7 @@ data::SoundId soundIdForWeapon(const data::WeaponType weaponType) {
 
     default:
       return SoundId::DukeNormalShot;
-  };
+  }
 }
 
 


### PR DESCRIPTION
Clang 8 introduces a few new warnings which we need to ignore/fix.

Fixes #360  