### PR TITLE
Add option to specify difficulty when jumping to level via command line

### DIFF
--- a/src/common/command_line_options.hpp
+++ b/src/common/command_line_options.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "base/spatial_types.hpp"
+#include "data/game_session_data.hpp"
 
 #include <optional>
 #include <string>
@@ -27,7 +28,7 @@ namespace rigel {
 
 struct CommandLineOptions {
   std::string mGamePath;
-  std::optional<std::pair<int, int>> mLevelToJumpTo;
+  std::optional<data::GameSessionId> mLevelToJumpTo;
   bool mSkipIntro = false;
   bool mDebugModeEnabled = false;
   std::optional<base::Vector> mPlayerPosition;

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -191,10 +191,8 @@ std::unique_ptr<GameMode> createInitialGameMode(
 {
   if (commandLineOptions.mLevelToJumpTo)
   {
-    auto [episode, level] = *commandLineOptions.mLevelToJumpTo;
-
     return std::make_unique<GameSessionMode>(
-      data::GameSessionId{episode, level, data::Difficulty::Medium},
+      *commandLineOptions.mLevelToJumpTo,
       context,
       commandLineOptions.mPlayerPosition);
   }


### PR DESCRIPTION
When specifying a level to jump to on the command line, it's now possible to also specify the difficulty.

Pass `--difficulty <DIFF>`, with `<DIFF>` being one of `easy`, `medium` or `hard`.
When no difficulty is specified, medium is chosen.

Closes #544 