### PR TITLE
Fix widescreen mode for low resolution 16:10 screen.

### DIFF
--- a/src/renderer/upscaling_utils.cpp
+++ b/src/renderer/upscaling_utils.cpp
@@ -20,6 +20,8 @@
 #include "data/game_traits.hpp"
 #include "renderer/renderer.hpp"
 
+#include <algorithm>
+
 
 namespace rigel::renderer {
 
@@ -35,13 +37,12 @@ WidescreenViewPortInfo determineWidescreenViewPort(const Renderer* pRenderer) {
 
   const auto widthScale = usableWidth / data::GameTraits::viewPortWidthPx;
 
-  const auto tileWidthScaled =
-    base::round(data::GameTraits::tileSize * widthScale);
+  const auto tileWidthScaled = data::GameTraits::tileSize * widthScale;
   const auto maxTilesOnScreen =
-    pRenderer->windowSize().width / tileWidthScaled;
+    base::round(pRenderer->windowSize().width / tileWidthScaled);
 
   const auto widthInPixels =
-    static_cast<int>(maxTilesOnScreen * data::GameTraits::tileSize * widthScale);
+    std::min(base::round(maxTilesOnScreen * tileWidthScaled), windowWidthInt);
   const auto paddingPixels =
     pRenderer->windowSize().width - widthInPixels;
 


### PR DESCRIPTION
Doing some more testing, I noticed that the viewport calculation for widescreen mode didn't use the full available width of the screen on my laptop, which has a 1280x800 screen (16:10 aspect ratio). With that resolution, the horizontal scale factor works out to 3.33333..., which means we can fit 48 tiles into 1280 pixels (1 tile = 8 px, thus 8*3.333... -> 26.6666. 1280/26.6666 -> 48). But due to rounding too early, the calculation would work out to 47 tiles instead, leaving a gap of 13 pixels on each side of the screen.