### PR TITLE
Numpad Enter support within the game menus

### DIFF
--- a/src/game_runner.cpp
+++ b/src/game_runner.cpp
@@ -104,6 +104,7 @@ void GameRunner::handleEvent(const SDL_Event& event) {
           return;
 
         case SDLK_RETURN:
+        case SDLK_KP_ENTER:
           saveGame(state.mSlotIndex, state.mTextEntryWidget.text());
           leaveTextEntry();
           return;

--- a/src/game_session_mode.cpp
+++ b/src/game_session_mode.cpp
@@ -81,6 +81,7 @@ void GameSessionMode::handleEvent(const SDL_Event& event) {
             enterHighScore("");
             return;
 
+          case SDLK_KP_ENTER:
           case SDLK_RETURN:
             enterHighScore(state.mNameEntryWidget.text());
             return;

--- a/src/ui/duke_script_runner.cpp
+++ b/src/ui/duke_script_runner.cpp
@@ -193,6 +193,7 @@ void DukeScriptRunner::handleEvent(const SDL_Event& event) {
 
       case SDLK_RETURN:
       case SDLK_SPACE:
+      case SDLK_KP_ENTER:
         if (mPagerState->mMode == PagingMode::Menu) {
           selectCurrentMenuItem(state);
         } else {


### PR DESCRIPTION
Currently one cannot navigate using num pad Enter on menus and in-game. This pull request adds that support.  
 (I don't know why whitespaces are being shown up in PR and git doesn't allow to re-edit. I use spaces for indentation)