### PR TITLE
Specify exception handling mode for Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ if(MSVC)
         /MP
         /W4
         /WX
+        /EHsc
         /wd4100 # Unused parameter
         /wd4503 # Decorated name length exceeded
         /wd4800 # Forcing value to bool


### PR DESCRIPTION
This fixes errors/warnings when compiling under Visual Studio 19 version 16.1.1.