### PR TITLE
Implement correct move-semantics for Renderer::StateSaver

### DIFF
--- a/src/renderer/renderer.hpp
+++ b/src/renderer/renderer.hpp
@@ -93,17 +93,38 @@ public:
     {
     }
 
+    StateSaver(StateSaver&& other) noexcept
+      : mpRenderer(other.mpRenderer)
+      , mClipRect(other.mClipRect)
+      , mGlobalTranslation(other.mGlobalTranslation)
+      , mGlobalScale(other.mGlobalScale)
+      , mRenderTarget(other.mRenderTarget)
+    {
+      // Mark the moved-from object as such (see ~StateSaver)
+      other.mpRenderer = nullptr;
+    }
+
+    StateSaver& operator=(StateSaver&& other) noexcept {
+      if (&other != this) {
+        *this = std::move(other);
+      }
+
+      return *this;
+    }
+
     ~StateSaver() {
-      mpRenderer->setRenderTarget(mRenderTarget);
-      mpRenderer->setClipRect(mClipRect);
-      mpRenderer->setGlobalTranslation(mGlobalTranslation);
-      mpRenderer->setGlobalScale(mGlobalScale);
+      // A nullptr renderer indicates a moved-from state, where we shouldn't
+      // reset anything
+      if (mpRenderer) {
+        mpRenderer->setRenderTarget(mRenderTarget);
+        mpRenderer->setClipRect(mClipRect);
+        mpRenderer->setGlobalTranslation(mGlobalTranslation);
+        mpRenderer->setGlobalScale(mGlobalScale);
+      }
     }
 
     StateSaver(const StateSaver&) = delete;
     StateSaver& operator=(const StateSaver&) = delete;
-    StateSaver(StateSaver&&) = default;
-    StateSaver& operator=(StateSaver&&) = default;
 
   private:
     Renderer* mpRenderer;


### PR DESCRIPTION
Without this, functions constructing a StateSaver and returning it have to rely on copy elision in order to work properly, but that's not guaranteed to happen on all compilers in all situations.

Most likely, this is responsible for the up-scaling not working for you @pratikone  Let me know if this fixes it! And sorry about the trouble, not sure why I didn't run into this, but it's clearly an oversight on my part.