### PR TITLE
16:9 widescreen now works with this code

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,16 +6,19 @@ branches:
     only:
         - master
 
-cache:
-    - c:\tools\vcpkg\installed\
-
 environment:
     BOOST_ROOT: C:\Libraries\boost_1_67_0
     BOOST_LIBRARYDIR: C:\Libraries\boost_1_67_0\lib64-msvc-14.1
 
 install:
     - git submodule update --init --recursive
-    - vcpkg install sdl2:x64-windows sdl2-mixer:x64-windows
+
+      # Download headers and pre-built binaries for SDL2 and SDL2_mixer
+    - mkdir C:\RigelLibs
+    - ps: Invoke-WebRequest -Uri https://www.libsdl.org/release/SDL2-devel-2.0.4-VC.zip -OutFile C:\RigelLibs\SDL2.zip
+    - ps: Invoke-WebRequest -Uri https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.1-VC.zip -OutFile C:\RigelLibs\SDL2_mixer.zip
+    - 7z x C:\RigelLibs\SDL2.zip -oC:\RigelLibs
+    - 7z x C:\RigelLibs\SDL2_mixer.zip -oC:\RigelLibs
 
 platform: x64
 
@@ -24,9 +27,12 @@ configuration:
     - Release
 
 before_build:
+    - set SDL2DIR=C:\RigelLibs\SDL2-2.0.4
+    - set SDL2MIXERDIR=C:\RigelLibs\SDL2_mixer-2.0.1
+
     - mkdir build
     - cd build
-    - cmake .. -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -G "Visual Studio 15 2017 Win64"
+    - cmake .. -G "Visual Studio 15 2017 Win64"
     - cd ..
 
 build:
@@ -34,12 +40,16 @@ build:
     project: build/RigelEngine.sln
     verbosity: minimal
 
+before_test:
+    - set PATH=%PATH%;%SDL2DIR%\lib\x64;%SDL2MIXERDIR%\lib\x64
+
 test_script:
     - cd build
     - ctest
 
 after_build:
-  - 7z a rigel_build.zip C:\projects\rigelengine\build\src\%CONFIGURATION%\RigelEngine.exe C:\projects\rigelengine\build\src\%CONFIGURATION%\SDL*.dll %BOOST_LIBRARYDIR%\boost_program_options-vc141-mt%BOOST_DBG_MARKER%-x64-1_67.dll
+  - IF "%CONFIGURATION%" == "Debug" set BOOST_DBG_MARKER=-gd
+  - 7z a rigel_build.zip C:\projects\rigelengine\build\src\%CONFIGURATION%\RigelEngine.exe %SDL2DIR%\lib\x64\SDL2.dll %SDL2MIXERDIR%\lib\x64\SDL2_mixer.dll %BOOST_LIBRARYDIR%\boost_program_options-vc141-mt%BOOST_DBG_MARKER%-x64-1_67.dll
 
 artifacts:
     - path: rigel_build.zip

