### PR TITLE
Allow switching game path from options menu

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -307,6 +307,7 @@ target_link_libraries(rigel_core
     entityx
     Boost::boost
     dear_imgui
+    imgui-filebrowser
 
     PRIVATE
     std::filesystem
@@ -350,6 +351,5 @@ target_link_libraries(${main_exe_name} PRIVATE
     Boost::boost
     Boost::program_options
     Boost::disable_autolinking
-    imgui-filebrowser
 )
 

--- a/src/base/container_utils.hpp
+++ b/src/base/container_utils.hpp
@@ -29,8 +29,8 @@ auto transformed(const RangeT& range, Callable elementTransform) {
   std::vector<std::invoke_result_t<Callable, decltype(*std::begin(range))>>
     result;
 
-  const auto start = std::cbegin(range);
-  const auto end = std::cend(range);
+  const auto start = std::begin(range);
+  const auto end = std::end(range);
   const auto distance = std::distance(start, end);
   if (distance > 0) {
     result.reserve(distance);
@@ -44,7 +44,7 @@ auto transformed(const RangeT& range, Callable elementTransform) {
 template<typename ContainerT>
 void appendTo(ContainerT& first, const ContainerT& second) {
   first.reserve(first.size() + second.size());
-  first.insert(first.end(), std::cbegin(second), std::cend(second));
+  first.insert(first.end(), std::begin(second), std::end(second));
 }
 
 

--- a/src/common/game_service_provider.hpp
+++ b/src/common/game_service_provider.hpp
@@ -19,6 +19,7 @@
 #include "data/game_session_data.hpp"
 #include "data/sound_ids.hpp"
 
+#include <filesystem>
 #include <string>
 
 namespace rigel::data { struct SavedGame; }
@@ -40,6 +41,7 @@ struct IGameServiceProvider {
   virtual void playMusic(const std::string& name) = 0;
   virtual void stopMusic() = 0;
   virtual void scheduleGameQuit() = 0;
+  virtual void switchGamePath(const std::filesystem::path& newGamePath) = 0;
   virtual bool isShareWareVersion() const = 0;
 };
 

--- a/src/data/game_session_data.hpp
+++ b/src/data/game_session_data.hpp
@@ -38,6 +38,10 @@ struct GameSessionId {
   {
   }
 
+  bool needsRegisteredVersion() const {
+    return mEpisode > 0;
+  }
+
   int mEpisode = 0;
   int mLevel = 0;
   Difficulty mDifficulty = Difficulty::Medium;

--- a/src/data/image.cpp
+++ b/src/data/image.cpp
@@ -73,7 +73,7 @@ void Image::insertImage(
     throw invalid_argument("Source image doesn't fit");
   }
 
-  auto sourceIter = pixels.cbegin();
+  auto sourceIter = pixels.begin();
   for (size_t row=0; row<inferredHeight; ++row) {
     for (size_t col=0; col<sourceWidth; ++col) {
       const auto targetOffset = (x+col) + (y+row)*mWidth;

--- a/src/engine/collision_checker.cpp
+++ b/src/engine/collision_checker.cpp
@@ -131,7 +131,7 @@ bool CollisionChecker::testVerticalSpan(
 bool CollisionChecker::testSolidBodyCollision(
   const BoundingBox& bboxToTest
 ) const {
-  return any_of(cbegin(mSolidBodies), cend(mSolidBodies),
+  return any_of(begin(mSolidBodies), end(mSolidBodies),
     [&bboxToTest](const ex::Entity& entity) {
       if (
         entity.has_component<BoundingBox>() &&

--- a/src/engine/imf_player.cpp
+++ b/src/engine/imf_player.cpp
@@ -62,7 +62,7 @@ void ImfPlayer::render(std::int16_t* pBuffer, std::size_t samplesRequired) {
     mSongSwitchPending = false;
     mAudioLock.unlock();
 
-    miNextCommand = mSongData.cbegin();
+    miNextCommand = mSongData.begin();
     mSamplesAvailable = 0;
   }
 
@@ -84,8 +84,8 @@ void ImfPlayer::render(std::int16_t* pBuffer, std::size_t samplesRequired) {
       commandDelay = command.delay;
       mEmulator.writeRegister(command.reg, command.value);
       ++miNextCommand;
-      if (miNextCommand == mSongData.cend()) {
-        miNextCommand = mSongData.cbegin();
+      if (miNextCommand == mSongData.end()) {
+        miNextCommand = mSongData.begin();
       }
     } while (commandDelay == 0);
 

--- a/src/engine/rendering_system.cpp
+++ b/src/engine/rendering_system.cpp
@@ -248,7 +248,7 @@ void RenderingSystem::update(
     mMapRenderer.renderBackground(*mpCameraPosition, viewPortSize);
 
     // behind foreground
-    for (auto it = spritesByDrawOrder.cbegin(); it != firstTopMostIt; ++it) {
+    for (auto it = spritesByDrawOrder.begin(); it != firstTopMostIt; ++it) {
       renderSprite(*it);
     }
   }
@@ -265,7 +265,7 @@ void RenderingSystem::update(
   mMapRenderer.renderForeground(*mpCameraPosition, viewPortSize);
 
   // top most
-  for (auto it = firstTopMostIt; it != spritesByDrawOrder.cend(); ++it) {
+  for (auto it = firstTopMostIt; it != spritesByDrawOrder.end(); ++it) {
     renderSprite(*it);
   }
 

--- a/src/engine/sound_system.cpp
+++ b/src/engine/sound_system.cpp
@@ -158,15 +158,15 @@ SoundHandle SoundSystem::addSound(const data::AudioBuffer& original) {
     conversionSpecs.len * conversionSpecs.len_mult);
   conversionSpecs.buf = reinterpret_cast<Uint8*>(tempBuffer.data());
   std::copy(
-    buffer.mSamples.cbegin(), buffer.mSamples.cend(), tempBuffer.begin());
+    buffer.mSamples.begin(), buffer.mSamples.end(), tempBuffer.begin());
 
   SDL_ConvertAudio(&conversionSpecs);
 
   data::AudioBuffer convertedBuffer{SAMPLE_RATE};
   convertedBuffer.mSamples.insert(
     convertedBuffer.mSamples.end(),
-    tempBuffer.cbegin(),
-    tempBuffer.cbegin() + conversionSpecs.len_cvt);
+    tempBuffer.begin(),
+    tempBuffer.begin() + conversionSpecs.len_cvt);
   return addConvertedSound(convertedBuffer);
 #else
   return addConvertedSound(buffer);

--- a/src/game_logic/effects_system.cpp
+++ b/src/game_logic/effects_system.cpp
@@ -67,8 +67,8 @@ void spawnEffects(
   effectSpawner.component<DestructionEffects>()->mActivated = true;
 
   const auto iHighestDelaySpec = std::max_element(
-    std::cbegin(effects.mEffectSpecs),
-    std::cend(effects.mEffectSpecs),
+    std::begin(effects.mEffectSpecs),
+    std::end(effects.mEffectSpecs),
     [](const auto& a, const auto& b) {
       return a.mDelay < b.mDelay;
     });

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -575,10 +575,7 @@ void Game::mainLoop() {
         mRenderer.submitBatch();
 
         if (mpUserProfile->mOptions.mShowFpsCounter) {
-          const auto afterRender = high_resolution_clock::now();
-          const auto innerRenderTime =
-            duration<engine::TimeDelta>(afterRender - startOfFrame).count();
-          mFpsDisplay.updateAndRender(elapsed, innerRenderTime);
+          mFpsDisplay.updateAndRender(elapsed);
         }
       }
     }

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -407,7 +407,8 @@ void gameMain(const StartupOptions& options) {
   SetProcessDPIAware();
 #endif
 
-  sdl_utils::check(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER));
+  sdl_utils::check(SDL_Init(
+    SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER));
   auto sdlGuard = defer([]() { SDL_Quit(); });
 
   sdl_utils::check(SDL_GL_LoadLibrary(nullptr));

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -296,6 +296,24 @@ std::filesystem::path runFolderBrowser(SDL_Window* pWindow)
   auto folderPath = std::filesystem::path();
   auto folderBrowser =
     ImGui::FileBrowser{ImGuiFileBrowserFlags_SelectDirectory};
+
+  // TODO: There is some code duplication with the game path browser in the
+  // options menu for setting the size and title, but until we've decided if we
+  // will merge those two into one by showing the options menu at first launch
+  // or not, we'll leave it like this. Should we decide against showing the
+  // options menu at first launch, we should extract some constants and helper
+  // functions to avoid this duplication.
+  folderBrowser.SetTitle("Choose Duke Nukem II installation");
+
+  {
+    int windowWidth = 0;
+    int windowHeight = 0;
+    SDL_GetWindowSize(pWindow, &windowWidth, &windowHeight);
+    folderBrowser.SetWindowSize(
+      base::round(windowWidth * 0.64f),
+      base::round(windowHeight * 0.64f));
+  }
+
   folderBrowser.Open();
 
   do

--- a/src/game_main.ipp
+++ b/src/game_main.ipp
@@ -74,6 +74,9 @@ private:
 
   void mainLoop();
   void pumpEvents(std::vector<SDL_Event>& eventQueue);
+  void updateAndRender(
+    entityx::TimeDelta elapsed,
+    const std::vector<SDL_Event>& eventQueue);
 
   GameMode::Context makeModeContext();
 

--- a/src/game_main.ipp
+++ b/src/game_main.ipp
@@ -57,6 +57,11 @@ private:
 
 class Game : public IGameServiceProvider {
 public:
+  enum class RunResult {
+    GameEnded,
+    RestartNeeded
+  };
+
   Game(
     const StartupOptions& startupOptions,
     UserProfile* pUserProfile,
@@ -64,7 +69,7 @@ public:
   Game(const Game&) = delete;
   Game& operator=(const Game&) = delete;
 
-  void run(const StartupOptions& options);
+  RunResult run(const StartupOptions& options);
 
 private:
   enum class FadeType {
@@ -72,7 +77,7 @@ private:
     Out
   };
 
-  void mainLoop();
+  RunResult mainLoop();
   void pumpEvents(std::vector<SDL_Event>& eventQueue);
   void updateAndRender(
     entityx::TimeDelta elapsed,
@@ -96,6 +101,8 @@ private:
   void stopMusic() override;
 
   void scheduleGameQuit() override;
+
+  void switchGamePath(const std::filesystem::path& newGamePath) override;
 
   bool isShareWareVersion() const override {
     return mIsShareWareVersion;
@@ -122,6 +129,7 @@ private:
 
   UserProfile* mpUserProfile;
   data::GameOptions mPreviousOptions;
+  std::filesystem::path mGamePathToSwitchTo;
 
   ui::DukeScriptRunner mScriptRunner;
   loader::ScriptBundle mAllScripts;

--- a/src/game_runner.cpp
+++ b/src/game_runner.cpp
@@ -231,7 +231,8 @@ bool GameRunner::handleMenuEnterEvent(const SDL_Event& event) {
         pWorld->mPlayerInput = {};
       }
       mStateStack.push(ui::OptionsMenu{
-        &mContext.mpUserProfile->mOptions,
+        mContext.mpUserProfile,
+        mContext.mpServiceProvider,
         ui::OptionsMenu::Type::InGame});
       break;
 

--- a/src/game_runner.cpp
+++ b/src/game_runner.cpp
@@ -326,7 +326,14 @@ void GameRunner::onRestoreGameMenuFinished(const ExecutionResult& result) {
     const auto slotIndex = result.mSelectedPage;
     const auto& slot = mContext.mpUserProfile->mSaveSlots[*slotIndex];
     if (slot) {
-      mRequestedGameToLoad = *slot;
+      if (
+        mContext.mpServiceProvider->isShareWareVersion() &&
+        slot->mSessionId.needsRegisteredVersion()
+      ) {
+        showErrorMessageScript("No_Can_Order");
+      } else {
+        mRequestedGameToLoad = *slot;
+      }
     } else {
       showErrorMessageScript("No_Game_Restore");
     }

--- a/src/game_runner.cpp
+++ b/src/game_runner.cpp
@@ -230,7 +230,9 @@ bool GameRunner::handleMenuEnterEvent(const SDL_Event& event) {
       if (auto pWorld = std::get_if<World>(&mStateStack.top())) {
         pWorld->mPlayerInput = {};
       }
-      mStateStack.push(ui::OptionsMenu{&mContext.mpUserProfile->mOptions});
+      mStateStack.push(ui::OptionsMenu{
+        &mContext.mpUserProfile->mOptions,
+        ui::OptionsMenu::Type::InGame});
       break;
 
     case SDLK_F2:

--- a/src/game_runner.cpp
+++ b/src/game_runner.cpp
@@ -300,6 +300,23 @@ void GameRunner::fadeToWorld() {
 
 
 void GameRunner::onRestoreGameMenuFinished(const ExecutionResult& result) {
+  auto showErrorMessageScript = [this](const char* scriptName) {
+    // When selecting a slot that can't be loaded, we show a message and
+    // then return to the save slot selection menu.  The latter stays on the
+    // stack, we push another menu state on top of the stack for showing the
+    // message.
+    enterMenu(
+      scriptName,
+      [this](const auto&) {
+        leaveMenu();
+        runScript(mContext, "Restore_Game");
+      },
+      noopEventHook,
+      false, // isTransparent
+      false); // shouldClearScriptCanvas
+  };
+
+
   using STT = ui::DukeScriptRunner::ScriptTerminationType;
 
   if (result.mTerminationType == STT::AbortedByUser) {
@@ -311,19 +328,7 @@ void GameRunner::onRestoreGameMenuFinished(const ExecutionResult& result) {
     if (slot) {
       mRequestedGameToLoad = *slot;
     } else {
-      // When selecting an empty slot, we show a message ("no game in this
-      // slot") and then return to the save slot selection menu.
-      // The latter stays on the stack, we push another menu state on top of
-      // the stack for showing the message.
-      enterMenu(
-        "No_Game_Restore",
-        [this](const auto&) {
-          leaveMenu();
-          runScript(mContext, "Restore_Game");
-        },
-        noopEventHook,
-        false, // isTransparent
-        false); // shouldClearScriptCanvas
+      showErrorMessageScript("No_Game_Restore");
     }
   }
 }

--- a/src/intro_demo_loop_mode.cpp
+++ b/src/intro_demo_loop_mode.cpp
@@ -147,7 +147,7 @@ std::unique_ptr<GameMode> IntroDemoLoopMode::updateAndRender(
       mCurrentStage = 0;
 
       if (mFirstRunIncludedStoryAnimation) {
-        const auto storyStageIter = mStages.cbegin() + 2;
+        const auto storyStageIter = mStages.begin() + 2;
         mStages.erase(storyStageIter);
         mFirstRunIncludedStoryAnimation = false;
       }

--- a/src/loader/actor_image_package.cpp
+++ b/src/loader/actor_image_package.cpp
@@ -162,7 +162,7 @@ data::Image ActorImagePackage::loadImage(
     throw invalid_argument("Not enough data");
   }
 
-  const auto dataStart = mImageData.cbegin() + frameHeader.mFileOffset;
+  const auto dataStart = mImageData.begin() + frameHeader.mFileOffset;
   return loadTiledImage(
     dataStart,
     dataStart + dataSize,
@@ -193,7 +193,7 @@ FontData ActorImagePackage::loadFont() const {
       throw runtime_error("Not enough data");
     }
 
-    const auto dataStart = mImageData.cbegin() + frameHeader.mFileOffset;
+    const auto dataStart = mImageData.begin() + frameHeader.mFileOffset;
     auto characterBitmap = loadTiledFontBitmap(
       dataStart,
       dataStart + dataSize,

--- a/src/loader/adlib_emulator.hpp
+++ b/src/loader/adlib_emulator.hpp
@@ -58,8 +58,8 @@ public:
       mEmulator.GenerateBlock2(
         static_cast<DBOPL::Bitu>(samplesForIteration), mTempBuffer.data());
       destination = std::transform(
-        mTempBuffer.cbegin(),
-        mTempBuffer.cbegin() + samplesForIteration,
+        mTempBuffer.begin(),
+        mTempBuffer.begin() + samplesForIteration,
         destination,
         [volumeScale](const auto sample32Bit) {
           return static_cast<std::int16_t>(

--- a/src/loader/audio_package.cpp
+++ b/src/loader/audio_package.cpp
@@ -100,7 +100,7 @@ AudioPackage::AudioPackage(
   for (auto i=34u; i<68u; ++i) {
     const auto& dictEntry = audioDict[i];
 
-    const auto soundStartIter = bundledAudioData.cbegin() + dictEntry.mOffset;
+    const auto soundStartIter = bundledAudioData.begin() + dictEntry.mOffset;
     LeStreamReader reader(soundStartIter, soundStartIter + dictEntry.mSize);
     mSounds.emplace_back(reader);
   }

--- a/src/loader/cmp_file_package.cpp
+++ b/src/loader/cmp_file_package.cpp
@@ -49,7 +49,7 @@ std::string normalizedFileName(const std::string& fileName) {
 CMPFilePackage::CMPFilePackage(const string& filePath)
   : mFileData(loadFile(filePath))
 {
-  LeStreamReader dictReader(mFileData.cbegin(), mFileData.cend());
+  LeStreamReader dictReader(mFileData.begin(), mFileData.end());
 
   while (dictReader.hasData()) {
     const auto fileName = readFixedSizeString(dictReader, 12);

--- a/src/loader/duke_script_loader.cpp
+++ b/src/loader/duke_script_loader.cpp
@@ -289,9 +289,9 @@ vector<Action> parseTextCommandWithBigText(
   vector<Action> textActions;
 
   const auto numPrecedingCharacters = static_cast<int>(
-    distance(sourceText.cbegin(), bigTextMarkerIter));
+    distance(sourceText.begin(), bigTextMarkerIter));
   if (numPrecedingCharacters > 0) {
-    string regularTextPart(sourceText.cbegin(), bigTextMarkerIter);
+    string regularTextPart(sourceText.begin(), bigTextMarkerIter);
     textActions.emplace_back(DrawText{x, y, regularTextPart});
   }
 
@@ -299,7 +299,7 @@ vector<Action> parseTextCommandWithBigText(
     numPrecedingCharacters * GameTraits::menuFontCharacterBitmapSizeTiles.width;
 
   const auto colorIndex = static_cast<uint8_t>(*bigTextMarkerIter) - 0xF0;
-  string bigTextPart(next(bigTextMarkerIter), sourceText.cend());
+  string bigTextPart(next(bigTextMarkerIter), sourceText.end());
   textActions.emplace_back(DrawBigText{
     x + positionOffset,
     y,
@@ -316,8 +316,8 @@ Action parseDrawSpriteCommand(const int x, const int y, const string& source) {
     throw invalid_argument("Corrupt Duke Script file");
   }
 
-  string actorNumberString(source.cbegin() + 1, source.cbegin() + 4);
-  string frameNumberString(source.cbegin() + 4, source.cbegin() + 6);
+  string actorNumberString(source.begin() + 1, source.begin() + 4);
+  string frameNumberString(source.begin() + 4, source.begin() + 6);
 
   return {DrawSprite{
     x + 2,
@@ -372,11 +372,11 @@ vector<Action> parseTextCommand(istream& lineTextStream) {
     textActions.emplace_back(parseDrawSpriteCommand(x, y, sourceText));
   } else {
     const auto bigTextMarkerIter =
-      std::find_if(sourceText.cbegin(), sourceText.cend(), [](const auto ch) {
+      std::find_if(sourceText.begin(), sourceText.end(), [](const auto ch) {
         return static_cast<uint8_t>(ch) >= 0xF0;
       });
 
-    if (bigTextMarkerIter != sourceText.cend()) {
+    if (bigTextMarkerIter != sourceText.end()) {
       return parseTextCommandWithBigText(x, y, sourceText, bigTextMarkerIter);
     } else {
       textActions.emplace_back(DrawText{x, y, sourceText});
@@ -442,7 +442,7 @@ PagesDefinition parsePagesDefinition(
         const auto actions = parseCommand(
           command, sourceTextStream, lineTextStream);
         auto& currentPage = pages.back();
-        currentPage.insert(currentPage.end(), actions.cbegin(), actions.cend());
+        currentPage.insert(currentPage.end(), actions.begin(), actions.end());
       }
     });
 
@@ -465,7 +465,7 @@ data::script::Script parseScript(istream& sourceTextStream) {
         actions = parseCommand(command, sourceTextStream, lineTextStream);
       }
 
-      script.insert(script.end(), actions.cbegin(), actions.cend());
+      script.insert(script.end(), actions.begin(), actions.end());
     });
 
   return script;

--- a/src/loader/ega_image_decoder.hpp
+++ b/src/loader/ega_image_decoder.hpp
@@ -45,8 +45,8 @@ inline data::Image loadTiledImage(
   const data::TileImageType type = data::TileImageType::Unmasked
 ) {
   return loadTiledImage(
-    data.cbegin(),
-    data.cend(),
+    data.begin(),
+    data.end(),
     widthInTiles,
     palette,
     type);

--- a/src/loader/file_utils.cpp
+++ b/src/loader/file_utils.cpp
@@ -69,7 +69,7 @@ std::string asText(const ByteBuffer& buffer) {
 
 
 LeStreamReader::LeStreamReader(const ByteBuffer& data)
-  : LeStreamReader(data.cbegin(), data.cend())
+  : LeStreamReader(data.begin(), data.end())
 {
 }
 

--- a/src/loader/palette.hpp
+++ b/src/loader/palette.hpp
@@ -39,12 +39,12 @@ Palette256 load6bitPalette256(ByteBufferCIter begin, ByteBufferCIter end);
 
 
 inline Palette16 load6bitPalette16(const ByteBuffer& buffer) {
-  return load6bitPalette16(buffer.cbegin(), buffer.cend());
+  return load6bitPalette16(buffer.begin(), buffer.end());
 }
 
 
 inline Palette256 load6bitPalette256(const ByteBuffer& buffer) {
-  return load6bitPalette256(buffer.cbegin(), buffer.cend());
+  return load6bitPalette256(buffer.begin(), buffer.end());
 }
 
 }

--- a/src/loader/resource_loader.cpp
+++ b/src/loader/resource_loader.cpp
@@ -104,14 +104,14 @@ data::Image ResourceLoader::loadStandaloneFullscreenImage(
   const std::string& name
 ) const {
   const auto& data = file(name);
-  const auto paletteStart = data.cbegin() + FULL_SCREEN_IMAGE_DATA_SIZE;
+  const auto paletteStart = data.begin() + FULL_SCREEN_IMAGE_DATA_SIZE;
   const auto palette = load6bitPalette16(
     paletteStart,
-    data.cend());
+    data.end());
 
   auto pixels = decodeSimplePlanarEgaBuffer(
-    data.cbegin(),
-    data.cbegin() + FULL_SCREEN_IMAGE_DATA_SIZE,
+    data.begin(),
+    data.begin() + FULL_SCREEN_IMAGE_DATA_SIZE,
     palette);
   return data::Image(
     std::move(pixels),
@@ -129,12 +129,12 @@ data::Image ResourceLoader::loadAntiPiracyImage() const {
   //
   // See http://www.shikadi.net/moddingwiki/Duke_Nukem_II_Full-screen_Images
   const auto& data = file(ANTI_PIRACY_SCREEN_FILENAME);
-  const auto iImageStart = cbegin(data) + 256*3;
-  const auto palette = load6bitPalette256(cbegin(data), iImageStart);
+  const auto iImageStart = begin(data) + 256*3;
+  const auto palette = load6bitPalette256(begin(data), iImageStart);
 
   data::PixelBuffer pixels;
   pixels.reserve(GameTraits::viewPortWidthPx * GameTraits::viewPortHeightPx);
-  transform(iImageStart, cend(data), back_inserter(pixels),
+  transform(iImageStart, end(data), back_inserter(pixels),
     [&palette](const auto indexedPixel) { return palette[indexedPixel]; });
   return data::Image(
     move(pixels),
@@ -147,8 +147,8 @@ loader::Palette16 ResourceLoader::loadPaletteFromFullScreenImage(
   const std::string& imageName
 ) const {
   const auto& data = file(imageName);
-  const auto paletteStart = data.cbegin() + FULL_SCREEN_IMAGE_DATA_SIZE;
-  return load6bitPalette16(paletteStart, data.cend());
+  const auto paletteStart = data.begin() + FULL_SCREEN_IMAGE_DATA_SIZE;
+  return load6bitPalette16(paletteStart, data.end());
 }
 
 
@@ -159,7 +159,7 @@ TileSet ResourceLoader::loadCZone(const std::string& name) const {
 
   const auto& data = file(name);
   LeStreamReader attributeReader(
-    data.cbegin(), data.cbegin() + GameTraits::CZone::attributeBytesTotal);
+    data.begin(), data.begin() + GameTraits::CZone::attributeBytesTotal);
 
   vector<uint16_t> attributes;
   attributes.reserve(GameTraits::CZone::numTilesTotal);
@@ -176,7 +176,7 @@ TileSet ResourceLoader::loadCZone(const std::string& name) const {
     tilesToPixels(GameTraits::CZone::tileSetImageHeight));
 
   const auto tilesBegin =
-    data.cbegin() + GameTraits::CZone::attributeBytesTotal;
+    data.begin() + GameTraits::CZone::attributeBytesTotal;
   const auto maskedTilesBegin =
     tilesBegin + GameTraits::CZone::numSolidTiles*GameTraits::CZone::tileBytes;
 
@@ -188,7 +188,7 @@ TileSet ResourceLoader::loadCZone(const std::string& name) const {
     T::Unmasked);
   const auto maskedTilesImage = loadTiledImage(
     maskedTilesBegin,
-    data.cend(),
+    data.end(),
     GameTraits::CZone::tileSetImageWidth,
     INGAME_PALETTE,
     T::Masked);

--- a/src/menu_mode.cpp
+++ b/src/menu_mode.cpp
@@ -95,7 +95,8 @@ void MenuMode::handleEvent(const SDL_Event& event) {
        event.cbutton.button == SDL_CONTROLLER_BUTTON_A))
     ) {
       mOptionsMenu = ui::OptionsMenu{
-        &mContext.mpUserProfile->mOptions,
+        mContext.mpUserProfile,
+        mContext.mpServiceProvider,
         ui::OptionsMenu::Type::Main};
       return;
     }

--- a/src/menu_mode.cpp
+++ b/src/menu_mode.cpp
@@ -94,7 +94,9 @@ void MenuMode::handleEvent(const SDL_Event& event) {
       (event.type == SDL_CONTROLLERBUTTONDOWN &&
        event.cbutton.button == SDL_CONTROLLER_BUTTON_A))
     ) {
-      mOptionsMenu = ui::OptionsMenu{&mContext.mpUserProfile->mOptions};
+      mOptionsMenu = ui::OptionsMenu{
+        &mContext.mpUserProfile->mOptions,
+        ui::OptionsMenu::Type::Main};
       return;
     }
   }

--- a/src/menu_mode.cpp
+++ b/src/menu_mode.cpp
@@ -267,7 +267,15 @@ std::unique_ptr<GameMode> MenuMode::navigateToNextMenu(
         const auto slotIndex = *result.mSelectedPage;
         const auto& slot = mContext.mpUserProfile->mSaveSlots[slotIndex];
         if (slot) {
-          return std::make_unique<GameSessionMode>(*slot, mContext);
+          if (
+            mContext.mpServiceProvider->isShareWareVersion() &&
+            slot->mSessionId.needsRegisteredVersion()
+          ) {
+            runScript(mContext, "No_Can_Order");
+            mMenuState = MenuState::NoSavedGameInSlotMessage;
+          } else {
+            return std::make_unique<GameSessionMode>(*slot, mContext);
+          }
         } else {
           runScript(mContext, "No_Game_Restore");
           mMenuState = MenuState::NoSavedGameInSlotMessage;

--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -508,7 +508,7 @@ void Renderer::drawTexture(
   fillVertexPositions(destRect, std::begin(vertices), 0, 4);
   fillTexCoords(sourceRect, textureData, std::begin(vertices), 2, 4);
 
-  batchQuadVertices(std::cbegin(vertices), std::cend(vertices), 4u);
+  batchQuadVertices(std::begin(vertices), std::end(vertices), 4u);
 }
 
 
@@ -635,7 +635,7 @@ void Renderer::drawPoint(
     color.a / 255.0f
   };
   mBatchData.insert(
-    std::end(mBatchData), std::cbegin(vertices), std::cend(vertices));
+    std::end(mBatchData), std::begin(vertices), std::end(vertices));
 }
 
 
@@ -671,7 +671,7 @@ void Renderer::drawWaterEffect(
     fillTexCoords(
       animSourceRect, mWaterSurfaceAnimTexture, std::begin(vertices), 2, 4);
 
-    batchQuadVertices(std::cbegin(vertices), std::cend(vertices), 4);
+    batchQuadVertices(std::begin(vertices), std::end(vertices), 4);
   };
 
   setRenderModeIfChanged(RenderMode::WaterEffect);
@@ -818,8 +818,8 @@ void Renderer::batchQuadVertices(
 
   GLushort indices[6];
   transform(
-    cbegin(QUAD_INDICES),
-    cend(QUAD_INDICES),
+    begin(QUAD_INDICES),
+    end(QUAD_INDICES),
     begin(indices),
     [&](const GLushort index) -> GLushort {
       return index + currentIndex;
@@ -830,7 +830,7 @@ void Renderer::batchQuadVertices(
     mBatchData.end(),
     forward<VertexIter>(dataBegin),
     forward<VertexIter>(dataEnd));
-  mBatchIndices.insert(mBatchIndices.end(), cbegin(indices), cend(indices));
+  mBatchIndices.insert(mBatchIndices.end(), begin(indices), end(indices));
 }
 
 

--- a/src/ui/fps_display.cpp
+++ b/src/ui/fps_display.cpp
@@ -35,10 +35,7 @@ const auto FILTER_WEIGHT = 0.9f;
 }
 
 
-void FpsDisplay::updateAndRender(
-  const engine::TimeDelta totalElapsed,
-  const engine::TimeDelta renderingElapsed
-) {
+void FpsDisplay::updateAndRender(const engine::TimeDelta totalElapsed) {
   mPreFilteredFrameTime = base::lerp(
     static_cast<float>(totalElapsed), mPreFilteredFrameTime, PRE_FILTER_WEIGHT);
   mFilteredFrameTime = base::lerp(
@@ -50,8 +47,7 @@ void FpsDisplay::updateAndRender(
   statsReport
     << smoothedFps << " FPS, "
     << std::setw(4) << std::fixed << std::setprecision(2)
-    << totalElapsed * 1000.0 << " ms, "
-    << renderingElapsed * 1000.0 << " ms (inner)";
+    << totalElapsed * 1000.0 << " ms";
 
   const auto reportString = statsReport.str();
   drawText(reportString, 0, 0, {255, 255, 255, 255});

--- a/src/ui/fps_display.hpp
+++ b/src/ui/fps_display.hpp
@@ -23,9 +23,8 @@ namespace rigel::ui {
 
 class FpsDisplay {
 public:
-  void updateAndRender(
-    engine::TimeDelta totalElapsed,
-    engine::TimeDelta renderingElapsed);
+  void updateAndRender(engine::TimeDelta elapsed);
+
 
 private:
   float mPreFilteredFrameTime = 0.0f;

--- a/src/ui/hud_renderer.cpp
+++ b/src/ui/hud_renderer.cpp
@@ -273,10 +273,10 @@ void HudRenderer::render(
   const auto inventoryStartPos = base::Vector{
     topRightTexturePosX + GameTraits::tileSize,
     2*GameTraits::tileSize};
-  auto inventoryIter = playerModel.inventory().cbegin();
+  auto inventoryIter = playerModel.inventory().begin();
   for (int row = 0; row < 3; ++row) {
     for (int col = 0; col < 2; ++col) {
-      if (inventoryIter != playerModel.inventory().cend()) {
+      if (inventoryIter != playerModel.inventory().end()) {
         const auto itemType = *inventoryIter++;
         const auto drawPos =
           inventoryStartPos + base::Vector{col, row} * GameTraits::tileSize*2;

--- a/src/ui/options_menu.hpp
+++ b/src/ui/options_menu.hpp
@@ -24,8 +24,14 @@ namespace rigel::ui {
 
 class OptionsMenu {
 public:
-  OptionsMenu(data::GameOptions* pOptions)
+  enum class Type {
+    Main,
+    InGame
+  };
+
+  OptionsMenu(data::GameOptions* pOptions, const Type type)
     : mpOptions(pOptions)
+    , mType(type)
   {
   }
 
@@ -34,6 +40,7 @@ public:
 
 private:
   data::GameOptions* mpOptions;
+  Type mType;
   bool mMenuOpen = true;
 };
 

--- a/src/ui/options_menu.hpp
+++ b/src/ui/options_menu.hpp
@@ -16,8 +16,19 @@
 
 #pragma once
 
+#include "base/warnings.hpp"
 #include "data/game_options.hpp"
 #include "engine/timing.hpp"
+
+RIGEL_DISABLE_WARNINGS
+#include <imfilebrowser.h>
+RIGEL_RESTORE_WARNINGS
+
+
+namespace rigel {
+  struct IGameServiceProvider;
+  class UserProfile;
+}
 
 
 namespace rigel::ui {
@@ -29,19 +40,22 @@ public:
     InGame
   };
 
-  OptionsMenu(data::GameOptions* pOptions, const Type type)
-    : mpOptions(pOptions)
-    , mType(type)
-  {
-  }
+  OptionsMenu(
+    UserProfile* pUserProfile,
+    IGameServiceProvider* pServiceProvider,
+    Type type);
 
   void updateAndRender(engine::TimeDelta dt);
   bool isFinished() const;
 
 private:
+  ImGui::FileBrowser mGamePathBrowser;
+  UserProfile* mpUserProfile;
   data::GameOptions* mpOptions;
+  IGameServiceProvider* mpServiceProvider;
   Type mType;
   bool mMenuOpen = true;
+  bool mShowErrorBox = false;
 };
 
 }

--- a/test/utils.hpp
+++ b/test/utils.hpp
@@ -45,6 +45,7 @@ struct MockServiceProvider : public rigel::IGameServiceProvider {
   void playMusic(const std::string&) override {}
   void stopMusic() override {}
   void scheduleGameQuit() override {}
+  void switchGamePath(const std::filesystem::path&) override {}
   bool isShareWareVersion() const override { return false; }
 
   std::optional<rigel::data::SoundId> mLastTriggeredSoundId;


### PR DESCRIPTION
This adds a button to the options menu, which allows choosing a different game path using the UI. Handy when a user wants to switch from a shareware install to a registered version install, for example.

The button is only shown in the main menu's options menu. When a valid new path is chosen, the game restarts itself to load resources from the new path, and stores the new path in the user profile.