### PR TITLE
Add User Profile conversion tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,5 +115,6 @@ target_compile_options(entityx PRIVATE
 
 enable_testing()
 
+add_subdirectory(modding_tools)
 add_subdirectory(src)
 add_subdirectory(test)

--- a/modding_tools/CMakeLists.txt
+++ b/modding_tools/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(UserProfileTool user_profile_tool.cpp)
+target_link_libraries(UserProfileTool PRIVATE
+    SDL2::Main
+    rigel_core
+)

--- a/modding_tools/user_profile_tool.cpp
+++ b/modding_tools/user_profile_tool.cpp
@@ -1,0 +1,162 @@
+/* Copyright (C) 2019, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <base/warnings.hpp>
+#include <common/user_profile.hpp>
+#include <loader/file_utils.hpp>
+
+RIGEL_DISABLE_WARNINGS
+#include <nlohmann/json.hpp>
+RIGEL_RESTORE_WARNINGS
+
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+
+
+namespace {
+
+constexpr auto INDENTATION_WIDTH = 2;
+
+
+void printBanner(const std::filesystem::path& prefsDirPath) {
+  std::cout <<
+    "== Rigel Engine user profile tool ==\n"
+    "\n"
+    "User profile path: \"" << prefsDirPath.u8string() << "\"\n"
+    "\n";
+}
+
+
+void printUsage() {
+  std::cout <<
+R"(Usage:
+  UserProfileTool <command>
+
+With command being 'encode' or 'decode'. Both commands operate in-place in
+the user profile directory.
+
+encode - reads JSON version of profile, and writes binary version
+decode - reads binary profile file, and writes a JSON version
+)";
+}
+
+
+std::string readJsonFile(const std::filesystem::path& path) {
+  auto inFile = std::ifstream{path.u8string()};
+  if (inFile.is_open()) {
+    return std::string{
+      std::istreambuf_iterator<char>{inFile},
+      std::istreambuf_iterator<char>{}};
+  }
+
+  return "";
+}
+
+
+void writeJsonFile(
+  const std::string& json,
+  const std::filesystem::path& path
+) {
+  auto outFile = std::ofstream{path.u8string()};
+  outFile << json;
+}
+
+
+bool userConfirmed() {
+  std::cout
+    << "WARNING: This will overwrite your current profile.\n"
+    << "Proceed? [Y/n] ";
+
+  char confirmation = 'n';
+  std::cin >> confirmation;
+
+  return confirmation == 'y' || confirmation == 'Y';
+}
+
+}
+
+
+int main(int argc, char** argv) {
+  const auto USER_PROFILE_FILENAME =
+    std::string{rigel::USER_PROFILE_BASE_NAME} + rigel::USER_PROFILE_FILE_EXTENSION;
+  const auto JSON_USER_PROFILE_FILENAME =
+    std::string{rigel::USER_PROFILE_BASE_NAME} + ".json";
+
+  using namespace std::literals;
+
+  namespace fs = std::filesystem;
+
+  try {
+    const auto prefsDirPath = rigel::createOrGetPreferencesPath();
+    if (!prefsDirPath) {
+      std::cerr << "ERROR: Failed to get preferences path\n";
+      return 1;
+    }
+
+    printBanner(*prefsDirPath);
+
+    if (argc < 2) {
+      printUsage();
+      return 1;
+    }
+
+
+    const auto command = argv[1];
+
+    if (command == "decode"s) {
+      const auto profileFilePath = *prefsDirPath / USER_PROFILE_FILENAME;
+      if (!fs::exists(profileFilePath)) {
+        std::cerr << "ERROR: No profile file found\n";
+        return 1;
+      }
+
+      const auto buffer = rigel::loader::loadFile(profileFilePath);
+      const auto profile = nlohmann::json::from_msgpack(buffer);
+      const auto outFilePath = *prefsDirPath / JSON_USER_PROFILE_FILENAME;
+      writeJsonFile(profile.dump(INDENTATION_WIDTH), outFilePath);
+
+      std::cout <<
+        "Profile successfully decoded. Find the JSON file at:\n"
+        "\t\"" << outFilePath.u8string() << "\"\n";
+    } else if (command == "encode"s) {
+      const auto jsonFilePath = *prefsDirPath / JSON_USER_PROFILE_FILENAME;
+      if (!fs::exists(jsonFilePath)) {
+        std::cerr << "ERROR: No decoded profile (JSON file) found\n";
+        return 1;
+      }
+
+      const auto jsonProfileText = readJsonFile(jsonFilePath);
+      const auto jsonProfile = nlohmann::json::parse(jsonProfileText);
+      const auto serializedBuffer = nlohmann::json::to_msgpack(jsonProfile);
+
+      if (userConfirmed()) {
+        const auto profileFilePath = *prefsDirPath / USER_PROFILE_FILENAME;
+        rigel::loader::saveToFile(serializedBuffer, profileFilePath);
+
+        std::cout << "Profile successfully encoded.\n";
+      }
+    } else {
+      printUsage();
+    }
+  } catch (const std::exception& ex) {
+    std::cerr << "ERROR: " << ex.what() << '\n';
+    return 1;
+  }
+
+  return 0;
+}

--- a/src/common/user_profile.cpp
+++ b/src/common/user_profile.cpp
@@ -402,20 +402,6 @@ UserProfile loadProfile(const std::filesystem::path& profileFile) {
   return loadProfile(profileFile, profileFile);
 }
 
-
-void saveToFile(
-  const loader::ByteBuffer& buffer,
-  const std::filesystem::path& filePath
-) {
-  std::ofstream file(filePath.u8string(), std::ios::binary);
-  if (!file.is_open()) {
-    std::cerr << "WARNING: Failed to store user profile\n";
-    return;
-  }
-
-  file.write(reinterpret_cast<const char*>(buffer.data()), buffer.size());
-}
-
 }
 
 
@@ -467,7 +453,11 @@ void UserProfile::saveToDisk() {
   }
 
   const auto buffer = json::to_msgpack(serializedProfile);
-  saveToFile(buffer, *mProfilePath);
+  try {
+    loader::saveToFile(buffer, *mProfilePath);
+  } catch (const std::exception&) {
+    std::cerr << "WARNING: Failed to store user profile\n";
+  }
 }
 
 

--- a/src/common/user_profile.cpp
+++ b/src/common/user_profile.cpp
@@ -90,7 +90,6 @@ namespace {
 
 constexpr auto PREF_PATH_ORG_NAME = "lethal-guitar";
 constexpr auto PREF_PATH_APP_NAME = "Rigel Engine";
-constexpr auto USER_PROFILE_FILENAME = "UserProfile_v2.rigel";
 constexpr auto USER_PROFILE_FILENAME_V1 = "UserProfile.rigel";
 
 
@@ -485,7 +484,8 @@ UserProfile loadOrCreateUserProfile(const std::string& gamePath) {
     return {};
   }
 
-  const auto profileFilePath = *preferencesPath / USER_PROFILE_FILENAME;
+  const auto profileFilePath = *preferencesPath /
+    (std::string{USER_PROFILE_BASE_NAME} + USER_PROFILE_FILE_EXTENSION);
   if (fs::exists(profileFilePath)) {
     return loadProfile(profileFilePath);
   }

--- a/src/common/user_profile.hpp
+++ b/src/common/user_profile.hpp
@@ -27,6 +27,9 @@
 
 namespace rigel {
 
+constexpr auto USER_PROFILE_BASE_NAME = "UserProfile_v2";
+constexpr auto USER_PROFILE_FILE_EXTENSION = ".rigel";
+
 /** Store for user specific data
  *
  * The user profile stores data like saved games, high score lists, and game

--- a/src/loader/file_utils.cpp
+++ b/src/loader/file_utils.cpp
@@ -48,6 +48,20 @@ ByteBuffer loadFile(const string& fileName) {
 }
 
 
+void saveToFile(
+  const loader::ByteBuffer& buffer,
+  const std::filesystem::path& filePath
+) {
+  std::ofstream file(filePath.u8string(), std::ios::binary);
+  if (!file.is_open()) {
+    throw runtime_error(string("File can't be opened: ") + filePath.u8string());
+  }
+  file.exceptions(ios::failbit | ios::badbit);
+
+  file.write(reinterpret_cast<const char*>(buffer.data()), buffer.size());
+}
+
+
 std::string asText(const ByteBuffer& buffer) {
   const auto pBytesAsChars = reinterpret_cast<const char*>(buffer.data());
   return std::string(pBytesAsChars, pBytesAsChars + buffer.size());

--- a/src/loader/file_utils.hpp
+++ b/src/loader/file_utils.hpp
@@ -35,6 +35,10 @@ inline ByteBuffer loadFile(const std::filesystem::path& path) {
   return loadFile(path.u8string());
 }
 
+void saveToFile(
+  const loader::ByteBuffer& buffer,
+  const std::filesystem::path& filePath);
+
 std::string asText(const ByteBuffer& buffer);
 
 


### PR DESCRIPTION
Adds a new standalone executable called `UserProfileTool`, which can convert between binary and JSON encoding. This makes it easier to inspect and modify the user profile with a text editor, without changing the way the game itself stores the profile.

@pratikone what do you think?

Closes #460 