### PR TITLE
GameController functionality for playing Duke and menus

### DIFF
--- a/src/anti_piracy_screen_mode.cpp
+++ b/src/anti_piracy_screen_mode.cpp
@@ -42,7 +42,7 @@ std::unique_ptr<GameMode> AntiPiracyScreenMode::updateAndRender(
 
   const auto anyButtonPressed = any_of(begin(events), end(events),
     [](const SDL_Event& event) {
-      return event.type == SDL_KEYDOWN;
+      return (event.type == SDL_KEYDOWN) || (event.type == SDL_CONTROLLERBUTTONDOWN);
     });
 
   if (anyButtonPressed) {

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -25,7 +25,6 @@
 #include "renderer/opengl.hpp"
 #include "renderer/upscaling_utils.hpp"
 #include "sdl_utils/error.hpp"
-#include "sdl_utils/ptr.hpp"
 #include "ui/imgui_integration.hpp"
 
 #include "anti_piracy_screen_mode.hpp"
@@ -227,7 +226,7 @@ void gameMain(const StartupOptions& options) {
   SetProcessDPIAware();
 #endif
 
-  sdl_utils::check(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO));
+  sdl_utils::check(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER));
   auto sdlGuard = defer([]() { SDL_Quit(); });
 
   sdl_utils::check(SDL_GL_LoadLibrary(nullptr));
@@ -330,8 +329,18 @@ void Game::run(const StartupOptions& startupOptions) {
   mpCurrentGameMode = wrapWithInitialFadeIn(createInitialGameMode(
     makeModeContext(), startupOptions, mIsShareWareVersion));
 
+  //TODO : support multiple controllers
+  for (std::uint8_t i = 0; i < SDL_NumJoysticks(); ++i) {
+    if (SDL_IsGameController(i)) {
+      mpGameController =
+        sdl_utils::Ptr<SDL_GameController>{SDL_GameControllerOpen(i)};
+      break;
+    }
+  }
+
   mainLoop();
 
+  // exiting the game
   mpUserProfile->saveToDisk();
 }
 

--- a/src/game_main.ipp
+++ b/src/game_main.ipp
@@ -27,9 +27,12 @@
 #include "loader/resource_loader.hpp"
 #include "renderer/renderer.hpp"
 #include "renderer/texture.hpp"
+#include "sdl_utils/ptr.hpp"
 #include "ui/duke_script_runner.hpp"
 #include "ui/fps_display.hpp"
 #include "ui/menu_element_renderer.hpp"
+
+#include "SDL_gamecontroller.h"
 
 #include <chrono>
 #include <memory>
@@ -122,6 +125,7 @@ private:
   engine::TiledTexture mUiSpriteSheet;
   ui::MenuElementRenderer mTextRenderer;
   ui::FpsDisplay mFpsDisplay;
+  sdl_utils::Ptr<SDL_GameController> mpGameController;
 };
 
 }

--- a/src/game_runner.hpp
+++ b/src/game_runner.hpp
@@ -70,7 +70,8 @@ private:
     void updateAndRender(engine::TimeDelta dt);
 
     void updateWorld(engine::TimeDelta dt);
-    void handlePlayerInput(const SDL_Event& event);
+    void handlePlayerKeyboardInput(const SDL_Event& event);
+    void handlePlayerGameControllerInput(const SDL_Event& event);
     void handleDebugKeys(const SDL_Event& event);
 
     game_logic::GameWorld* mpWorld;

