### PR TITLE
Make it possible to disable treating warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(main_exe_name RigelEngine)
 ###############################################################################
 
 option(USE_GL_ES "Use OpenGL ES instead of regular OpenGL" OFF)
+option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" ON)
 
 
 # Dependencies
@@ -36,16 +37,18 @@ if(MSVC)
         /permissive-
         /MP
         /W4
-        /WX
         /EHsc
         /wd4100 # Unused parameter
         /wd4503 # Decorated name length exceeded
         /wd4800 # Forcing value to bool
     )
     add_definitions(-D_SCL_SECURE_NO_WARNINGS)
+
+    if (WARNINGS_AS_ERRORS)
+        add_compile_options(/WX)
+    endif()
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(
-        -Werror
         -Weverything
         -Wno-unknown-warning-option
         -Wno-c++98-compat
@@ -63,15 +66,22 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 
         -fcolor-diagnostics
     )
+
+    if (WARNINGS_AS_ERRORS)
+        add_compile_options(-Werror)
+    endif()
 elseif(CMAKE_COMPILER_IS_GNUCXX)
     add_compile_options(
-        -Werror
         -Wall
         -Wextra
         -pedantic
         -Wno-maybe-uninitialized
         -Wno-unused-parameter
     )
+
+    if (WARNINGS_AS_ERRORS)
+        add_compile_options(-Werror)
+    endif()
 else()
     message(FATAL_ERROR "Unrecognized compiler")
 endif()

--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ cd RigelEngine
 git submodule update --init --recursive
 ``` 
 
+### A note about warnings as errors
+
+By default, warnings during compilation are treated as errors. This behavior
+can be changed by passing `-DWARNINGS_AS_ERRORS=OFF` to CMake when configuring.
+If you plan to work on RigelEngine, I'd recommend leaving this on, as you might
+otherwise have your build fail on CI despite it building successfully locally.
+
+On the other hand, if you only want to use RigelEngine, but there are no
+pre-built binaries for your platform, disabling warnings as errors is
+recommended.
+
 ### Linux build quick start guide
 
 If you're on Linux and running a recent enough Ubuntu/Debian-like distro<sup>[1](#foot-note-linux)</sup>,
@@ -104,11 +115,14 @@ sudo apt-get install cmake libboost-all-dev libsdl2-dev libsdl2-mixer-dev
 # Configure and build:
 mkdir build
 cd build
-cmake ..
+cmake .. -DWARNINGS_AS_ERRORS=OFF
 make
 
 # NOTE:  Pass -j<NUM_PROCESSES> to 'make' in order to get multi-core
 # compilation, '8' is a good number for a 4-core machine with hyperthreading
+#
+# If you plan to develop RigelEngine, I recommend dropping the
+# -DWARNINGS_AS_ERRORS part - see the note about warnings as errors above.
 
 # Now run it!
 ./src/RigelEngine <PATH_TO_YOUR_GAME_FILES>
@@ -166,7 +180,7 @@ unset rigel_llvm_path;
 # Now, the regular build via CMake should work:
 mkdir build
 cd build
-cmake ..
+cmake .. -DWARNINGS_AS_ERRORS=OFF
 make
 ```
 


### PR DESCRIPTION
Based on the discussion in https://github.com/lethal-guitar/RigelEngine/issues/360, make it possible to build RigelEngine without treating warnigns as errors. This is to make life easier for those who would like to use RigelEngine, but have no pre-built binaries available for their platform, and who aren't interested in developing.