### PR TITLE
OpenGl robustness

### DIFF
--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -227,10 +227,7 @@ void showErrorMessage(SDL_Window* pWindow, const std::string& error) {
       ImGui::OpenPopup("Error!");
     }
 
-    const auto flags =
-      ImGuiWindowFlags_NoResize |
-      ImGuiWindowFlags_NoMove;
-    if (ImGui::BeginPopupModal("Error!", &boxIsVisible, flags)) {
+    if (ImGui::BeginPopupModal("Error!", &boxIsVisible, 0)) {
       ImGui::Text("%s", error.c_str());
 
       if (ImGui::Button("Ok")) {

--- a/src/renderer/opengl.cpp
+++ b/src/renderer/opengl.cpp
@@ -16,6 +16,8 @@
 
 #include "opengl.hpp"
 
+#include "sdl_utils/error.hpp"
+
 RIGEL_DISABLE_WARNINGS
 #include <SDL_video.h>
 RIGEL_RESTORE_WARNINGS
@@ -26,9 +28,13 @@ RIGEL_RESTORE_WARNINGS
 void rigel::renderer::loadGlFunctions() {
   int result = 0;
 #ifdef RIGEL_USE_GL_ES
-  result = gladLoadGLES2Loader(SDL_GL_GetProcAddress);
+  result = gladLoadGLES2Loader([](const char* proc) {
+    return sdl_utils::check(SDL_GL_GetProcAddress(proc));
+  });
 #else
-  result = gladLoadGLLoader(SDL_GL_GetProcAddress);
+  result = gladLoadGLLoader([](const char* proc) {
+    return sdl_utils::check(SDL_GL_GetProcAddress(proc));
+  });
 #endif
 
   if (!result) {

--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -60,6 +60,12 @@ precision mediump float;
 
 #else
 
+// We generally want to stick to GLSL version 130 (from OpenGL 3.0) in order to
+// maximize compatibility with older graphics cards. Unfortunately, Mac OS only
+// supports GLSL 150 (from OpenGL 3.2), even when requesting a OpenGL 3.0
+// context. Therefore, we use different GLSL versions depending on the
+// platform.
+#if defined(__APPLE__)
 const auto SHADER_PREAMBLE = R"shd(
 #version 150
 
@@ -71,6 +77,19 @@ const auto SHADER_PREAMBLE = R"shd(
 #define OUTPUT_COLOR_DECLARATION out vec4 outputColor;
 #define SET_POINT_SIZE
 )shd";
+#else
+const auto SHADER_PREAMBLE = R"shd(
+#version 130
+
+#define ATTRIBUTE in
+#define OUT out
+#define IN in
+#define TEXTURE_LOOKUP texture2D
+#define OUTPUT_COLOR outputColor
+#define OUTPUT_COLOR_DECLARATION out vec4 outputColor;
+#define SET_POINT_SIZE
+)shd";
+#endif
 
 #endif
 


### PR DESCRIPTION
A couple of changes to make OpenGL usage more robust:

* Use GLSL 130 instead of 150 on non-Apple platforms. Some graphics cards support OpenGL 3.0, But don't support GLSL 150. See #374 for an example.
* Check for errors when loading GL function pointers. This should prevent segfaults due to uninitialized function pointers as seen in #539, and turn them into an error message instead.