### PR TITLE
Fix: Ship laser passes through enemies

### DIFF
--- a/src/game_logic/player/projectile_system.cpp
+++ b/src/game_logic/player/projectile_system.cpp
@@ -158,12 +158,15 @@ void ProjectileSystem::update(entityx::EntityManager& es) {
 
       if (
         projectile.mType == PlayerProjectile::Type::Laser ||
+        projectile.mType == PlayerProjectile::Type::ShipLaser ||
         projectile.mType == PlayerProjectile::Type::ReactorDebris
       ) {
         if (
           damage.mHasCausedDamage &&
-          projectile.mType == PlayerProjectile::Type::ReactorDebris
+          (projectile.mType == PlayerProjectile::Type::ReactorDebris ||
+           projectile.mType == PlayerProjectile::Type::ShipLaser)
         ) {
+          damage.mHasCausedDamage = false;
           spawnEnemyImpactEffect(*mpEntityFactory, position);
         }
 
@@ -176,21 +179,16 @@ void ProjectileSystem::update(entityx::EntityManager& es) {
 
       // Check if we hit an enemy, deactivate if so.
       if (damage.mHasCausedDamage) {
-        if (
-          isRocket ||
-          projectile.mType == PlayerProjectile::Type::ShipLaser
-        ) {
+        if (isRocket) {
           spawnEnemyImpactEffect(*mpEntityFactory, position);
         }
+
         deactivateProjectile(entity);
         return;
       }
 
-      if (
-        projectile.mType == PlayerProjectile::Type::Flame ||
-        projectile.mType == PlayerProjectile::Type::ShipLaser
-      ) {
-        // These projectiles pass through walls, so no further checking
+      if (projectile.mType == PlayerProjectile::Type::Flame) {
+        // The flame thrower passes through walls, so no further checking
         // necessary.
         return;
       }


### PR DESCRIPTION
At first, I incorrectly implemented the ship laser to stop when hitting
an enemy.

This commit also fixes an issue with the reactor debris impact effect,
which would occur every frame after the projectile hit an enemy, instead
of only when it actually hits one.

Run `git diff 132729146a36d5ce7dea60d5144822f36862ea0f~1 -- src/game_logic/player/projectile_system.cpp` to see how the diff should actually have looked like in #461 to be correct from the start:

```
diff --git a/src/game_logic/player/projectile_system.cpp b/src/game_logic/player/projectile_system.cpp
index f78f940..449cec6 100644
--- a/src/game_logic/player/projectile_system.cpp
+++ b/src/game_logic/player/projectile_system.cpp
@@ -108,7 +108,7 @@ void spawnRocketWallImpactEffect(
 }
 
 
-void spawnRocketEnemyImpactEffect(
+void spawnEnemyImpactEffect(
   EntityFactory& entityFactory,
   const base::Vector& position
 ) {
@@ -156,13 +156,22 @@ void ProjectileSystem::update(entityx::EntityManager& es) {
         body.mIsActive = true;
       }
 
-      // TODO: Impact explosions for reactor debris?
       if (
         projectile.mType == PlayerProjectile::Type::Laser ||
+        projectile.mType == PlayerProjectile::Type::ShipLaser ||
         projectile.mType == PlayerProjectile::Type::ReactorDebris
       ) {
+        if (
+          damage.mHasCausedDamage &&
+          (projectile.mType == PlayerProjectile::Type::ReactorDebris ||
+           projectile.mType == PlayerProjectile::Type::ShipLaser)
+        ) {
+          damage.mHasCausedDamage = false;
+          spawnEnemyImpactEffect(*mpEntityFactory, position);
+        }
+
         // These projectiles pass through enemies and walls, so there's nothing
-        // we have to do.
+        // more we have to do.
         return;
       }
 
@@ -171,8 +180,9 @@ void ProjectileSystem::update(entityx::EntityManager& es) {
       // Check if we hit an enemy, deactivate if so.
       if (damage.mHasCausedDamage) {
         if (isRocket) {
-          spawnRocketEnemyImpactEffect(*mpEntityFactory, position);
+          spawnEnemyImpactEffect(*mpEntityFactory, position);
         }
+
         deactivateProjectile(entity);
         return;
       }
```