### PR TITLE
Godmode and fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
             - sdl2
             - sdl2_mixer
             - llvm@8
+            - z3
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set(core_sources
     base/math_tools.hpp
     base/spatial_types.hpp
     base/warnings.hpp
+    common/command_line_options.hpp
     common/game_mode.cpp
     common/game_mode.hpp
     common/game_service_provider.hpp

--- a/src/common/command_line_options.hpp
+++ b/src/common/command_line_options.hpp
@@ -25,7 +25,7 @@
 
 namespace rigel {
 
-struct StartupOptions {
+struct CommandLineOptions {
   std::string mGamePath;
   std::optional<std::pair<int, int>> mLevelToJumpTo;
   bool mSkipIntro = false;

--- a/src/common/command_line_options.hpp
+++ b/src/common/command_line_options.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016, Nikolai Wuttke. All rights reserved.
+/* Copyright (C) 2020, Nikolai Wuttke. All rights reserved.
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -16,11 +16,21 @@
 
 #pragma once
 
-#include "common/command_line_options.hpp"
+#include "base/spatial_types.hpp"
+
+#include <optional>
+#include <string>
+#include <utility>
 
 
 namespace rigel {
 
-void gameMain(const StartupOptions& options);
+struct StartupOptions {
+  std::string mGamePath;
+  std::optional<std::pair<int, int>> mLevelToJumpTo;
+  bool mSkipIntro = false;
+  bool mDebugModeEnabled = false;
+  std::optional<base::Vector> mPlayerPosition;
+};
 
 }

--- a/src/common/game_service_provider.hpp
+++ b/src/common/game_service_provider.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "common/command_line_options.hpp"
 #include "data/game_session_data.hpp"
 #include "data/sound_ids.hpp"
 
@@ -43,6 +44,7 @@ struct IGameServiceProvider {
   virtual void scheduleGameQuit() = 0;
   virtual void switchGamePath(const std::filesystem::path& newGamePath) = 0;
   virtual bool isShareWareVersion() const = 0;
+  virtual const StartupOptions& commandLineOptions() const = 0;
 };
 
 }

--- a/src/common/game_service_provider.hpp
+++ b/src/common/game_service_provider.hpp
@@ -44,7 +44,7 @@ struct IGameServiceProvider {
   virtual void scheduleGameQuit() = 0;
   virtual void switchGamePath(const std::filesystem::path& newGamePath) = 0;
   virtual bool isShareWareVersion() const = 0;
-  virtual const StartupOptions& commandLineOptions() const = 0;
+  virtual const CommandLineOptions& commandLineOptions() const = 0;
 };
 
 }

--- a/src/engine/movement.cpp
+++ b/src/engine/movement.cpp
@@ -274,10 +274,40 @@ void applyConveyorBeltMotion(
     });
   };
 
+  // NOTE: Using stair stepping is not 100% reproducing what the original game
+  // does, but it works out to the same as far as I can tell.
+  // In the original, the player always uses stair stepping when in regular
+  // state (OnGround). Other actors don't use stair stepping, but there is some
+  // code in the physics update right before applying conveyor belt motion,
+  // which makes the sloped conveyors in N7 work. It looks roughly like this:
+  //
+  //  if (actor currently colliding with ground) {
+  //    --actor.y;
+  //  }
+  //
+  // Due to the way the level is laid out in N7, this works out to pushing
+  // the actor upwards by one first, before doing the conveyor belt motion.
+  // Due to being pushed up, the actor is not colliding on the right anymore,
+  // and can be moved. Visually, this looks as follows:
+  //
+  //   1.         2.         3.         4.
+  //       _          _          _          _
+  //     _ _|       _ _|       X _|       _ X|
+  //   X _|       _ X|       _ _|       _ _|
+  //
+  // On step 2, the actor has reached the beginning of the slope. Due to the
+  // solid edge on the right, the actor cannot move to the right. But, notice
+  // the horizontal edge above the actor. This effectively makes the actor
+  // 'stuck in the ground', which triggers the code above and pushes the actor
+  // up by one in step 3. On step 4, the actor is now free to move to the
+  // right.
+  //
+  // I'm not sure why this was done this way, instead of using stair stepping
+  // for conveyor belt motion.
   if (anyFlagIs(ConveyorBeltFlag::Left)) {
-    moveHorizontally(collisionChecker, entity, -1);
+    moveHorizontallyWithStairStepping(collisionChecker, entity, -1);
   } else if (anyFlagIs(ConveyorBeltFlag::Right)) {
-    moveHorizontally(collisionChecker, entity, 1);
+    moveHorizontallyWithStairStepping(collisionChecker, entity, 1);
   }
 }
 

--- a/src/game_logic/game_world.cpp
+++ b/src/game_logic/game_world.cpp
@@ -39,7 +39,6 @@
 #include <cassert>
 #include <chrono>
 #include <iostream>
-#include <sstream>
 
 
 namespace rigel::game_logic {
@@ -798,13 +797,9 @@ void GameWorld::showTutorialMessage(const data::TutorialMessageId id) {
 }
 
 
-void GameWorld::showDebugText() {
-  std::stringstream infoText;
-  mpSystems->printDebugText(infoText);
-  infoText
-    << "Entities: " << mEntities.size();
-
-  ui::drawText(infoText.str(), 0, 32, {255, 255, 255, 255});
+void GameWorld::printDebugText(std::ostream& stream) const {
+  mpSystems->printDebugText(stream);
+  stream << "Entities: " << mEntities.size() << '\n';
 }
 
 }

--- a/src/game_logic/game_world.hpp
+++ b/src/game_logic/game_world.hpp
@@ -38,6 +38,7 @@ RIGEL_DISABLE_WARNINGS
 #include <entityx/entityx.h>
 RIGEL_RESTORE_WARNINGS
 
+#include <iosfwd>
 #include <optional>
 #include <vector>
 
@@ -98,7 +99,7 @@ private:
   void updateTemporaryItemExpiration();
   void showTutorialMessage(const data::TutorialMessageId id);
 
-  void showDebugText();
+  void printDebugText(std::ostream& stream) const;
 
 private:
   struct LevelBonusInfo {

--- a/src/game_logic/ingame_systems.cpp
+++ b/src/game_logic/ingame_systems.cpp
@@ -89,7 +89,7 @@ IngameSystems::IngameSystems(
       pEntityFactory,
       &eventManager,
       resources)
-  , mPlayerDamageSystem(&mPlayer, &eventManager)
+  , mPlayerDamageSystem(&mPlayer)
   , mPlayerProjectileSystem(
       pEntityFactory,
       pServiceProvider,

--- a/src/game_logic/player.cpp
+++ b/src/game_logic/player.cpp
@@ -504,6 +504,11 @@ void Player::takeDamage(const int amount) {
 }
 
 
+void Player::takeFatalDamage() {
+  die();
+}
+
+
 void Player::die() {
   if (stateIs<InShip>()) {
     exitShip();

--- a/src/game_logic/player.cpp
+++ b/src/game_logic/player.cpp
@@ -494,6 +494,7 @@ void Player::takeDamage(const int amount) {
     return;
   }
 
+  mpEvents->emit(rigel::events::PlayerTookDamage{});
   mpPlayerModel->takeDamage(amount);
   if (!mpPlayerModel->isDead()) {
     mMercyFramesRemaining = mMercyFramesPerHit;
@@ -505,6 +506,7 @@ void Player::takeDamage(const int amount) {
 
 
 void Player::takeFatalDamage() {
+  mpEvents->emit(rigel::events::PlayerTookDamage{});
   die();
 }
 

--- a/src/game_logic/player.cpp
+++ b/src/game_logic/player.cpp
@@ -490,7 +490,7 @@ void Player::update(const PlayerInput& unfilteredInput) {
 
 
 void Player::takeDamage(const int amount) {
-  if (isDead() || mMercyFramesRemaining > 0) {
+  if (isDead() || mMercyFramesRemaining > 0 || mGodModeOn) {
     return;
   }
 
@@ -506,8 +506,10 @@ void Player::takeDamage(const int amount) {
 
 
 void Player::takeFatalDamage() {
-  mpEvents->emit(rigel::events::PlayerTookDamage{});
-  die();
+  if (!mGodModeOn) {
+    mpEvents->emit(rigel::events::PlayerTookDamage{});
+    die();
+  }
 }
 
 

--- a/src/game_logic/player.hpp
+++ b/src/game_logic/player.hpp
@@ -216,6 +216,7 @@ public:
   void update(const PlayerInput& inputs);
 
   void takeDamage(int amount);
+  void takeFatalDamage();
   void die();
 
   void enterShip(

--- a/src/game_logic/player.hpp
+++ b/src/game_logic/player.hpp
@@ -219,6 +219,12 @@ public:
   void takeFatalDamage();
   void die();
 
+  /** Set to true to prevent player taking damage (fatal or regular) */
+  // For simplicity, this a public member instead of a getter/setter pair.
+  // There is no need to encapsulate this state, and should we ever need to
+  // in the future, it's easy to introduce a setter/getter then.
+  bool mGodModeOn = false;
+
   void enterShip(
     const base::Vector& shipPosition,
     engine::components::Orientation shipOrientation);

--- a/src/game_logic/player/damage_system.cpp
+++ b/src/game_logic/player/damage_system.cpp
@@ -62,7 +62,7 @@ void DamageSystem::update(entityx::EntityManager& es) {
         mpEvents->emit(rigel::events::PlayerTookDamage{});
 
         if (damage.mIsFatal) {
-          mpPlayer->die();
+          mpPlayer->takeFatalDamage();
         } else {
           mpPlayer->takeDamage(damage.mAmount);
         }

--- a/src/game_logic/player/damage_system.cpp
+++ b/src/game_logic/player/damage_system.cpp
@@ -33,9 +33,8 @@ using engine::toWorldSpace;
 using game_logic::components::PlayerDamaging;
 
 
-DamageSystem::DamageSystem(Player* pPlayer, entityx::EventManager* pEvents)
+DamageSystem::DamageSystem(Player* pPlayer)
   : mpPlayer(pPlayer)
-  , mpEvents(pEvents)
 {
 }
 
@@ -59,8 +58,6 @@ void DamageSystem::update(entityx::EntityManager& es) {
         mpPlayer->canTakeDamage() || damage.mIsFatal;
 
       if (hasCollision && playerCanTakeDamage) {
-        mpEvents->emit(rigel::events::PlayerTookDamage{});
-
         if (damage.mIsFatal) {
           mpPlayer->takeFatalDamage();
         } else {

--- a/src/game_logic/player/damage_system.hpp
+++ b/src/game_logic/player/damage_system.hpp
@@ -30,13 +30,12 @@ namespace rigel::game_logic::player {
 
 class DamageSystem {
 public:
-  explicit DamageSystem(Player* pPlayer, entityx::EventManager* pEvents);
+  explicit DamageSystem(Player* pPlayer);
 
   void update(entityx::EntityManager& es);
 
 private:
   Player* mpPlayer;
-  entityx::EventManager* mpEvents;
 };
 
 }

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -422,10 +422,12 @@ void initAndRunGame(
   // Some game option changes (like choosing a new game path) require
   // restarting the game to make the change effective. If the first game run
   // ended with a result of RestartNeeded, launch a new game, but start from
-  // the main menu and discard command line options.
+  // the main menu and discard most command line options.
   if (result == Game::RunResult::RestartNeeded) {
     auto optionsForRestartedGame = CommandLineOptions{};
     optionsForRestartedGame.mSkipIntro = true;
+    optionsForRestartedGame.mDebugModeEnabled =
+      commandLineOptions.mDebugModeEnabled;
 
     while (result == Game::RunResult::RestartNeeded) {
       result = run(optionsForRestartedGame);

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -410,7 +410,7 @@ void initAndRunGame(
 ) {
   auto run = [&](const StartupOptions& options) {
     Game game(options, &userProfile, pWindow);
-    return game.run(options);
+    return game.run();
   };
 
   if (!userProfile.mGamePath) {
@@ -526,6 +526,7 @@ Game::Game(
       mRenderer.maxWindowSize().height)
   , mIsRunning(true)
   , mIsMinimized(false)
+  , mCommandLineOptions(startupOptions)
   , mpUserProfile(pUserProfile)
   , mScriptRunner(&mResources, &mRenderer, &mpUserProfile->mSaveSlots, this)
   , mAllScripts(loadScripts(mResources))
@@ -538,7 +539,7 @@ Game::Game(
 }
 
 
-auto Game::run(const StartupOptions& startupOptions) -> RunResult {
+auto Game::run() -> RunResult {
   mRenderer.clear();
   mRenderer.swapBuffers();
 
@@ -549,7 +550,7 @@ auto Game::run(const StartupOptions& startupOptions) -> RunResult {
   applyChangedOptions();
 
   mpCurrentGameMode = wrapWithInitialFadeIn(createInitialGameMode(
-    makeModeContext(), startupOptions, mIsShareWareVersion));
+    makeModeContext(), mCommandLineOptions, mIsShareWareVersion));
 
   //TODO : support multiple controllers
   for (std::uint8_t i = 0; i < SDL_NumJoysticks(); ++i) {

--- a/src/game_main.hpp
+++ b/src/game_main.hpp
@@ -21,6 +21,6 @@
 
 namespace rigel {
 
-void gameMain(const StartupOptions& options);
+void gameMain(const CommandLineOptions& options);
 
 }

--- a/src/game_main.ipp
+++ b/src/game_main.ipp
@@ -69,7 +69,7 @@ public:
   Game(const Game&) = delete;
   Game& operator=(const Game&) = delete;
 
-  RunResult run(const StartupOptions& options);
+  RunResult run();
 
 private:
   enum class FadeType {
@@ -108,6 +108,10 @@ private:
     return mIsShareWareVersion;
   }
 
+  const StartupOptions& commandLineOptions() const override {
+    return mCommandLineOptions;
+  }
+
 private:
   SDL_Window* mpWindow;
   renderer::Renderer mRenderer;
@@ -127,6 +131,7 @@ private:
   bool mIsMinimized;
   std::chrono::high_resolution_clock::time_point mLastTime;
 
+  StartupOptions mCommandLineOptions;
   UserProfile* mpUserProfile;
   data::GameOptions mPreviousOptions;
   std::filesystem::path mGamePathToSwitchTo;

--- a/src/game_main.ipp
+++ b/src/game_main.ipp
@@ -63,7 +63,7 @@ public:
   };
 
   Game(
-    const StartupOptions& startupOptions,
+    const CommandLineOptions& commandLineOptions,
     UserProfile* pUserProfile,
     SDL_Window* pWindow);
   Game(const Game&) = delete;
@@ -108,7 +108,7 @@ private:
     return mIsShareWareVersion;
   }
 
-  const StartupOptions& commandLineOptions() const override {
+  const CommandLineOptions& commandLineOptions() const override {
     return mCommandLineOptions;
   }
 
@@ -131,7 +131,7 @@ private:
   bool mIsMinimized;
   std::chrono::high_resolution_clock::time_point mLastTime;
 
-  StartupOptions mCommandLineOptions;
+  CommandLineOptions mCommandLineOptions;
   UserProfile* mpUserProfile;
   data::GameOptions mPreviousOptions;
   std::filesystem::path mGamePathToSwitchTo;

--- a/src/game_runner.cpp
+++ b/src/game_runner.cpp
@@ -130,6 +130,12 @@ void GameRunner::handleEvent(const SDL_Event& event) {
     [&event, this](World& state) {
       if (!handleMenuEnterEvent(event)) {
         state.handleEvent(event);
+
+        const auto debugModeEnabled =
+          mContext.mpServiceProvider->commandLineOptions().mDebugModeEnabled;
+        if (debugModeEnabled) {
+          state.handleDebugKeys(event);
+        }
       }
     },
 
@@ -370,7 +376,6 @@ void GameRunner::saveGame(const int slotIndex, std::string_view name) {
 void GameRunner::World::handleEvent(const SDL_Event& event) {
   handlePlayerKeyboardInput(event);
   handlePlayerGameControllerInput(event);
-  handleDebugKeys(event);
 }
 
 

--- a/src/game_runner.cpp
+++ b/src/game_runner.cpp
@@ -21,6 +21,7 @@
 #include "common/user_profile.hpp"
 #include "game_logic/ingame_systems.hpp"
 #include "loader/resource_loader.hpp"
+#include "ui/utils.hpp"
 
 #include <sstream>
 
@@ -385,11 +386,16 @@ void GameRunner::World::updateAndRender(const engine::TimeDelta dt) {
   updateWorld(dt);
   mpWorld->render();
 
-  if (mShowDebugText) {
-    std::stringstream debugText;
-    mpWorld->printDebugText(debugText);
-    ui::drawText(debugText.str(), 0, 32, {255, 255, 255, 255});
+  std::stringstream debugText;
+  if (mpWorld->mpSystems->player().mGodModeOn) {
+    debugText << "GOD MODE on\n";
   }
+
+  if (mShowDebugText) {
+    mpWorld->printDebugText(debugText);
+  }
+
+  ui::drawText(debugText.str(), 0, 32, {255, 255, 255, 255});
 
   mpWorld->processEndOfFrameActions();
 }
@@ -595,6 +601,13 @@ void GameRunner::World::handleDebugKeys(const SDL_Event& event) {
     case SDLK_SPACE:
       if (mSingleStepping) {
         mDoNextSingleStep = true;
+      }
+      break;
+
+    case SDLK_F10:
+      {
+        auto& player = mpWorld->mpSystems->player();
+        player.mGodModeOn = !player.mGodModeOn;
       }
       break;
   }

--- a/src/game_runner.cpp
+++ b/src/game_runner.cpp
@@ -22,6 +22,8 @@
 #include "game_logic/ingame_systems.hpp"
 #include "loader/resource_loader.hpp"
 
+#include <sstream>
+
 
 namespace rigel {
 
@@ -384,7 +386,9 @@ void GameRunner::World::updateAndRender(const engine::TimeDelta dt) {
   mpWorld->render();
 
   if (mShowDebugText) {
-    mpWorld->showDebugText();
+    std::stringstream debugText;
+    mpWorld->printDebugText(debugText);
+    ui::drawText(debugText.str(), 0, 32, {255, 255, 255, 255});
   }
 
   mpWorld->processEndOfFrameActions();

--- a/src/game_runner.cpp
+++ b/src/game_runner.cpp
@@ -386,16 +386,7 @@ void GameRunner::World::updateAndRender(const engine::TimeDelta dt) {
   updateWorld(dt);
   mpWorld->render();
 
-  std::stringstream debugText;
-  if (mpWorld->mpSystems->player().mGodModeOn) {
-    debugText << "GOD MODE on\n";
-  }
-
-  if (mShowDebugText) {
-    mpWorld->printDebugText(debugText);
-  }
-
-  ui::drawText(debugText.str(), 0, 32, {255, 255, 255, 255});
+  renderDebugText();
 
   mpWorld->processEndOfFrameActions();
 }
@@ -568,6 +559,21 @@ void GameRunner::World::handlePlayerGameControllerInput(const SDL_Event& event) 
       }
       break;
   }
+}
+
+
+void GameRunner::World::renderDebugText() {
+  std::stringstream debugText;
+
+  if (mpWorld->mpSystems->player().mGodModeOn) {
+    debugText << "GOD MODE on\n";
+  }
+
+  if (mShowDebugText) {
+    mpWorld->printDebugText(debugText);
+  }
+
+  ui::drawText(debugText.str(), 0, 32, {255, 255, 255, 255});
 }
 
 

--- a/src/game_runner.hpp
+++ b/src/game_runner.hpp
@@ -67,12 +67,12 @@ private:
     }
 
     void handleEvent(const SDL_Event& event);
+    void handleDebugKeys(const SDL_Event& event);
     void updateAndRender(engine::TimeDelta dt);
 
     void updateWorld(engine::TimeDelta dt);
     void handlePlayerKeyboardInput(const SDL_Event& event);
     void handlePlayerGameControllerInput(const SDL_Event& event);
-    void handleDebugKeys(const SDL_Event& event);
 
     game_logic::GameWorld* mpWorld;
     game_logic::PlayerInput mPlayerInput;

--- a/src/game_runner.hpp
+++ b/src/game_runner.hpp
@@ -73,6 +73,7 @@ private:
     void updateWorld(engine::TimeDelta dt);
     void handlePlayerKeyboardInput(const SDL_Event& event);
     void handlePlayerGameControllerInput(const SDL_Event& event);
+    void renderDebugText();
 
     game_logic::GameWorld* mpWorld;
     game_logic::PlayerInput mPlayerInput;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -102,7 +102,7 @@ base::Vector parsePlayerPosition(const std::string& playerPosString) {
 int main(int argc, char** argv) {
   showBanner();
 
-  StartupOptions config;
+  CommandLineOptions config;
 
   po::options_description optionsDescription("Options");
   optionsDescription.add_options()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,6 +117,9 @@ int main(int argc, char** argv) {
      po::value<std::string>(),
      "Specify position to place the player at (to be used in conjunction with\n"
      "'play-level')")
+    ("debug-mode,d",
+     po::bool_switch(&config.mDebugModeEnabled),
+     "Enable debugging features")
     ("game-path",
      po::value<std::string>(&config.mGamePath)->default_value(""),
      "Path to original game's installation. Can also be given as positional "

--- a/test/utils.hpp
+++ b/test/utils.hpp
@@ -48,8 +48,8 @@ struct MockServiceProvider : public rigel::IGameServiceProvider {
   void switchGamePath(const std::filesystem::path&) override {}
   bool isShareWareVersion() const override { return false; }
 
-  const StartupOptions& commandLineOptions() const override {
-    static auto dummyOptions = StartupOptions{};
+  const CommandLineOptions& commandLineOptions() const override {
+    static auto dummyOptions = CommandLineOptions{};
     return dummyOptions;
   }
 

--- a/test/utils.hpp
+++ b/test/utils.hpp
@@ -48,6 +48,11 @@ struct MockServiceProvider : public rigel::IGameServiceProvider {
   void switchGamePath(const std::filesystem::path&) override {}
   bool isShareWareVersion() const override { return false; }
 
+  const StartupOptions& commandLineOptions() const override {
+    static auto dummyOptions = StartupOptions{};
+    return dummyOptions;
+  }
+
   std::optional<rigel::data::SoundId> mLastTriggeredSoundId;
 };
 


### PR DESCRIPTION
Implements a god mode as requested by #505. I chose to implement the god mode as a "debug" feature, which means the game has to be started with a command line argument `-d` to enable debug tools. Then, pressing `F10` toggles god mode on and off. I've chosen `F10` instead of `F12`, since `F12` might be used for taking screenshots in the future (see #412).

When god mode is on, the player takes no damage, not even from force fields/reactors. However, the player still dies when falling into a bottomless pit.

Also, fixes the conveyor belt issue found in N7, and puts debugging tools behind a command line switch, to avoid accidentally triggering debugging features during regular gameplay.

Closes #505 
Fixes #506 