--- a/src/base/spatial_types.hpp
+++ b/src/base/spatial_types.hpp
@@ -196,6 +196,52 @@ Point<ValueT>& operator-=(Point<ValueT>& lhs, const Point<ValueT>& rhs) {
 
 
 template<typename ValueT>
+Size<ValueT> operator+(
+  const Size<ValueT>& lhs,
+  const Size<ValueT>& rhs
+) {
+  return Size<ValueT>(lhs.width + rhs.width, lhs.height + rhs.height);
+}
+
+
+template<typename ValueT>
+Size<ValueT> operator-(
+  const Size<ValueT>& lhs,
+  const Size<ValueT>& rhs
+) {
+  return Size<ValueT>(lhs.width - rhs.width, lhs.height - rhs.height);
+}
+
+
+template<typename ValueT, typename ScalarT>
+auto operator*(
+  const Size<ValueT>& size,
+  const ScalarT scalar
+) {
+  return Size<decltype(size.width * scalar)>{
+    size.width * scalar,
+    size.height * scalar
+  };
+}
+
+
+template<typename ValueT>
+Size<ValueT>& operator+=(Size<ValueT>& lhs, const Size<ValueT>& rhs) {
+  auto newSize = lhs + rhs;
+  std::swap(lhs, newSize);
+  return lhs;
+}
+
+
+template<typename ValueT>
+Size<ValueT>& operator-=(Size<ValueT>& lhs, const Size<ValueT>& rhs) {
+  auto newSize = lhs - rhs;
+  std::swap(lhs, newSize);
+  return lhs;
+}
+
+
+template<typename ValueT>
 Rect<ValueT> operator+(
   const Rect<ValueT>& rect,
   const Point<ValueT>& translation

--- a/src/common/user_profile.cpp
+++ b/src/common/user_profile.cpp
@@ -202,6 +202,7 @@ nlohmann::json serialize(const data::GameOptions& options) {
   serialized["soundVolume"] = options.mSoundVolume;
   serialized["musicOn"] = options.mMusicOn;
   serialized["soundOn"] = options.mSoundOn;
+  serialized["widescreenModeOn"] = options.mWidescreenModeOn;
   return serialized;
 }
 
@@ -333,6 +334,8 @@ data::GameOptions deserialize<data::GameOptions>(const nlohmann::json& json) {
   extractValueIfExists("soundVolume", result.mSoundVolume, json);
   extractValueIfExists("musicOn", result.mMusicOn, json);
   extractValueIfExists("soundOn", result.mSoundOn, json);
+  extractValueIfExists("widescreenModeOn", result.mWidescreenModeOn, json);
+
 
   return result;
 }

--- a/src/data/game_options.hpp
+++ b/src/data/game_options.hpp
@@ -32,6 +32,9 @@ struct GameOptions {
   float mSoundVolume = SOUND_VOLUME_DEFAULT;
   bool mMusicOn = true;
   bool mSoundOn = true;
+
+  // Enhancements
+  bool mWidescreenModeOn = false;
 };
 
 }

--- a/src/data/game_traits.hpp
+++ b/src/data/game_traits.hpp
@@ -82,6 +82,14 @@ struct GameTraits {
   static const int minDrawOrder = -1;
   static const int maxDrawOrder = 4;
 
+  // The game's original 320x200 resolution would give us a 16:10 aspect ratio
+  // when using square pixels, but monitors of the time had a 4:3 aspect ratio,
+  // and that's what the game's graphics were designed for (very noticeable e.g.
+  // with the earth in the Apogee logo). CRTs are not limited to square pixels,
+  // and the monitor would stretch the 320x200 into the right shape for a 4:3
+  // picture.
+  static constexpr auto aspectRatio = 4.0f / 3.0f;
+
   struct CZone {
     static const std::size_t numSolidTiles = 1000u;
     static const std::size_t numMaskedTiles = 160u;

--- a/src/engine/entity_activation_system.cpp
+++ b/src/engine/entity_activation_system.cpp
@@ -60,11 +60,10 @@ bool determineActiveState(entityx::Entity entity, const bool inActiveRegion) {
 
 void markActiveEntities(
   entityx::EntityManager& es,
-  const base::Vector& cameraPosition
+  const base::Vector& cameraPosition,
+  const base::Extents& viewPortSize
 ) {
-  const BoundingBox activeRegionBox{
-    cameraPosition,
-    data::GameTraits::mapViewPortSize};
+  const BoundingBox activeRegionBox{cameraPosition, viewPortSize};
 
   es.each<WorldPosition, BoundingBox>([&activeRegionBox](
     entityx::Entity entity,

--- a/src/engine/entity_activation_system.hpp
+++ b/src/engine/entity_activation_system.hpp
@@ -28,6 +28,7 @@ namespace rigel::engine {
 
 void markActiveEntities(
   entityx::EntityManager& es,
-  const base::Vector& cameraPosition);
+  const base::Vector& cameraPosition,
+  const base::Extents& viewPortSize);
 
 }

--- a/src/engine/map_renderer.cpp
+++ b/src/engine/map_renderer.cpp
@@ -115,28 +115,11 @@ void MapRenderer::renderBackdrop(const base::Vector& cameraPosition) {
     }
   }
 
-  const auto offsetForDrawing = offset * -1;
-  const auto offsetForRepeating = base::Vector{
-    GameTraits::viewPortWidthPx - offset.x,
-    GameTraits::viewPortHeightPx - offset.y};
-
-  // TODO: This can be simplified by using texture wrap mode (GL_REPEAT)
-  mBackdropTexture.render(mpRenderer, offsetForDrawing);
-  if (!autoScrollY) {
-    mBackdropTexture.render(
-      mpRenderer,
-      base::Vector{offsetForRepeating.x, offsetForDrawing.y});
-  }
-
-  if (parallaxBoth || autoScrollY) {
-    mBackdropTexture.render(
-      mpRenderer,
-      base::Vector{offsetForDrawing.x, offsetForRepeating.y});
-  }
-
-  if (parallaxBoth) {
-    mBackdropTexture.render(mpRenderer, offsetForRepeating);
-  }
+  mpRenderer->drawTexture(
+    mBackdropTexture.data(),
+    {offset, mBackdropTexture.extents()},
+    {{}, mBackdropTexture.extents()},
+    true);
 }
 
 

--- a/src/engine/map_renderer.cpp
+++ b/src/engine/map_renderer.cpp
@@ -95,8 +95,8 @@ void MapRenderer::renderBackdrop(const base::Vector& cameraPosition) {
 
   if (parallaxHorizontal || parallaxBoth) {
     offset = wrapBackgroundOffset({
-      parallaxHorizontal ?  cameraPosition.x*PARALLAX_FACTOR : 0,
-      parallaxBoth ?  cameraPosition.y*PARALLAX_FACTOR : 0
+      parallaxHorizontal ? cameraPosition.x*PARALLAX_FACTOR : 0,
+      parallaxBoth ? cameraPosition.y*PARALLAX_FACTOR : 0
     });
   } else if (autoScrollX || autoScrollY) {
     // TODO Currently this only works right when running at 60 FPS.

--- a/src/engine/map_renderer.cpp
+++ b/src/engine/map_renderer.cpp
@@ -74,12 +74,12 @@ void MapRenderer::switchBackdrops() {
 
 
 void MapRenderer::renderBackground(const base::Vector& cameraPosition) {
-  renderMapTiles(cameraPosition, false);
+  renderMapTiles(cameraPosition, DrawMode::Background);
 }
 
 
 void MapRenderer::renderForeground(const base::Vector& cameraPosition) {
-  renderMapTiles(cameraPosition, true);
+  renderMapTiles(cameraPosition, DrawMode::Foreground);
 }
 
 
@@ -142,7 +142,7 @@ void MapRenderer::renderBackdrop(const base::Vector& cameraPosition) {
 
 void MapRenderer::renderMapTiles(
   const base::Vector& cameraPosition,
-  const bool renderForeground
+  const DrawMode drawMode
 ) {
   for (int layer=0; layer<2; ++layer) {
     for (int y=0; y<GameTraits::mapViewPortHeightTiles; ++y) {
@@ -156,7 +156,9 @@ void MapRenderer::renderMapTiles(
         const auto tileIndex = mpMap->tileAt(layer, col, row);
         const auto isForeground =
           mpMap->attributeDict().attributes(tileIndex).isForeGround();
-        if (isForeground != renderForeground) {
+        const auto shouldRenderForeground = drawMode == DrawMode::Foreground;
+
+        if (isForeground != shouldRenderForeground) {
           continue;
         }
 

--- a/src/engine/map_renderer.hpp
+++ b/src/engine/map_renderer.hpp
@@ -61,9 +61,14 @@ public:
     const base::Vector& cameraPosition);
 
 private:
+  enum class DrawMode {
+    Background,
+    Foreground
+  };
+
   void renderMapTiles(
     const base::Vector& cameraPosition,
-    bool renderForeground);
+    DrawMode drawMode);
   void renderTile(data::map::TileIndex index, int x, int y);
   data::map::TileIndex animatedTileIndex(data::map::TileIndex) const;
 

--- a/src/engine/map_renderer.hpp
+++ b/src/engine/map_renderer.hpp
@@ -49,9 +49,15 @@ public:
 
   void switchBackdrops();
 
-  void renderBackdrop(const base::Vector& cameraPosition);
-  void renderBackground(const base::Vector& cameraPosition);
-  void renderForeground(const base::Vector& cameraPosition);
+  void renderBackdrop(
+    const base::Vector& cameraPosition,
+    const base::Extents& viewPortSize);
+  void renderBackground(
+    const base::Vector& sectionStart,
+    const base::Extents& sectionSize);
+  void renderForeground(
+    const base::Vector& sectionStart,
+    const base::Extents& sectionSize);
 
   void updateAnimatedMapTiles();
 
@@ -67,7 +73,8 @@ private:
   };
 
   void renderMapTiles(
-    const base::Vector& cameraPosition,
+    const base::Vector& sectionStart,
+    const base::Extents& sectionSize,
     DrawMode drawMode);
   void renderTile(data::map::TileIndex index, int x, int y);
   data::map::TileIndex animatedTileIndex(data::map::TileIndex) const;

--- a/src/engine/rendering_system.cpp
+++ b/src/engine/rendering_system.cpp
@@ -234,6 +234,7 @@ void RenderingSystem::update(
 
   {
     renderer::RenderTargetTexture::Binder bindRenderTarget(mRenderTarget, mpRenderer);
+    auto saved = renderer::setupDefaultState(mpRenderer);
 
     // Render
     if (backdropFlashColor) {

--- a/src/engine/rendering_system.cpp
+++ b/src/engine/rendering_system.cpp
@@ -200,8 +200,8 @@ RenderingSystem::RenderingSystem(
   : mpRenderer(pRenderer)
   , mRenderTarget(
       pRenderer,
-      data::GameTraits::inGameViewPortSize.width,
-      data::GameTraits::inGameViewPortSize.height)
+      pRenderer->windowSize().width,
+      pRenderer->windowSize().height)
   , mMapRenderer(pRenderer, pMap, std::move(mapRenderData))
   , mpCameraPosition(pCameraPosition)
 {
@@ -234,7 +234,6 @@ void RenderingSystem::update(
 
   {
     renderer::RenderTargetTexture::Binder bindRenderTarget(mRenderTarget, mpRenderer);
-    auto saved = renderer::setupDefaultState(mpRenderer);
 
     // Render
     if (backdropFlashColor) {
@@ -253,8 +252,12 @@ void RenderingSystem::update(
     }
   }
 
-
-  mRenderTarget.render(mpRenderer, 0, 0);
+  {
+    auto saved = renderer::Renderer::StateSaver(mpRenderer);
+    mpRenderer->setGlobalScale({1.0f, 1.0f});
+    mpRenderer->setGlobalTranslation({});
+    mRenderTarget.render(mpRenderer, 0, 0);
+  }
 
   renderWaterEffectAreas(es);
 

--- a/src/engine/rendering_system.cpp
+++ b/src/engine/rendering_system.cpp
@@ -210,7 +210,8 @@ RenderingSystem::RenderingSystem(
 
 void RenderingSystem::update(
   ex::EntityManager& es,
-  const std::optional<base::Color>& backdropFlashColor
+  const std::optional<base::Color>& backdropFlashColor,
+  const base::Extents& viewPortSize
 ) {
   using namespace std;
   using game_logic::components::TileDebris;
@@ -238,13 +239,13 @@ void RenderingSystem::update(
     // Render
     if (backdropFlashColor) {
       mpRenderer->setOverlayColor(*backdropFlashColor);
-      mMapRenderer.renderBackdrop(*mpCameraPosition);
+      mMapRenderer.renderBackdrop(*mpCameraPosition, viewPortSize);
       mpRenderer->setOverlayColor({});
     } else {
-      mMapRenderer.renderBackdrop(*mpCameraPosition);
+      mMapRenderer.renderBackdrop(*mpCameraPosition, viewPortSize);
     }
 
-    mMapRenderer.renderBackground(*mpCameraPosition);
+    mMapRenderer.renderBackground(*mpCameraPosition, viewPortSize);
 
     // behind foreground
     for (auto it = spritesByDrawOrder.cbegin(); it != firstTopMostIt; ++it) {
@@ -261,7 +262,7 @@ void RenderingSystem::update(
 
   renderWaterEffectAreas(es);
 
-  mMapRenderer.renderForeground(*mpCameraPosition);
+  mMapRenderer.renderForeground(*mpCameraPosition, viewPortSize);
 
   // top most
   for (auto it = firstTopMostIt; it != spritesByDrawOrder.cend(); ++it) {

--- a/src/engine/rendering_system.hpp
+++ b/src/engine/rendering_system.hpp
@@ -74,7 +74,8 @@ public:
   /** Render everything. Can be called at full frame rate. */
   void update(
     entityx::EntityManager& es,
-    const std::optional<base::Color>& backdropFlashColor);
+    const std::optional<base::Color>& backdropFlashColor,
+    const base::Extents& viewPortSize);
 
   void switchBackdrops() {
     mMapRenderer.switchBackdrops();

--- a/src/game_logic/behavior_controller_system.cpp
+++ b/src/game_logic/behavior_controller_system.cpp
@@ -47,12 +47,14 @@ BehaviorControllerSystem::BehaviorControllerSystem(
 
 void BehaviorControllerSystem::update(
   entityx::EntityManager& es,
-  const PlayerInput& input
+  const PlayerInput& input,
+  const base::Extents& viewPortSize
 ) {
   using engine::components::Active;
   using game_logic::components::BehaviorController;
 
   mPerFrameState.mInput = input;
+  mPerFrameState.mCurrentViewPortSize = viewPortSize;
 
   es.each<BehaviorController, Active>([this](
     entityx::Entity entity,

--- a/src/game_logic/behavior_controller_system.hpp
+++ b/src/game_logic/behavior_controller_system.hpp
@@ -43,7 +43,8 @@ public:
 
   void update(
     entityx::EntityManager& es,
-    const PlayerInput& input);
+    const PlayerInput& input,
+    const base::Extents& viewPortSize);
 
   void receive(const events::ShootableDamaged& event);
   void receive(const events::ShootableKilled& event);

--- a/src/game_logic/camera.cpp
+++ b/src/game_logic/camera.cpp
@@ -83,9 +83,20 @@ base::Rect<int> deadZoneRect(const Player& player) {
 
 base::Vector offsetToDeadZone(
   const Player& player,
-  const base::Vector& cameraPosition
+  const base::Vector& cameraPosition,
+  const base::Extents& viewPortSize
 ) {
-  const auto playerBounds = player.worldSpaceCollisionBox();
+  const auto extraTiles =
+    viewPortSize.width - data::GameTraits::mapViewPortSize.width;
+  const auto offsetToCenter = extraTiles / 2;
+  auto playerBounds = player.worldSpaceCollisionBox();
+
+  // This makes the camera code work correctly when in widescreen mode. The
+  // dead zone is tailored towards normal (i.e. not widescreen) mode, which
+  // would cause the player to be constrained to move inside the left half of
+  // the screen when in widescreen mode. By shifting the player position, we
+  // effectively move the dead zone to the center of the screen instead.
+  playerBounds.topLeft.x -= offsetToCenter;
 
   auto worldSpaceDeadZone = deadZoneRect(player);
   worldSpaceDeadZone.topLeft += cameraPosition;
@@ -119,12 +130,14 @@ Camera::Camera(
 )
   : mpPlayer(pPlayer)
   , mpMap(&map)
+  , mViewPortSize(data::GameTraits::mapViewPortSize)
 {
   eventManager.subscribe<rigel::events::PlayerFiredShot>(*this);
 }
 
 
-void Camera::update(const PlayerInput& input) {
+void Camera::update(const PlayerInput& input, const base::Extents& viewPortSize) {
+  mViewPortSize = viewPortSize;
   updateManualScrolling(input);
   updateAutomaticScrolling();
 }
@@ -153,7 +166,8 @@ void Camera::updateManualScrolling(const PlayerInput& input) {
 
 
 void Camera::updateAutomaticScrolling() {
-  const auto [offsetX, offsetY] = offsetToDeadZone(*mpPlayer, mPosition);
+  const auto [offsetX, offsetY] =
+    offsetToDeadZone(*mpPlayer, mPosition, mViewPortSize);
 
   const auto maxAdjustDown = mpPlayer->isRidingElevator()
     ? MAX_ADJUST_DOWN_ELEVATOR
@@ -169,15 +183,15 @@ void Camera::updateAutomaticScrolling() {
 
 void Camera::setPosition(const base::Vector position) {
   const auto maxPosition = base::Extents{
-    static_cast<int>(mpMap->width() - data::GameTraits::mapViewPortWidthTiles),
-    static_cast<int>(mpMap->height() - data::GameTraits::mapViewPortHeightTiles)};
+    static_cast<int>(mpMap->width() - mViewPortSize.width),
+    static_cast<int>(mpMap->height() - mViewPortSize.height)};
   mPosition.x = std::clamp(position.x, 0, maxPosition.width);
   mPosition.y = std::clamp(position.y, 0, maxPosition.height);
 }
 
 
 void Camera::centerViewOnPlayer() {
-  setPosition(offsetToDeadZone(*mpPlayer, {}));
+  setPosition(offsetToDeadZone(*mpPlayer, {}, mViewPortSize));
 }
 
 

--- a/src/game_logic/camera.cpp
+++ b/src/game_logic/camera.cpp
@@ -118,9 +118,7 @@ Camera::Camera(
   entityx::EventManager& eventManager
 )
   : mpPlayer(pPlayer)
-  , mMaxPosition(base::Extents{
-    static_cast<int>(map.width() - data::GameTraits::mapViewPortWidthTiles),
-    static_cast<int>(map.height() - data::GameTraits::mapViewPortHeightTiles)})
+  , mpMap(&map)
 {
   eventManager.subscribe<rigel::events::PlayerFiredShot>(*this);
 }
@@ -170,8 +168,11 @@ void Camera::updateAutomaticScrolling() {
 
 
 void Camera::setPosition(const base::Vector position) {
-  mPosition.x = std::clamp(position.x, 0, mMaxPosition.width);
-  mPosition.y = std::clamp(position.y, 0, mMaxPosition.height);
+  const auto maxPosition = base::Extents{
+    static_cast<int>(mpMap->width() - data::GameTraits::mapViewPortWidthTiles),
+    static_cast<int>(mpMap->height() - data::GameTraits::mapViewPortHeightTiles)};
+  mPosition.x = std::clamp(position.x, 0, maxPosition.width);
+  mPosition.y = std::clamp(position.y, 0, maxPosition.height);
 }
 
 

--- a/src/game_logic/camera.hpp
+++ b/src/game_logic/camera.hpp
@@ -42,7 +42,7 @@ public:
     const data::map::Map& map,
     entityx::EventManager& eventManager);
 
-  void update(const PlayerInput& input);
+  void update(const PlayerInput& input, const base::Extents& viewPortSize);
   void centerViewOnPlayer();
 
   const base::Vector& position() const;
@@ -57,6 +57,7 @@ private:
   const Player* mpPlayer;
   const data::map::Map* mpMap;
   base::Vector mPosition;
+  base::Extents mViewPortSize;
   int mManualScrollCooldown = 0;
 };
 

--- a/src/game_logic/camera.hpp
+++ b/src/game_logic/camera.hpp
@@ -55,8 +55,8 @@ private:
   void setPosition(base::Vector position);
 
   const Player* mpPlayer;
+  const data::map::Map* mpMap;
   base::Vector mPosition;
-  base::Extents mMaxPosition;
   int mManualScrollCooldown = 0;
 };
 

--- a/src/game_logic/debugging_system.cpp
+++ b/src/game_logic/debugging_system.cpp
@@ -16,7 +16,6 @@
 
 #include "debugging_system.hpp"
 
-#include "data/game_traits.hpp"
 #include "data/unit_conversions.hpp"
 #include "engine/base_components.hpp"
 #include "engine/physical_components.hpp"
@@ -87,12 +86,15 @@ void DebuggingSystem::toggleGridDisplay() {
 }
 
 
-void DebuggingSystem::update(ex::EntityManager& es) {
+void DebuggingSystem::update(
+  ex::EntityManager& es,
+  const base::Extents& viewPortSize
+) {
   if (mShowWorldCollisionData) {
     const auto drawColor = base::Color{255, 255, 0, 255};
 
-    for (int y=0; y<GameTraits::mapViewPortHeightTiles; ++y) {
-      for (int x=0; x<GameTraits::mapViewPortWidthTiles; ++x) {
+    for (int y=0; y<viewPortSize.height; ++y) {
+      for (int x=0; x<viewPortSize.width; ++x) {
         const auto col = x + mpCameraPos->x;
         const auto row = y + mpCameraPos->y;
         if (col >= mpMap->width() || row >= mpMap->height()) {
@@ -178,17 +180,17 @@ void DebuggingSystem::update(ex::EntityManager& es) {
 
   if (mShowGrid) {
     const auto drawColor = base::Color{255, 255, 255, 190};
-    const auto maxX = tilesToPixels(GameTraits::mapViewPortWidthTiles);
-    const auto maxY = tilesToPixels(GameTraits::mapViewPortHeightTiles);
+    const auto maxX = tilesToPixels(viewPortSize.width);
+    const auto maxY = tilesToPixels(viewPortSize.height);
 
     // Horizontal lines
-    for (int y=0; y<GameTraits::mapViewPortHeightTiles; ++y) {
+    for (int y=0; y<viewPortSize.height; ++y) {
       const auto pxY = tilesToPixels(y);
       mpRenderer->drawLine(0, pxY, maxX, pxY, drawColor);
     }
 
     // Vertical lines
-    for (int x=0; x<GameTraits::mapViewPortWidthTiles; ++x) {
+    for (int x=0; x<viewPortSize.width; ++x) {
       const auto pxX = tilesToPixels(x);
       mpRenderer->drawLine(pxX, 0, pxX, maxY, drawColor);
     }

--- a/src/game_logic/debugging_system.hpp
+++ b/src/game_logic/debugging_system.hpp
@@ -39,7 +39,7 @@ public:
   void toggleWorldCollisionDataDisplay();
   void toggleGridDisplay();
 
-  void update(entityx::EntityManager& es);
+  void update(entityx::EntityManager& es, const base::Extents& viewPortSize);
 
 private:
   renderer::Renderer* mpRenderer;

--- a/src/game_logic/effect_actor_components.cpp
+++ b/src/game_logic/effect_actor_components.cpp
@@ -29,7 +29,6 @@ namespace rigel::game_logic::components {
 
 namespace {
 
-const auto RIGHT_SCREEN_EDGE = data::GameTraits::mapViewPortSize.width - 1;
 constexpr auto MAX_Y_OFFSET = 16;
 
 }
@@ -47,8 +46,10 @@ void WindBlownSpiderGenerator::update(
     d.mpRandomGenerator->gen() % 2 != 0 &&
     s.mpPerFrameState->mIsOddFrame
   ) {
+    const auto rightScreenEdge =
+      s.mpPerFrameState->mCurrentViewPortSize.width - 1;
     const auto effectActorId = 241 + d.mpRandomGenerator->gen() % 3;
-    const auto xPos = s.mpCameraPosition->x + RIGHT_SCREEN_EDGE;
+    const auto xPos = s.mpCameraPosition->x + rightScreenEdge;
     const auto yPos = s.mpCameraPosition->y +
       d.mpRandomGenerator->gen() % MAX_Y_OFFSET;
     const auto movementType = d.mpRandomGenerator->gen() % 2 != 0

--- a/src/game_logic/game_world.cpp
+++ b/src/game_logic/game_world.cpp
@@ -447,17 +447,22 @@ void GameWorld::updateGameLogic(const PlayerInput& input) {
 
 
 void GameWorld::render() {
+  auto drawWorld = [this](const base::Extents& viewPortSize) {
+    if (!mScreenFlashColor) {
+      mpSystems->render(
+        mEntities, mBackdropFlashColor, viewPortSize);
+    } else {
+      mpRenderer->clear(*mScreenFlashColor);
+    }
+  };
+
+
   mpRenderer->clear();
 
   {
     const auto saved = setupIngameViewport(mpRenderer, mScreenShakeOffsetX);
 
-    if (!mScreenFlashColor) {
-      mpSystems->render(
-        mEntities, mBackdropFlashColor, data::GameTraits::mapViewPortSize);
-    } else {
-      mpRenderer->clear(*mScreenFlashColor);
-    }
+    drawWorld(data::GameTraits::mapViewPortSize);
     mHudRenderer.render();
   }
 

--- a/src/game_logic/game_world.cpp
+++ b/src/game_logic/game_world.cpp
@@ -17,6 +17,8 @@
 #include "game_world.hpp"
 
 #include "common/game_service_provider.hpp"
+#include "common/user_profile.hpp"
+#include "data/game_options.hpp"
 #include "data/game_traits.hpp"
 #include "data/map.hpp"
 #include "data/sound_ids.hpp"
@@ -190,6 +192,7 @@ GameWorld::GameWorld(
       *context.mpResources,
       context.mpUiSpriteSheet)
   , mMessageDisplay(mpServiceProvider, context.mpUiRenderer)
+  , mpOptions(&context.mpUserProfile->mOptions)
 {
   mEventManager.subscribe<rigel::events::CheckPointActivated>(*this);
   mEventManager.subscribe<rigel::events::ExitReached>(*this);

--- a/src/game_logic/game_world.cpp
+++ b/src/game_logic/game_world.cpp
@@ -456,6 +456,18 @@ void GameWorld::render() {
     }
   };
 
+  auto drawTopRow = [this]() {
+    if (mActiveBossEntity) {
+      using game_logic::components::Shootable;
+
+      const auto health = mActiveBossEntity.has_component<Shootable>()
+        ? mActiveBossEntity.component<Shootable>()->mHealth : 0;
+      drawBossHealthBar(health, *mpTextRenderer, *mpUiSpriteSheet);
+    } else {
+      mMessageDisplay.render();
+    }
+  };
+
 
   mpRenderer->clear();
 
@@ -466,15 +478,7 @@ void GameWorld::render() {
     mHudRenderer.render();
   }
 
-  if (mActiveBossEntity) {
-    using game_logic::components::Shootable;
-
-    const auto health = mActiveBossEntity.has_component<Shootable>()
-      ? mActiveBossEntity.component<Shootable>()->mHealth : 0;
-    drawBossHealthBar(health, *mpTextRenderer, *mpUiSpriteSheet);
-  } else {
-    mMessageDisplay.render();
-  }
+  drawTopRow();
 }
 
 

--- a/src/game_logic/game_world.cpp
+++ b/src/game_logic/game_world.cpp
@@ -453,7 +453,8 @@ void GameWorld::render() {
     const auto saved = setupIngameViewport(mpRenderer, mScreenShakeOffsetX);
 
     if (!mScreenFlashColor) {
-      mpSystems->render(mEntities, mBackdropFlashColor);
+      mpSystems->render(
+        mEntities, mBackdropFlashColor, data::GameTraits::mapViewPortSize);
     } else {
       mpRenderer->clear(*mScreenFlashColor);
     }

--- a/src/game_logic/game_world.hpp
+++ b/src/game_logic/game_world.hpp
@@ -42,6 +42,7 @@ RIGEL_RESTORE_WARNINGS
 #include <vector>
 
 namespace rigel { class GameRunner; }
+namespace rigel::data { struct GameOptions; }
 
 
 namespace rigel::game_logic {
@@ -150,6 +151,7 @@ private:
   engine::RandomNumberGenerator mRandomGenerator;
   ui::HudRenderer mHudRenderer;
   ui::IngameMessageDisplay mMessageDisplay;
+  const data::GameOptions* mpOptions;
 
   std::optional<EarthQuakeEffect> mEarthQuakeEffect;
   std::optional<base::Color> mScreenFlashColor;

--- a/src/game_logic/global_dependencies.hpp
+++ b/src/game_logic/global_dependencies.hpp
@@ -60,6 +60,7 @@ struct GlobalDependencies {
 
 struct PerFrameState {
   PlayerInput mInput;
+  base::Extents mCurrentViewPortSize;
   bool mIsOddFrame = false;
   bool mIsEarthShaking = false;
 };

--- a/src/game_logic/ingame_systems.cpp
+++ b/src/game_logic/ingame_systems.cpp
@@ -174,7 +174,8 @@ IngameSystems::IngameSystems(
 
 void IngameSystems::update(
   const PlayerInput& input,
-  entityx::EntityManager& es
+  entityx::EntityManager& es,
+  const base::Extents& viewPortSize
 ) {
   // ----------------------------------------------------------------------
   // Animation update
@@ -189,8 +190,8 @@ void IngameSystems::update(
   mPlayerInteractionSystem.updatePlayerInteraction(input, es);
 
   mPlayer.update(input);
-  mCamera.update(input);
-  engine::markActiveEntities(es, mCamera.position());
+  mCamera.update(input, viewPortSize);
+  engine::markActiveEntities(es, mCamera.position(), viewPortSize);
 
   // ----------------------------------------------------------------------
   // Player related logic update
@@ -212,7 +213,7 @@ void IngameSystems::update(
   mSlimeBlobSystem.update(es);
   mSpiderSystem.update(es);
   mSpikeBallSystem.update(es);
-  mBehaviorControllerSystem.update(es, input);
+  mBehaviorControllerSystem.update(es, input, viewPortSize);
 
   // ----------------------------------------------------------------------
   // Physics and other updates
@@ -246,7 +247,7 @@ void IngameSystems::render(
 ) {
   mRenderingSystem.update(es, backdropFlashColor, viewPortSize);
   mParticles.render(mCamera.position());
-  mDebuggingSystem.update(es);
+  mDebuggingSystem.update(es, viewPortSize);
 }
 
 

--- a/src/game_logic/ingame_systems.cpp
+++ b/src/game_logic/ingame_systems.cpp
@@ -241,9 +241,10 @@ void IngameSystems::update(
 
 void IngameSystems::render(
   entityx::EntityManager& es,
-  const std::optional<base::Color>& backdropFlashColor
+  const std::optional<base::Color>& backdropFlashColor,
+  const base::Extents& viewPortSize
 ) {
-  mRenderingSystem.update(es, backdropFlashColor);
+  mRenderingSystem.update(es, backdropFlashColor, viewPortSize);
   mParticles.render(mCamera.position());
   mDebuggingSystem.update(es);
 }

--- a/src/game_logic/ingame_systems.hpp
+++ b/src/game_logic/ingame_systems.hpp
@@ -84,7 +84,10 @@ public:
     entityx::EventManager& eventManager,
     const loader::ResourceLoader& resources);
 
-  void update(const PlayerInput& inputState, entityx::EntityManager& es);
+  void update(
+    const PlayerInput& inputState,
+    entityx::EntityManager& es,
+    const base::Extents& viewPortSize);
   void render(
     entityx::EntityManager& es,
     const std::optional<base::Color>& backdropFlashColor,

--- a/src/game_logic/ingame_systems.hpp
+++ b/src/game_logic/ingame_systems.hpp
@@ -87,7 +87,8 @@ public:
   void update(const PlayerInput& inputState, entityx::EntityManager& es);
   void render(
     entityx::EntityManager& es,
-    const std::optional<base::Color>& backdropFlashColor);
+    const std::optional<base::Color>& backdropFlashColor,
+    const base::Extents& viewPortSize);
 
   DebuggingSystem& debuggingSystem();
 

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -148,8 +148,6 @@ void Game::run(const StartupOptions& startupOptions) {
     mSoundsById.emplace_back(mSoundSystem.addSound(mResources.loadSound(id)));
   });
 
-  mMusicEnabled = startupOptions.mEnableMusic;
-
   applyChangedOptions();
 
   // Check if running registered version
@@ -413,10 +411,6 @@ void Game::stopSound(const data::SoundId id) {
 
 
 void Game::playMusic(const std::string& name) {
-  if (!mMusicEnabled) {
-    return;
-  }
-
   mSoundSystem.playSong(mResources.loadMusic(name));
 }
 

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -304,6 +304,7 @@ void Game::performScreenFadeBlocking(const bool doFadeIn) {
   }
 
   renderer::DefaultRenderTargetBinder bindDefaultRenderTarget(&mRenderer);
+  auto saved = renderer::setupDefaultState(&mRenderer);
 
   engine::TimeDelta elapsedTime = 0.0;
 
@@ -374,6 +375,8 @@ void Game::fadeOutScreen() {
 
   // Clear render canvas after a fade-out
   RenderTargetBinder bindRenderTarget(mRenderTarget, &mRenderer);
+  auto saved = renderer::setupDefaultState(&mRenderer);
+
   mRenderer.clear();
 }
 

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -63,15 +63,6 @@ auto loadScripts(const loader::ResourceLoader& resources) {
 }
 
 
-// The game's original 320x200 resolution would give us a 16:10 aspect ratio
-// when using square pixels, but monitors of the time had a 4:3 aspect ratio,
-// and that's what the game's graphics were designed for (very noticeable e.g.
-// with the earth in the Apogee logo). CRTs are not limited to square pixels,
-// and the monitor would stretch the 320x200 into the right shape for a 4:3
-// picture.
-const auto TARGET_ASPECT_RATIO = 4.0f / 3.0f;
-
-
 [[nodiscard]] auto setupSimpleUpscaling(renderer::Renderer* pRenderer) {
   auto saved = renderer::Renderer::StateSaver{pRenderer};
 
@@ -80,10 +71,10 @@ const auto TARGET_ASPECT_RATIO = 4.0f / 3.0f;
   const auto windowHeight = float(windowHeightInt);
 
   const auto usableWidth = windowWidth > windowHeight
-    ? TARGET_ASPECT_RATIO * windowHeight
+    ? data::GameTraits::aspectRatio * windowHeight
     : windowWidth;
   const auto usableHeight = windowHeight >= windowWidth
-    ? 1.0f / TARGET_ASPECT_RATIO * windowWidth
+    ? 1.0f / data::GameTraits::aspectRatio * windowWidth
     : windowHeight;
 
   const auto widthScale = usableWidth / data::GameTraits::viewPortWidthPx;

--- a/src/game_main.hpp
+++ b/src/game_main.hpp
@@ -34,7 +34,6 @@ struct StartupOptions {
   std::string mGamePath;
   std::optional<std::pair<int, int>> mLevelToJumpTo;
   bool mSkipIntro = false;
-  bool mEnableMusic = true;
   std::optional<base::Vector> mPlayerPosition;
 };
 

--- a/src/game_main.ipp
+++ b/src/game_main.ipp
@@ -94,7 +94,6 @@ private:
 
   std::vector<engine::SoundSystem::SoundHandle> mSoundsById;
 
-  bool mMusicEnabled = true;
   bool mShowFps = false;
 
   bool mIsRunning;

--- a/src/game_runner.cpp
+++ b/src/game_runner.cpp
@@ -152,9 +152,13 @@ void GameRunner::updateAndRender(engine::TimeDelta dt) {
     return;
   }
 
-  std::visit(
-    [dt](auto& state) { state.updateAndRender(dt); },
-    mStateStack.top());
+  base::match(mStateStack.top(),
+    [dt, this](ui::OptionsMenu& state) {
+      state.updateAndRender(dt);
+      mWorld.render();
+    },
+
+    [dt](auto& state) { state.updateAndRender(dt); });
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -165,7 +165,6 @@ int main(int argc, char** argv) {
   showBanner();
 
   StartupOptions config;
-  bool disableMusic = false;
 
   po::options_description optionsDescription("Options");
   optionsDescription.add_options()
@@ -176,9 +175,6 @@ int main(int argc, char** argv) {
     ("play-level,l",
      po::value<string>(),
      "Directly jump to given map, skipping intro/menu etc.")
-    ("no-music",
-     po::bool_switch(&disableMusic),
-     "Disable music playback")
     ("player-pos",
      po::value<string>(),
      "Specify position to place the player at (to be used in conjunction with\n"
@@ -205,10 +201,6 @@ int main(int argc, char** argv) {
     if (options.count("help")) {
       cout << optionsDescription << '\n';
       return 0;
-    }
-
-    if (disableMusic) {
-      config.mEnableMusic = false;
     }
 
     if (options.count("play-level")) {

--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -707,6 +707,8 @@ void Renderer::setClipRect(const std::optional<base::Rect<int>>& clipRect) {
     return;
   }
 
+  submitBatch();
+
   mClipRect = clipRect;
   if (mClipRect) {
     glEnable(GL_SCISSOR_TEST);

--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -199,7 +199,7 @@ void setScissorBox(
   const auto offsetAtBottom = frameBufferSize.height - clipRect.bottom();
   glScissor(
     clipRect.topLeft.x,
-    offsetAtBottom,
+    offsetAtBottom - 1,
     clipRect.size.width,
     clipRect.size.height);
 }

--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -95,9 +95,16 @@ uniform sampler2D textureData;
 uniform vec4 overlayColor;
 
 uniform vec4 colorModulation;
+uniform bool enableRepeat;
 
 void main() {
-  vec4 baseColor = TEXTURE_LOOKUP(textureData, texCoordFrag);
+  vec2 texCoords = texCoordFrag;
+  if (enableRepeat) {
+    texCoords.x = fract(texCoords.x);
+    texCoords.y = fract(texCoords.y);
+  }
+
+  vec4 baseColor = TEXTURE_LOOKUP(textureData, texCoords);
   vec4 modulated = baseColor * colorModulation;
   float targetAlpha = modulated.a;
 
@@ -453,7 +460,8 @@ void Renderer::setColorModulation(const base::Color& colorModulation) {
 void Renderer::drawTexture(
   const TextureData& textureData,
   const base::Rect<int>& sourceRect,
-  const base::Rect<int>& destRect
+  const base::Rect<int>& destRect,
+  const bool repeat
 ) {
   if (!isVisible(destRect)) {
     return;
@@ -466,6 +474,13 @@ void Renderer::drawTexture(
 
     glBindTexture(GL_TEXTURE_2D, textureData.mHandle);
     mLastUsedTexture = textureData.mHandle;
+  }
+
+  if (repeat != mTextureRepeatOn) {
+    submitBatch();
+
+    mTexturedQuadShader.setUniform("enableRepeat", repeat);
+    mTextureRepeatOn = repeat;
   }
 
   // x, y, tex_u, tex_v
@@ -805,6 +820,7 @@ void Renderer::updateShaders() {
   switch (mRenderMode) {
     case RenderMode::SpriteBatch:
       useShaderIfChanged(mTexturedQuadShader);
+      mTexturedQuadShader.setUniform("enableRepeat", mTextureRepeatOn);
       mTexturedQuadShader.setUniform("transform", mProjectionMatrix);
       glVertexAttribPointer(
         0,

--- a/src/renderer/renderer.hpp
+++ b/src/renderer/renderer.hpp
@@ -149,7 +149,8 @@ public:
   void drawTexture(
     const TextureData& textureData,
     const base::Rect<int>& pSourceRect,
-    const base::Rect<int>& pDestRect);
+    const base::Rect<int>& pDestRect,
+    bool repeat = false);
 
   void drawRectangle(
     const base::Rect<int>& rect,
@@ -265,6 +266,7 @@ private:
   GLuint mLastUsedTexture;
   base::Color mLastColorModulation;
   base::Color mLastOverlayColor;
+  bool mTextureRepeatOn = false;
 
   RenderMode mRenderMode;
 

--- a/src/renderer/texture.cpp
+++ b/src/renderer/texture.cpp
@@ -136,12 +136,15 @@ RenderTargetTexture::Binder::Binder(
   const renderer::Renderer::RenderTarget& target,
   renderer::Renderer* pRenderer
 )
-  : mStateSaver(pRenderer)
+  : mPreviousRenderTarget(pRenderer->currentRenderTarget())
+  , mpRenderer(pRenderer)
 {
   pRenderer->setRenderTarget(target);
-  pRenderer->setGlobalTranslation({});
-  pRenderer->setGlobalScale({1.0f, 1.0f});
-  pRenderer->setClipRect({});
+}
+
+
+RenderTargetTexture::Binder::~Binder() {
+  mpRenderer->setRenderTarget(mPreviousRenderTarget);
 }
 
 

--- a/src/renderer/texture.hpp
+++ b/src/renderer/texture.hpp
@@ -200,12 +200,17 @@ public:
   class Binder {
   public:
     Binder(RenderTargetTexture& renderTarget, Renderer* pRenderer);
+    ~Binder();
+
+    Binder(Binder&&) = delete;
+    Binder& operator=(Binder&&) = delete;
 
   protected:
     Binder(const Renderer::RenderTarget&, Renderer* pRenderer);
 
   private:
-    Renderer::StateSaver mStateSaver;
+    Renderer::RenderTarget mPreviousRenderTarget;
+    Renderer* mpRenderer;
   };
 
   RenderTargetTexture(
@@ -233,5 +238,14 @@ class DefaultRenderTargetBinder : public RenderTargetTexture::Binder {
 public:
   explicit DefaultRenderTargetBinder(renderer::Renderer* pRenderer);
 };
+
+
+[[nodiscard]] inline auto setupDefaultState(Renderer* pRenderer) {
+  auto saved = Renderer::StateSaver{pRenderer};
+  pRenderer->setGlobalTranslation({});
+  pRenderer->setGlobalScale({1.0f, 1.0f});
+  pRenderer->setClipRect({});
+  return saved;
+}
 
 }

--- a/src/ui/options_menu.cpp
+++ b/src/ui/options_menu.cpp
@@ -76,6 +76,13 @@ void OptionsMenu::updateAndRender(engine::TimeDelta dt) {
       ImGui::EndTabItem();
     }
 
+    if (ImGui::BeginTabItem("Enhancements"))
+    {
+      ImGui::NewLine();
+      ImGui::Checkbox("Widescreen mode", &mpOptions->mWidescreenModeOn);
+      ImGui::EndTabItem();
+    }
+
     ImGui::EndTabBar();
   }
 


### PR DESCRIPTION
- This code completes #385 widescreen support for Rigel Engine.     
- --widescreen command line argument enables widescreen mode   
- widescreen mode will make the game take the entire screen instead of leaving black vertical bars on both sides due to earlier 4:3 display mode     
-  actual resolution changed from 320x200 to 450x200 for 16:9 
-  this increases horizontal FOV
- texture fetching and loading is still performed at original 320x200   
- use of get() apis to access dimensions which would be helpful for future updates to display mode (more kinds of widescreen support etc)
- need more elegant way of passing widescreen boolean to parts of code 
- loading splash screen and menu appear offsetted to X=0, they could be brought back to center but it will require more code to handle, hence skipped