--- a/src/intro_demo_loop_mode.cpp
+++ b/src/intro_demo_loop_mode.cpp
@@ -93,7 +93,7 @@ IntroDemoLoopMode::IntroDemoLoopMode(
 
 
 bool IntroDemoLoopMode::handleEvent(const SDL_Event& event) {
-  if (event.type != SDL_KEYDOWN) {
+  if ((event.type != SDL_KEYDOWN) && (event.type != SDL_CONTROLLERBUTTONDOWN)) {
     return false;
   }
 
@@ -110,8 +110,10 @@ bool IntroDemoLoopMode::handleEvent(const SDL_Event& event) {
     auto& currentStage = mStages[mCurrentStage];
 
     if (
-      event.key.keysym.sym == SDLK_ESCAPE
-      || !canStageHandleEvents(currentStage)
+      (event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_ESCAPE) ||
+      (event.type == SDL_CONTROLLERBUTTONDOWN &&
+       event.cbutton.button == SDL_CONTROLLER_BUTTON_B) ||
+      !canStageHandleEvents(currentStage)
     ) {
       return true;
     } else {

--- a/src/menu_mode.cpp
+++ b/src/menu_mode.cpp
@@ -62,8 +62,9 @@ MenuMode::MenuMode(Context context)
 void MenuMode::handleEvent(const SDL_Event& event) {
   if (mOptionsMenu) {
     if (
-      event.type == SDL_KEYDOWN &&
-      event.key.keysym.sym == SDLK_ESCAPE
+      (event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_ESCAPE) ||
+      (event.type == SDL_CONTROLLERBUTTONDOWN &&
+       event.cbutton.button == SDL_CONTROLLER_BUTTON_B)
     ) {
       mOptionsMenu = std::nullopt;
     }
@@ -72,8 +73,9 @@ void MenuMode::handleEvent(const SDL_Event& event) {
 
   if (
     mMenuState == MenuState::AskIfQuit &&
-    event.type == SDL_KEYDOWN &&
-    event.key.keysym.sym == SDLK_y
+    ((event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_y) ||
+     (event.type == SDL_CONTROLLERBUTTONDOWN &&
+      event.cbutton.button == SDL_CONTROLLER_BUTTON_A))
   ) {
     mContext.mpServiceProvider->scheduleGameQuit();
     return;
@@ -84,10 +86,13 @@ void MenuMode::handleEvent(const SDL_Event& event) {
     const auto optionsMenuSelected = maybeIndex && *maybeIndex == 2;
     if (
       optionsMenuSelected &&
-      event.type == SDL_KEYDOWN &&
-      (event.key.keysym.sym == SDLK_RETURN ||
-       event.key.keysym.sym == SDLK_KP_ENTER ||
-       event.key.keysym.sym == SDLK_SPACE)
+      ((event.type == SDL_KEYDOWN && (
+        event.key.keysym.sym == SDLK_RETURN ||
+        event.key.keysym.sym == SDLK_KP_ENTER ||
+        event.key.keysym.sym == SDLK_SPACE))
+      ||
+      (event.type == SDL_CONTROLLERBUTTONDOWN &&
+       event.cbutton.button == SDL_CONTROLLER_BUTTON_A))
     ) {
       mOptionsMenu = ui::OptionsMenu{&mContext.mpUserProfile->mOptions};
       return;

--- a/src/sdl_utils/ptr.hpp
+++ b/src/sdl_utils/ptr.hpp
@@ -43,6 +43,11 @@ struct DeleterFor<SDL_Window> {
 };
 
 template<>
+struct DeleterFor<SDL_GameController> {
+  static auto deleter() { return &SDL_GameControllerClose; }
+};
+
+template<>
 struct DeleterFor<Mix_Chunk> {
   static auto deleter() { return &Mix_FreeChunk; }
 };

--- a/src/ui/duke_script_runner.hpp
+++ b/src/ui/duke_script_runner.hpp
@@ -165,9 +165,14 @@ private:
 
   void drawCurrentKeyBindings();
 
+  void handleKeyboardEvent(const SDL_Event& event);
+  void handleGameControllerEvent(const SDL_Event& event);
+
   bool hasMenuPages() const;
   void selectNextPage(PagerState& state);
   void selectPreviousPage(PagerState& state);
+  void confirmOrSelectNextPage(PagerState& state);
+  void handleUnassignedButton(PagerState& state);
   void onPageChanged(PagerState& state);
   void executeCurrentPageScript(PagerState& state);
   void selectCurrentMenuItem(PagerState& state);

--- a/src/ui/episode_end_sequence.cpp
+++ b/src/ui/episode_end_sequence.cpp
@@ -86,7 +86,7 @@ void EpisodeEndScreen::updateAndRender(engine::TimeDelta dt) {
 
 
 void EpisodeEndScreen::handleEvent(const SDL_Event& event) {
-  if (event.type != SDL_KEYDOWN) {
+  if ((event.type != SDL_KEYDOWN) && (event.type != SDL_CONTROLLERBUTTONDOWN)) {
     return;
   }
 


### PR DESCRIPTION
This PR adds game controller functionality to the engine. It also adds game controller support for most of the menus (not all especially those related to typing).
The sticks and dpad are used for movement (only dpad during the menus). B and A for jump, X and Right shoulder for fire.
For the menus, dpad for the movement, A to select and B for exit.
It has been tested with xbox one controller on Windows. Needs testing on other OSes and other controllers like PS 4 controller and Nintendo Switch one. 