### PR TITLE
Introduce top-level ingame menu for using ingame menus with gamepad

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -268,6 +268,8 @@ set(core_sources
     ui/hud_renderer.hpp
     ui/imgui_integration.cpp
     ui/imgui_integration.hpp
+    ui/ingame_menu.cpp
+    ui/ingame_menu.hpp
     ui/ingame_message_display.cpp
     ui/ingame_message_display.hpp
     ui/intro_movie.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -274,6 +274,8 @@ set(core_sources
     ui/intro_movie.hpp
     ui/menu_element_renderer.cpp
     ui/menu_element_renderer.hpp
+    ui/menu_navigation_helper.cpp
+    ui/menu_navigation_helper.hpp
     ui/movie_player.cpp
     ui/movie_player.hpp
     ui/options_menu.cpp

--- a/src/game_logic/entity_configuration.ipp
+++ b/src/game_logic/entity_configuration.ipp
@@ -1444,7 +1444,7 @@ void EntityFactory::configureEntity(
       entity.assign<DestructionEffects>(
         HOVER_BOT_KILL_EFFECT_SPEC,
         DestructionEffects::TriggerCondition::OnKilled,
-        mSpriteFactory.actorFrameRect(actorID, 0));
+        mpSpriteFactory->actorFrameRect(actorID, 0));
       break;
 
     case ActorID::Big_green_cat_LEFT:
@@ -1460,7 +1460,7 @@ void EntityFactory::configureEntity(
       entity.assign<DestructionEffects>(
         BIOLOGICAL_ENEMY_KILL_EFFECT_SPEC,
         DestructionEffects::TriggerCondition::OnKilled,
-        mSpriteFactory.actorFrameRect(actorID, 0));
+        mpSpriteFactory->actorFrameRect(actorID, 0));
       entity.assign<AppearsOnRadar>();
       break;
 
@@ -1485,7 +1485,7 @@ void EntityFactory::configureEntity(
       entity.assign<DestructionEffects>(
         SIMPLE_TECH_KILL_EFFECT_SPEC,
         DestructionEffects::TriggerCondition::OnKilled,
-        mSpriteFactory.actorFrameRect(actorID, 0));
+        mpSpriteFactory->actorFrameRect(actorID, 0));
       addDefaultMovingBody(entity, boundingBox);
       entity.component<MovingBody>()->mGravityAffected = false;
       entity.assign<BehaviorController>(behaviors::WatchBot{});
@@ -1500,7 +1500,7 @@ void EntityFactory::configureEntity(
       entity.assign<DestructionEffects>(
         SIMPLE_TECH_KILL_EFFECT_SPEC,
         DestructionEffects::TriggerCondition::OnKilled,
-        mSpriteFactory.actorFrameRect(actorID, 0));
+        mpSpriteFactory->actorFrameRect(actorID, 0));
       entity.assign<AppearsOnRadar>();
       break;
 
@@ -1581,7 +1581,7 @@ void EntityFactory::configureEntity(
       entity.assign<DestructionEffects>(
         BIOLOGICAL_ENEMY_KILL_EFFECT_SPEC,
         DestructionEffects::TriggerCondition::OnKilled,
-        mSpriteFactory.actorFrameRect(actorID, 0));
+        mpSpriteFactory->actorFrameRect(actorID, 0));
       entity.assign<PlayerDamaging>(Damage{1});
       entity.assign<ai::components::SlimeBlob>();
       addDefaultMovingBody(entity, boundingBox);
@@ -1638,7 +1638,7 @@ void EntityFactory::configureEntity(
       entity.assign<DestructionEffects>(
         BIOLOGICAL_ENEMY_KILL_EFFECT_SPEC,
         DestructionEffects::TriggerCondition::OnKilled,
-        mSpriteFactory.actorFrameRect(actorID, 0));
+        mpSpriteFactory->actorFrameRect(actorID, 0));
       entity.assign<BoundingBox>(boundingBox);
       entity.assign<BehaviorController>(behaviors::CeilingSucker{});
       entity.assign<AppearsOnRadar>();
@@ -1680,7 +1680,7 @@ void EntityFactory::configureEntity(
       entity.assign<DestructionEffects>(
         SKELETON_KILL_EFFECT_SPEC,
         DestructionEffects::TriggerCondition::OnKilled,
-        mSpriteFactory.actorFrameRect(actorID, 0));
+        mpSpriteFactory->actorFrameRect(actorID, 0));
       entity.assign<PlayerDamaging>(Damage{1});
       entity.assign<ai::components::SimpleWalker>(skeletonAiConfig());
       addDefaultMovingBody(entity, boundingBox);
@@ -1697,7 +1697,7 @@ void EntityFactory::configureEntity(
       entity.assign<DestructionEffects>(
         GRABBER_CLAW_KILL_EFFECT_SPEC,
         DestructionEffects::TriggerCondition::OnKilled,
-        mSpriteFactory.actorFrameRect(actorID, 0));
+        mpSpriteFactory->actorFrameRect(actorID, 0));
       entity.assign<CustomRenderFunc>(&behaviors::GrabberClaw::render);
       entity.assign<AppearsOnRadar>();
       break;
@@ -1742,7 +1742,7 @@ void EntityFactory::configureEntity(
       entity.assign<DestructionEffects>(
         BIOLOGICAL_ENEMY_KILL_EFFECT_SPEC,
         DestructionEffects::TriggerCondition::OnKilled,
-        mSpriteFactory.actorFrameRect(actorID, 0));
+        mpSpriteFactory->actorFrameRect(actorID, 0));
       entity.assign<AnimationSequence>(FLY_ANIMATION_SEQUENCE, 0, true);
       entity.assign<AppearsOnRadar>();
       break;
@@ -1762,7 +1762,7 @@ void EntityFactory::configureEntity(
       entity.assign<DestructionEffects>(
         EXTENDED_BIOLOGICAL_ENEMY_KILL_EFFECT_SPEC,
         DestructionEffects::TriggerCondition::OnKilled,
-        mSpriteFactory.actorFrameRect(actorID, 0));
+        mpSpriteFactory->actorFrameRect(actorID, 0));
       entity.assign<AppearsOnRadar>();
       break;
 
@@ -1794,7 +1794,7 @@ void EntityFactory::configureEntity(
       entity.assign<DestructionEffects>(
         BLUE_GUARD_KILL_EFFECT_SPEC,
         DestructionEffects::TriggerCondition::OnKilled,
-        mSpriteFactory.actorFrameRect(ActorID::Blue_guard_RIGHT, 0));
+        mpSpriteFactory->actorFrameRect(ActorID::Blue_guard_RIGHT, 0));
       entity.assign<AppearsOnRadar>();
       break;
 
@@ -1843,7 +1843,7 @@ void EntityFactory::configureEntity(
       entity.assign<Shootable>(
         Health{675 + 75 * difficultyOffset}, GivenScore{0});
       entity.component<Shootable>()->mDestroyWhenKilled = false;
-      entity.assign<BoundingBox>(mSpriteFactory.actorFrameRect(actorID, 0));
+      entity.assign<BoundingBox>(mpSpriteFactory->actorFrameRect(actorID, 0));
       entity.assign<BehaviorController>(behaviors::BossEpisode3{});
       entity.assign<ActivationSettings>(
         ActivationSettings::Policy::AlwaysAfterFirstActivation);
@@ -1873,7 +1873,7 @@ void EntityFactory::configureEntity(
       entity.assign<DestructionEffects>(
         BOSS4_PROJECTILE_KILL_EFFECT_SPEC,
         DestructionEffects::TriggerCondition::OnKilled,
-        mSpriteFactory.actorFrameRect(actorID, 0));
+        mpSpriteFactory->actorFrameRect(actorID, 0));
       entity.assign<AppearsOnRadar>();
       break;
 
@@ -1930,7 +1930,7 @@ void EntityFactory::configureEntity(
       entity.assign<DestructionEffects>(
         RIGELATIN_KILL_EFFECT_SPEC,
         DestructionEffects::TriggerCondition::OnKilled,
-        mSpriteFactory.actorFrameRect(ActorID::Rigelatin_soldier, 0));
+        mpSpriteFactory->actorFrameRect(ActorID::Rigelatin_soldier, 0));
       entity.assign<AppearsOnRadar>();
       break;
 
@@ -1997,7 +1997,7 @@ void EntityFactory::configureEntity(
       entity.assign<DestructionEffects>(
         REACTOR_KILL_EFFECT_SPEC,
         DestructionEffects::TriggerCondition::OnKilled,
-        mSpriteFactory.actorFrameRect(ActorID::Electric_reactor, 0));
+        mpSpriteFactory->actorFrameRect(ActorID::Electric_reactor, 0));
       entity.assign<ActorTag>(ActorTag::Type::Reactor);
       entity.assign<AppearsOnRadar>();
       break;

--- a/src/game_logic/entity_factory.cpp
+++ b/src/game_logic/entity_factory.cpp
@@ -477,12 +477,11 @@ base::Rect<int> SpriteFactory::actorFrameRect(
 
 
 EntityFactory::EntityFactory(
-  renderer::Renderer* pRenderer,
+  SpriteFactory* pSpriteFactory,
   ex::EntityManager* pEntityManager,
   engine::RandomNumberGenerator* pRandomGenerator,
-  const loader::ActorImagePackage* pSpritePackage,
   const data::Difficulty difficulty)
-  : mSpriteFactory(pRenderer, pSpritePackage)
+  : mpSpriteFactory(pSpriteFactory)
   , mpEntityManager(pEntityManager)
   , mpRandomGenerator(pRandomGenerator)
   , mDifficulty(difficulty)
@@ -491,7 +490,7 @@ EntityFactory::EntityFactory(
 
 
 Sprite EntityFactory::createSpriteForId(const ActorID actorID) {
-  auto sprite = mSpriteFactory.createSprite(actorID);
+  auto sprite = mpSpriteFactory->createSprite(actorID);
   configureSprite(sprite, actorID);
   return sprite;
 }

--- a/src/game_logic/entity_factory.hpp
+++ b/src/game_logic/entity_factory.hpp
@@ -114,10 +114,9 @@ private:
 class EntityFactory : public IEntityFactory {
 public:
   EntityFactory(
-    renderer::Renderer* pRenderer,
+    SpriteFactory* pSpriteFactory,
     entityx::EntityManager* pEntityManager,
     engine::RandomNumberGenerator* pRandomGenerator,
-    const loader::ActorImagePackage* pSpritePackage,
     data::Difficulty difficulty);
 
   entityx::Entity createEntitiesForLevel(
@@ -175,7 +174,7 @@ private:
     const engine::components::BoundingBox& boundingBox
   );
 
-  SpriteFactory mSpriteFactory;
+  SpriteFactory* mpSpriteFactory;
   entityx::EntityManager* mpEntityManager;
   engine::RandomNumberGenerator* mpRandomGenerator;
   int mSpawnIndex = 0;

--- a/src/game_logic/game_world.cpp
+++ b/src/game_logic/game_world.cpp
@@ -745,24 +745,16 @@ void GameWorld::handlePlayerDeath() {
 void GameWorld::restartLevel() {
   mpServiceProvider->fadeOutScreen();
 
-  if (mpState->mBackdropSwitched) {
-    mpState->mpSystems->switchBackdrops();
-    mpState->mBackdropSwitched = false;
-  }
-
-  mpState->mMap = mpState->mMapAtLevelStart;
-  mpState->mBonusInfo.mNumShotBonusGlobes = 0;
-  mpState->mBonusInfo.mPlayerTookDamage = false;
-
-  mpState->mEntities.reset();
-  auto playerEntity = mpState->mEntityFactory.createEntitiesForLevel(
-    mpState->mInitialActors);
-  mpState->mpSystems->restartFromBeginning(playerEntity);
-
   *mpPlayerModel = mPlayerModelAtLevelStart;
+  loadLevel();
 
   mpState->mpSystems->centerViewOnPlayer();
   updateGameLogic({});
+
+  if (mpState->mRadarDishCounter.radarDishesPresent()) {
+    mMessageDisplay.setMessage(data::Messages::FindAllRadars);
+  }
+
   render();
 
   mpServiceProvider->fadeInScreen();

--- a/src/game_logic/game_world.cpp
+++ b/src/game_logic/game_world.cpp
@@ -263,6 +263,13 @@ GameWorld::GameWorld(
   , mpTextRenderer(context.mpUiRenderer)
   , mpPlayerModel(pPlayerModel)
   , mpOptions(&context.mpUserProfile->mOptions)
+  , mPlayerModelAtLevelStart(*mpPlayerModel)
+  , mHudRenderer(
+      sessionId.mLevel + 1,
+      mpRenderer,
+      *context.mpResources,
+      context.mpUiSpriteSheet)
+  , mMessageDisplay(mpServiceProvider, context.mpUiRenderer)
   , mEntities(mEventManager)
   , mEntityFactory(
       context.mpRenderer,
@@ -270,14 +277,7 @@ GameWorld::GameWorld(
       &mRandomGenerator,
       &context.mpResources->mActorImagePackage,
       sessionId.mDifficulty)
-  , mPlayerModelAtLevelStart(*mpPlayerModel)
   , mRadarDishCounter(mEntities, mEventManager)
-  , mHudRenderer(
-      sessionId.mLevel + 1,
-      mpRenderer,
-      *context.mpResources,
-      context.mpUiSpriteSheet)
-  , mMessageDisplay(mpServiceProvider, context.mpUiRenderer)
 {
   mEventManager.subscribe<rigel::events::CheckPointActivated>(*this);
   mEventManager.subscribe<rigel::events::ExitReached>(*this);

--- a/src/game_logic/game_world.cpp
+++ b/src/game_logic/game_world.cpp
@@ -282,10 +282,8 @@ GameWorld::WorldState::WorldState(
   mBonusInfo.mInitialBonusGlobeCount = counts.mBonusGlobeCount;
 
   mMap = std::move(loadedLevel.mMap);
-  mInitialActors = std::move(loadedLevel.mActors);
   mBackdropSwitchCondition = loadedLevel.mBackdropSwitchCondition;
   mLevelMusicFile = loadedLevel.mMusicFile;
-  mMapAtLevelStart = mMap;
 
   mpSystems = std::make_unique<IngameSystems>(
     sessionId,

--- a/src/game_logic/game_world.cpp
+++ b/src/game_logic/game_world.cpp
@@ -261,6 +261,8 @@ GameWorld::GameWorld(
   , mpServiceProvider(context.mpServiceProvider)
   , mpUiSpriteSheet(context.mpUiSpriteSheet)
   , mpTextRenderer(context.mpUiRenderer)
+  , mpPlayerModel(pPlayerModel)
+  , mpOptions(&context.mpUserProfile->mOptions)
   , mEntities(mEventManager)
   , mEntityFactory(
       context.mpRenderer,
@@ -268,7 +270,6 @@ GameWorld::GameWorld(
       &mRandomGenerator,
       &context.mpResources->mActorImagePackage,
       sessionId.mDifficulty)
-  , mpPlayerModel(pPlayerModel)
   , mPlayerModelAtLevelStart(*mpPlayerModel)
   , mRadarDishCounter(mEntities, mEventManager)
   , mHudRenderer(
@@ -277,7 +278,6 @@ GameWorld::GameWorld(
       *context.mpResources,
       context.mpUiSpriteSheet)
   , mMessageDisplay(mpServiceProvider, context.mpUiRenderer)
-  , mpOptions(&context.mpUserProfile->mOptions)
 {
   mEventManager.subscribe<rigel::events::CheckPointActivated>(*this);
   mEventManager.subscribe<rigel::events::ExitReached>(*this);

--- a/src/game_logic/game_world.cpp
+++ b/src/game_logic/game_world.cpp
@@ -356,11 +356,9 @@ GameWorld::GameWorld(
 
   if (playerPositionOverride) {
     mpState->mpSystems->player().position() = *playerPositionOverride;
+    mpState->mpSystems->centerViewOnPlayer();
+    updateGameLogic({});
   }
-
-  mpState->mpSystems->centerViewOnPlayer();
-
-  updateGameLogic({});
 
   if (showWelcomeMessage) {
     mMessageDisplay.setMessage(data::Messages::WelcomeToDukeNukem2);
@@ -531,6 +529,9 @@ void GameWorld::loadLevel() {
     mEventManager,
     &mSpriteFactory,
     mSessionId);
+
+  mpState->mpSystems->centerViewOnPlayer();
+  updateGameLogic({});
 
   if (data::isBossLevel(mSessionId.mLevel)) {
     mpServiceProvider->playMusic(BOSS_LEVEL_INTRO_MUSIC);
@@ -747,9 +748,6 @@ void GameWorld::restartLevel() {
 
   *mpPlayerModel = mPlayerModelAtLevelStart;
   loadLevel();
-
-  mpState->mpSystems->centerViewOnPlayer();
-  updateGameLogic({});
 
   if (mpState->mRadarDishCounter.radarDishesPresent()) {
     mMessageDisplay.setMessage(data::Messages::FindAllRadars);

--- a/src/game_logic/game_world.cpp
+++ b/src/game_logic/game_world.cpp
@@ -263,6 +263,7 @@ GameWorld::GameWorld(
   , mpTextRenderer(context.mpUiRenderer)
   , mpPlayerModel(pPlayerModel)
   , mpOptions(&context.mpUserProfile->mOptions)
+  , mSpriteFactory(context.mpRenderer, &context.mpResources->mActorImagePackage)
   , mPlayerModelAtLevelStart(*mpPlayerModel)
   , mHudRenderer(
       sessionId.mLevel + 1,
@@ -272,10 +273,9 @@ GameWorld::GameWorld(
   , mMessageDisplay(mpServiceProvider, context.mpUiRenderer)
   , mEntities(mEventManager)
   , mEntityFactory(
-      context.mpRenderer,
+      &mSpriteFactory,
       &mEntities,
       &mRandomGenerator,
-      &context.mpResources->mActorImagePackage,
       sessionId.mDifficulty)
   , mRadarDishCounter(mEntities, mEventManager)
 {

--- a/src/game_logic/game_world.cpp
+++ b/src/game_logic/game_world.cpp
@@ -266,6 +266,7 @@ GameWorld::WorldState::WorldState(
     &mRandomGenerator,
     sessionId.mDifficulty)
   , mRadarDishCounter(mEntities, eventManager)
+  , mCollisionChecker(&mMap, mEntities, eventManager)
 {
   auto loadedLevel = loader::loadLevel(
     levelFileName(sessionId.mEpisode, sessionId.mLevel),
@@ -295,6 +296,7 @@ GameWorld::WorldState::WorldState(
     &mEntityFactory,
     &mRandomGenerator,
     &mRadarDishCounter,
+    &mCollisionChecker,
     pRenderer,
     mEntities,
     eventManager,

--- a/src/game_logic/game_world.hpp
+++ b/src/game_logic/game_world.hpp
@@ -113,6 +113,40 @@ private:
     bool mPlayerTookDamage = false;
   };
 
+  struct WorldState {
+    WorldState(
+      entityx::EventManager& eventManager,
+      SpriteFactory* pSpriteFactory,
+      data::GameSessionId sessionId);
+    ~WorldState();
+
+    entityx::EntityManager mEntities;
+    engine::RandomNumberGenerator mRandomGenerator;
+    EntityFactory mEntityFactory;
+    RadarDishCounter mRadarDishCounter;
+
+    data::map::Map mMap;
+    std::vector<data::map::LevelData::Actor> mInitialActors;
+    data::map::Map mMapAtLevelStart;
+    LevelBonusInfo mBonusInfo;
+    std::optional<std::string> mLevelMusicFile;
+
+    std::unique_ptr<IngameSystems> mpSystems;
+
+    std::optional<EarthQuakeEffect> mEarthQuakeEffect;
+    std::optional<base::Color> mScreenFlashColor;
+    std::optional<base::Color> mBackdropFlashColor;
+    std::optional<base::Vector> mTeleportTargetPosition;
+    entityx::Entity mActiveBossEntity;
+    std::optional<int> mReactorDestructionFramesElapsed;
+    int mScreenShakeOffsetX = 0;
+    data::map::BackdropSwitchCondition mBackdropSwitchCondition;
+    bool mBossDeathAnimationStartPending = false;
+    bool mBackdropSwitched = false;
+    bool mLevelFinished = false;
+    bool mPlayerDied = false;
+  };
+
   struct CheckpointData {
     data::PlayerModel::CheckpointState mState;
     base::Vector mPosition;
@@ -132,34 +166,7 @@ private:
   ui::HudRenderer mHudRenderer;
   ui::IngameMessageDisplay mMessageDisplay;
 
-  entityx::EntityManager mEntities;
-  engine::RandomNumberGenerator mRandomGenerator;
-  EntityFactory mEntityFactory;
-
-  LevelBonusInfo mBonusInfo;
-  std::optional<std::string> mLevelMusicFile;
-
-  std::optional<base::Vector> mTeleportTargetPosition;
-  entityx::Entity mActiveBossEntity;
-  bool mBossDeathAnimationStartPending = false;
-  bool mBackdropSwitched = false;
-  bool mLevelFinished = false;
-  bool mPlayerDied = false;
-
-  data::map::Map mMap;
-  std::vector<data::map::LevelData::Actor> mInitialActors;
-  data::map::BackdropSwitchCondition mBackdropSwitchCondition;
-  data::map::Map mMapAtLevelStart;
-
-  std::unique_ptr<IngameSystems> mpSystems;
-
-  RadarDishCounter mRadarDishCounter;
-
-  std::optional<EarthQuakeEffect> mEarthQuakeEffect;
-  std::optional<base::Color> mScreenFlashColor;
-  std::optional<base::Color> mBackdropFlashColor;
-  std::optional<int> mReactorDestructionFramesElapsed;
-  int mScreenShakeOffsetX = 0;
+  std::unique_ptr<WorldState> mpState;
 };
 
 }

--- a/src/game_logic/game_world.hpp
+++ b/src/game_logic/game_world.hpp
@@ -126,6 +126,7 @@ private:
   const data::GameOptions* mpOptions;
 
   entityx::EventManager mEventManager;
+  SpriteFactory mSpriteFactory;
   data::PlayerModel mPlayerModelAtLevelStart;
   std::optional<CheckpointData> mActivatedCheckpoint;
   ui::HudRenderer mHudRenderer;

--- a/src/game_logic/game_world.hpp
+++ b/src/game_logic/game_world.hpp
@@ -84,9 +84,7 @@ public:
   friend class rigel::GameRunner;
 
 private:
-  void loadLevel(
-    const data::GameSessionId& sessionId,
-    const loader::ResourceLoader& resources);
+  void loadLevel();
 
   void onReactorDestroyed(const base::Vector& position);
   void updateReactorDestructionEvent();
@@ -158,6 +156,8 @@ private:
   ui::MenuElementRenderer* mpTextRenderer;
   data::PlayerModel* mpPlayerModel;
   const data::GameOptions* mpOptions;
+  const loader::ResourceLoader* mpResources;
+  data::GameSessionId mSessionId;
 
   entityx::EventManager mEventManager;
   SpriteFactory mSpriteFactory;

--- a/src/game_logic/game_world.hpp
+++ b/src/game_logic/game_world.hpp
@@ -24,6 +24,7 @@
 #include "data/bonus.hpp"
 #include "data/player_model.hpp"
 #include "data/tutorial_messages.hpp"
+#include "engine/collision_checker.hpp"
 #include "engine/random_number_generator.hpp"
 #include "game_logic/damage_components.hpp"
 #include "game_logic/earth_quake_effect.hpp"
@@ -131,6 +132,7 @@ private:
     LevelBonusInfo mBonusInfo;
     std::string mLevelMusicFile;
 
+    engine::CollisionChecker mCollisionChecker;
     std::unique_ptr<IngameSystems> mpSystems;
 
     std::optional<EarthQuakeEffect> mEarthQuakeEffect;

--- a/src/game_logic/game_world.hpp
+++ b/src/game_logic/game_world.hpp
@@ -146,13 +146,9 @@ private:
   bool mLevelFinished = false;
   bool mPlayerDied = false;
 
-  struct LevelData {
-    data::map::Map mMap;
-    std::vector<data::map::LevelData::Actor> mInitialActors;
-    data::map::BackdropSwitchCondition mBackdropSwitchCondition;
-  };
-
-  LevelData mLevelData;
+  data::map::Map mMap;
+  std::vector<data::map::LevelData::Actor> mInitialActors;
+  data::map::BackdropSwitchCondition mBackdropSwitchCondition;
   data::map::Map mMapAtLevelStart;
 
   std::unique_ptr<IngameSystems> mpSystems;

--- a/src/game_logic/game_world.hpp
+++ b/src/game_logic/game_world.hpp
@@ -126,13 +126,16 @@ private:
   const data::GameOptions* mpOptions;
 
   entityx::EventManager mEventManager;
+  data::PlayerModel mPlayerModelAtLevelStart;
+  std::optional<CheckpointData> mActivatedCheckpoint;
+  ui::HudRenderer mHudRenderer;
+  ui::IngameMessageDisplay mMessageDisplay;
+
   entityx::EntityManager mEntities;
   engine::RandomNumberGenerator mRandomGenerator;
   EntityFactory mEntityFactory;
 
-  data::PlayerModel mPlayerModelAtLevelStart;
   LevelBonusInfo mBonusInfo;
-  std::optional<CheckpointData> mActivatedCheckpoint;
   std::optional<std::string> mLevelMusicFile;
 
   std::optional<base::Vector> mTeleportTargetPosition;
@@ -154,8 +157,6 @@ private:
   std::unique_ptr<IngameSystems> mpSystems;
 
   RadarDishCounter mRadarDishCounter;
-  ui::HudRenderer mHudRenderer;
-  ui::IngameMessageDisplay mMessageDisplay;
 
   std::optional<EarthQuakeEffect> mEarthQuakeEffect;
   std::optional<base::Color> mScreenFlashColor;

--- a/src/game_logic/game_world.hpp
+++ b/src/game_logic/game_world.hpp
@@ -122,12 +122,14 @@ private:
   IGameServiceProvider* mpServiceProvider;
   engine::TiledTexture* mpUiSpriteSheet;
   ui::MenuElementRenderer* mpTextRenderer;
+  data::PlayerModel* mpPlayerModel;
+  const data::GameOptions* mpOptions;
+
   entityx::EventManager mEventManager;
   entityx::EntityManager mEntities;
   engine::RandomNumberGenerator mRandomGenerator;
   EntityFactory mEntityFactory;
 
-  data::PlayerModel* mpPlayerModel;
   data::PlayerModel mPlayerModelAtLevelStart;
   LevelBonusInfo mBonusInfo;
   std::optional<CheckpointData> mActivatedCheckpoint;
@@ -154,7 +156,6 @@ private:
   RadarDishCounter mRadarDishCounter;
   ui::HudRenderer mHudRenderer;
   ui::IngameMessageDisplay mMessageDisplay;
-  const data::GameOptions* mpOptions;
 
   std::optional<EarthQuakeEffect> mEarthQuakeEffect;
   std::optional<base::Color> mScreenFlashColor;

--- a/src/game_logic/game_world.hpp
+++ b/src/game_logic/game_world.hpp
@@ -128,8 +128,6 @@ private:
     RadarDishCounter mRadarDishCounter;
 
     data::map::Map mMap;
-    std::vector<data::map::LevelData::Actor> mInitialActors;
-    data::map::Map mMapAtLevelStart;
     LevelBonusInfo mBonusInfo;
     std::string mLevelMusicFile;
 

--- a/src/game_logic/game_world.hpp
+++ b/src/game_logic/game_world.hpp
@@ -113,6 +113,10 @@ private:
 
   struct WorldState {
     WorldState(
+      IGameServiceProvider* pServiceProvider,
+      renderer::Renderer* pRenderer,
+      const loader::ResourceLoader* pResources,
+      data::PlayerModel* pPlayerModel,
       entityx::EventManager& eventManager,
       SpriteFactory* pSpriteFactory,
       data::GameSessionId sessionId);
@@ -127,7 +131,7 @@ private:
     std::vector<data::map::LevelData::Actor> mInitialActors;
     data::map::Map mMapAtLevelStart;
     LevelBonusInfo mBonusInfo;
-    std::optional<std::string> mLevelMusicFile;
+    std::string mLevelMusicFile;
 
     std::unique_ptr<IngameSystems> mpSystems;
 

--- a/src/game_logic/ingame_systems.cpp
+++ b/src/game_logic/ingame_systems.cpp
@@ -56,18 +56,18 @@ IngameSystems::IngameSystems(
   EntityFactory* pEntityFactory,
   engine::RandomNumberGenerator* pRandomGenerator,
   const RadarDishCounter* pRadarDishCounter,
+  const engine::CollisionChecker* pCollisionChecker,
   renderer::Renderer* pRenderer,
   entityx::EntityManager& entities,
   entityx::EventManager& eventManager,
   const loader::ResourceLoader& resources
 )
-  : mCollisionChecker(pMap, entities, eventManager)
-  , mPlayer(
+  : mPlayer(
       playerEntity,
       sessionId.mDifficulty,
       pPlayerModel,
       pServiceProvider,
-      &mCollisionChecker,
+      pCollisionChecker,
       pMap,
       pEntityFactory,
       &eventManager,
@@ -79,7 +79,7 @@ IngameSystems::IngameSystems(
       pRenderer,
       pMap,
       std::move(mapRenderData))
-  , mPhysicsSystem(&mCollisionChecker, pMap, &eventManager)
+  , mPhysicsSystem(pCollisionChecker, pMap, &eventManager)
   , mDebuggingSystem(pRenderer, &mCamera.position(), pMap)
   , mPlayerInteractionSystem(
       sessionId,
@@ -93,12 +93,12 @@ IngameSystems::IngameSystems(
   , mPlayerProjectileSystem(
       pEntityFactory,
       pServiceProvider,
-      &mCollisionChecker,
+      pCollisionChecker,
       pMap)
   , mElevatorSystem(
       playerEntity,
       pServiceProvider,
-      &mCollisionChecker,
+      const_cast<engine::CollisionChecker*>(pCollisionChecker),
       &eventManager)
   , mRadarComputerSystem(pRadarDishCounter)
   , mDamageInflictionSystem(pPlayerModel, pServiceProvider, &eventManager)
@@ -115,17 +115,17 @@ IngameSystems::IngameSystems(
       pEntityFactory,
       &mParticles,
       eventManager)
-  , mItemContainerSystem(&entities, &mCollisionChecker, eventManager)
+  , mItemContainerSystem(&entities, pCollisionChecker, eventManager)
   , mBlueGuardSystem(
       &mPlayer,
-      &mCollisionChecker,
+      const_cast<engine::CollisionChecker*>(pCollisionChecker),
       pEntityFactory,
       pServiceProvider,
       pRandomGenerator,
       eventManager)
   , mHoverBotSystem(
       playerEntity,
-      &mCollisionChecker,
+      const_cast<engine::CollisionChecker*>(pCollisionChecker),
       pEntityFactory)
   , mLaserTurretSystem(
       playerEntity,
@@ -145,24 +145,24 @@ IngameSystems::IngameSystems(
   , mRocketTurretSystem(playerEntity, pEntityFactory, pServiceProvider)
   , mSimpleWalkerSystem(
       playerEntity,
-      &mCollisionChecker)
+      const_cast<engine::CollisionChecker*>(pCollisionChecker))
   , mSlidingDoorSystem(playerEntity, pServiceProvider)
   , mSlimeBlobSystem(
       &mPlayer,
-      &mCollisionChecker,
+      const_cast<engine::CollisionChecker*>(pCollisionChecker),
       pEntityFactory,
       pRandomGenerator,
       eventManager)
   , mSpiderSystem(
       &mPlayer,
-      &mCollisionChecker,
+      const_cast<engine::CollisionChecker*>(pCollisionChecker),
       pRandomGenerator,
       pEntityFactory,
       eventManager)
-  , mSpikeBallSystem(&mCollisionChecker, pServiceProvider, eventManager)
+  , mSpikeBallSystem(pCollisionChecker, pServiceProvider, eventManager)
   , mBehaviorControllerSystem(
       GlobalDependencies{
-        &mCollisionChecker,
+        pCollisionChecker,
         &mParticles,
         pRandomGenerator,
         pEntityFactory,

--- a/src/game_logic/ingame_systems.cpp
+++ b/src/game_logic/ingame_systems.cpp
@@ -283,11 +283,6 @@ void IngameSystems::switchBackdrops() {
 }
 
 
-void IngameSystems::restartFromBeginning(entityx::Entity newPlayerEntity) {
-  mPlayer.resetAfterDeath(newPlayerEntity);
-}
-
-
 void IngameSystems::restartFromCheckpoint(
   const base::Vector& checkpointPosition
 ) {

--- a/src/game_logic/ingame_systems.hpp
+++ b/src/game_logic/ingame_systems.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include "engine/collision_checker.hpp"
 #include "engine/entity_activation_system.hpp"
 #include "engine/life_time_system.hpp"
 #include "engine/particle_system.hpp"
@@ -79,6 +78,7 @@ public:
     EntityFactory* pEntityFactory,
     engine::RandomNumberGenerator* pRandomGenerator,
     const RadarDishCounter* pRadarDishCounter,
+    const engine::CollisionChecker* pCollisionChecker,
     renderer::Renderer* pRenderer,
     entityx::EntityManager& entities,
     entityx::EventManager& eventManager,
@@ -111,7 +111,6 @@ public:
   void printDebugText(std::ostream& stream) const;
 
 private:
-  engine::CollisionChecker mCollisionChecker;
   Player mPlayer;
   Camera mCamera;
 

--- a/src/game_logic/ingame_systems.hpp
+++ b/src/game_logic/ingame_systems.hpp
@@ -100,7 +100,6 @@ public:
 
   void switchBackdrops();
 
-  void restartFromBeginning(entityx::Entity newPlayerEntity);
   void restartFromCheckpoint(const base::Vector& checkpointPosition);
 
   void centerViewOnPlayer();

--- a/src/game_logic/player.cpp
+++ b/src/game_logic/player.cpp
@@ -629,19 +629,9 @@ void Player::doInteractionAnimation() {
 }
 
 
-void Player::resetAfterDeath(entityx::Entity newEntity) {
+void Player::resetAfterRespawn() {
   // TODO: Refactor this - it would be much nicer if we could just consruct
   // a new player.
-  mEntity = newEntity;
-
-  resetAfterRespawn();
-
-  mFramesElapsedHavingRapidFire = mFramesElapsedHavingCloak = 0;
-}
-
-
-void Player::resetAfterRespawn() {
-  // TODO: Same as with resetAfterDeath()
   mState = OnGround{};
   mStance = WeaponStance::Regular;
   mVisualState = VisualState::Standing;

--- a/src/game_logic/player.hpp
+++ b/src/game_logic/player.hpp
@@ -235,7 +235,6 @@ public:
 
   void doInteractionAnimation();
 
-  void resetAfterDeath(entityx::Entity newEntity);
   void resetAfterRespawn();
 
   bool isInRegularState() const;

--- a/src/game_runner.cpp
+++ b/src/game_runner.cpp
@@ -16,12 +16,9 @@
 
 #include "game_runner.hpp"
 
-#include "base/match.hpp"
 #include "base/math_tools.hpp"
 #include "common/game_service_provider.hpp"
-#include "common/user_profile.hpp"
 #include "game_logic/ingame_systems.hpp"
-#include "loader/resource_loader.hpp"
 #include "ui/utils.hpp"
 
 #include <sstream>
@@ -40,32 +37,6 @@ namespace {
 // it's roughly 13 FPS. With 15 FPS, the feel should therefore be very close to
 // playing the game on a 486 at the default game speed setting.
 constexpr auto GAME_LOGIC_UPDATE_DELAY = 1.0/15.0;
-
-constexpr auto SAVE_SLOT_NAME_ENTRY_POS_X = 14;
-constexpr auto SAVE_SLOT_NAME_ENTRY_START_POS_Y = 6;
-constexpr auto SAVE_SLOT_NAME_HEIGHT = 2;
-
-constexpr auto MAX_SAVE_SLOT_NAME_LENGTH = 18;
-
-bool isNonRepeatKeyDown(const SDL_Event& event) {
-  return event.type == SDL_KEYDOWN && event.key.repeat == 0;
-}
-
-
-auto createSavedGame(
-  const data::GameSessionId& sessionId,
-  const data::PlayerModel& playerModel
-) {
-  return data::SavedGame{
-    sessionId,
-    playerModel.tutorialMessages(),
-    "", // will be filled in on saving
-    playerModel.weapon(),
-    playerModel.ammo(),
-    playerModel.score()
-  };
-}
-
 
 // Controller handling stuff.
 // TODO: This should move into its own file at some point.
@@ -102,7 +73,7 @@ GameRunner::GameRunner(
   const bool showWelcomeMessage
 )
   : mContext(context)
-  , mSavedGame(createSavedGame(sessionId, *pPlayerModel))
+  , mMenu(context, pPlayerModel, sessionId)
   , mWorld(
       pPlayerModel,
       sessionId,
@@ -110,317 +81,54 @@ GameRunner::GameRunner(
       playerPositionOverride,
       showWelcomeMessage)
 {
-  mStateStack.emplace(World{&mWorld});
 }
 
 
 void GameRunner::handleEvent(const SDL_Event& event) {
-  auto handleSavedGameNameEntryEvent = [&, this](
-    SavedGameNameEntry& state
-  ) {
-    auto leaveTextEntry = [&, this]() {
-      SDL_StopTextInput();
-
-      // Render one last time so we have something to fade out from
-      mContext.mpScriptRunner->updateAndRender(0.0);
-      state.updateAndRender(0.0);
-
-      mStateStack.pop();
-      mStateStack.pop();
-      fadeToWorld();
-    };
-
-    if (isNonRepeatKeyDown(event)) {
-      switch (event.key.keysym.sym) {
-        case SDLK_ESCAPE:
-          leaveTextEntry();
-          return;
-
-        case SDLK_RETURN:
-        case SDLK_KP_ENTER:
-          saveGame(state.mSlotIndex, state.mTextEntryWidget.text());
-          leaveTextEntry();
-          return;
-
-        default:
-          break;
-      }
-    }
-
-    state.mTextEntryWidget.handleEvent(event);
-  };
-
-
-  if (mGameWasQuit || mRequestedGameToLoad) {
+  if (gameQuit() || requestedGameToLoad()) {
     return;
   }
 
-  base::match(mStateStack.top(),
-    [&event, this](World& state) {
-      if (!handleMenuEnterEvent(event)) {
-        state.handleEvent(event);
+  mMenu.handleEvent(event);
+  if (mMenu.isActive()) {
+    // The menu overrides game event handling when it is active, therefore
+    // stop here
+    return;
+  }
 
-        const auto debugModeEnabled =
-          mContext.mpServiceProvider->commandLineOptions().mDebugModeEnabled;
-        if (debugModeEnabled) {
-          state.handleDebugKeys(event);
-        }
-      }
-    },
+  handlePlayerKeyboardInput(event);
+  handlePlayerGameControllerInput(event);
 
-    [&, this](SavedGameNameEntry& state) {
-      handleSavedGameNameEntryEvent(state);
-    },
-
-    [&event](Menu& state) {
-      state.handleEvent(event);
-    },
-
-    [&, this](const ui::OptionsMenu& options) {
-      const auto escapePressed = isNonRepeatKeyDown(event) &&
-        event.key.keysym.sym == SDLK_ESCAPE;
-      if (escapePressed || options.isFinished()) {
-        mStateStack.pop();
-      }
-    });
+  const auto debugModeEnabled =
+    mContext.mpServiceProvider->commandLineOptions().mDebugModeEnabled;
+  if (debugModeEnabled) {
+    handleDebugKeys(event);
+  }
 }
 
 
 void GameRunner::updateAndRender(engine::TimeDelta dt) {
-  if (mGameWasQuit || levelFinished() || mRequestedGameToLoad) {
+  if (gameQuit() || levelFinished() || requestedGameToLoad()) {
     // TODO: This is a workaround to make the fadeout on quitting work.
     // Would be good to find a better way to do this.
     mWorld.render();
     return;
   }
 
-  base::match(mStateStack.top(),
-    [dt, this](Menu& state) {
-      if (state.mIsTransparent) {
-        mWorld.render();
-      }
-
-      state.updateAndRender(dt);
-    },
-
-    [dt, this](ui::OptionsMenu& state) {
-      mWorld.render();
-      state.updateAndRender(dt);
-    },
-
-    [dt, this](SavedGameNameEntry& state) {
-      mContext.mpScriptRunner->updateAndRender(dt);
-      state.updateAndRender(dt);
-    },
-
-    [dt](auto& state) { state.updateAndRender(dt); });
-}
-
-
-bool GameRunner::handleMenuEnterEvent(const SDL_Event& event) {
-  auto leaveMenuHook = [this](const ExecutionResult&) {
-    leaveMenu();
-  };
-
-  auto leaveMenuWithFadeHook = [this](const ExecutionResult&) {
-    leaveMenu();
-    fadeToWorld();
-  };
-
-  auto quitConfirmEventHook = [this](const SDL_Event& ev) {
-    // The user needs to press Y in order to confirm quitting the game, but we
-    // want the confirmation to happen when the key is released, not when it's
-    // pressed. This is because the "a new high score" screen may appear after
-    // quitting the game, and if we were to quit on key down, it's very likely
-    // for the key to still be pressed while the new screen appears. This in
-    // turn would lead to an undesired letter Y being entered into the high
-    // score name entry field, because the text input system would see the key
-    // being released and treated as an input.
-    //
-    // Therefore, we quit on key up. Nevertheless, we still need to prevent the
-    // key down event from reaching the script runner, as it would cancel out
-    // the quit confirmation dialog otherwise.
-    if (ev.type == SDL_KEYDOWN && ev.key.keysym.sym == SDLK_y) {
-      return true;
-    }
-    if (ev.type == SDL_KEYUP && ev.key.keysym.sym == SDLK_y) {
-      mGameWasQuit = ev.type == SDL_KEYUP;
-      return true;
-    }
-
-    return false;
-  };
-
-
-  if (!isNonRepeatKeyDown(event)) {
-    return false;
+  if (updateMenu(dt)) {
+    return;
   }
 
-  switch (event.key.keysym.sym) {
-    case SDLK_ESCAPE:
-      enterMenu("2Quit_Select", leaveMenuHook, quitConfirmEventHook, true);
-      break;
-
-    case SDLK_F1:
-      if (auto pWorld = std::get_if<World>(&mStateStack.top())) {
-        pWorld->mPlayerInput = {};
-      }
-      mStateStack.push(ui::OptionsMenu{
-        mContext.mpUserProfile,
-        mContext.mpServiceProvider,
-        ui::OptionsMenu::Type::InGame});
-      break;
-
-    case SDLK_F2:
-      enterMenu(
-        "Save_Game",
-        [this](const auto& result) { onSaveGameMenuFinished(result); });
-      break;
-
-    case SDLK_F3:
-      enterMenu(
-        "Restore_Game",
-        [this](const auto& result) { onRestoreGameMenuFinished(result); });
-      break;
-
-    case SDLK_h:
-      enterMenu("&Instructions", leaveMenuWithFadeHook);
-      break;
-
-    case SDLK_p:
-      enterMenu("Paused", leaveMenuHook, noopEventHook, true);
-      break;
-
-    default:
-      return false;
-  }
-
-  return true;
-}
-
-
-template <typename ScriptEndHook, typename EventHook>
-void GameRunner::enterMenu(
-  const char* scriptName,
-  ScriptEndHook&& scriptEndedHook,
-  EventHook&& eventHook,
-  const bool isTransparent,
-  const bool shouldClearScriptCanvas
-) {
-  if (auto pWorld = std::get_if<World>(&mStateStack.top())) {
-    pWorld->mPlayerInput = {};
-    pWorld->mpWorld->render();
-  }
-
-  if (shouldClearScriptCanvas) {
-    mContext.mpScriptRunner->clearCanvas();
-  }
-
-  runScript(mContext, scriptName);
-  mStateStack.push(Menu{
-    mContext.mpScriptRunner,
-    std::forward<ScriptEndHook>(scriptEndedHook),
-    std::forward<EventHook>(eventHook),
-    isTransparent});
-}
-
-
-void GameRunner::leaveMenu() {
-  mStateStack.pop();
-}
-
-
-void GameRunner::fadeToWorld() {
-  mContext.mpServiceProvider->fadeOutScreen();
-  mWorld.render();
-  mContext.mpServiceProvider->fadeInScreen();
-}
-
-
-void GameRunner::onRestoreGameMenuFinished(const ExecutionResult& result) {
-  auto showErrorMessageScript = [this](const char* scriptName) {
-    // When selecting a slot that can't be loaded, we show a message and
-    // then return to the save slot selection menu.  The latter stays on the
-    // stack, we push another menu state on top of the stack for showing the
-    // message.
-    enterMenu(
-      scriptName,
-      [this](const auto&) {
-        leaveMenu();
-        runScript(mContext, "Restore_Game");
-      },
-      noopEventHook,
-      false, // isTransparent
-      false); // shouldClearScriptCanvas
-  };
-
-
-  using STT = ui::DukeScriptRunner::ScriptTerminationType;
-
-  if (result.mTerminationType == STT::AbortedByUser) {
-    leaveMenu();
-    fadeToWorld();
-  } else {
-    const auto slotIndex = result.mSelectedPage;
-    const auto& slot = mContext.mpUserProfile->mSaveSlots[*slotIndex];
-    if (slot) {
-      if (
-        mContext.mpServiceProvider->isShareWareVersion() &&
-        slot->mSessionId.needsRegisteredVersion()
-      ) {
-        showErrorMessageScript("No_Can_Order");
-      } else {
-        mRequestedGameToLoad = *slot;
-      }
-    } else {
-      showErrorMessageScript("No_Game_Restore");
-    }
-  }
-}
-
-
-void GameRunner::onSaveGameMenuFinished(const ExecutionResult& result) {
-  using STT = ui::DukeScriptRunner::ScriptTerminationType;
-
-  if (result.mTerminationType == STT::AbortedByUser) {
-    leaveMenu();
-    fadeToWorld();
-  } else {
-    const auto slotIndex = *result.mSelectedPage;
-    SDL_StartTextInput();
-    mStateStack.push(SavedGameNameEntry{mContext, slotIndex});
-  }
-}
-
-
-void GameRunner::saveGame(const int slotIndex, std::string_view name) {
-  auto savedGame = mSavedGame;
-  savedGame.mName = name;
-
-  mContext.mpUserProfile->mSaveSlots[slotIndex] = savedGame;
-  mContext.mpUserProfile->saveToDisk();
-}
-
-
-void GameRunner::World::handleEvent(const SDL_Event& event) {
-  handlePlayerKeyboardInput(event);
-  handlePlayerGameControllerInput(event);
-}
-
-
-void GameRunner::World::updateAndRender(const engine::TimeDelta dt) {
   updateWorld(dt);
-  mpWorld->render();
-
+  mWorld.render();
   renderDebugText();
-
-  mpWorld->processEndOfFrameActions();
+  mWorld.processEndOfFrameActions();
 }
 
 
-void GameRunner::World::updateWorld(const engine::TimeDelta dt) {
+void GameRunner::updateWorld(const engine::TimeDelta dt) {
   auto update = [this]() {
-    mpWorld->updateGameLogic(combinedInput(mPlayerInput, mAnalogStickVector));
+    mWorld.updateGameLogic(combinedInput(mPlayerInput, mAnalogStickVector));
     mPlayerInput.resetTriggeredStates();
   };
 
@@ -439,12 +147,35 @@ void GameRunner::World::updateWorld(const engine::TimeDelta dt) {
       update();
     }
 
-    mpWorld->mpState->mpSystems->updateBackdropAutoScrolling(dt);
+    mWorld.mpState->mpSystems->updateBackdropAutoScrolling(dt);
   }
 }
 
 
-void GameRunner::World::handlePlayerKeyboardInput(const SDL_Event& event) {
+bool GameRunner::updateMenu(const engine::TimeDelta dt) {
+  if (mMenu.isActive()) {
+    // Still render the world if the menu is active, as some menus don't cover
+    // the entire screen. But we don't update the world, since the game is
+    // paused when the menu is active.
+    mPlayerInput = {};
+    mWorld.render();
+
+    const auto result = mMenu.updateAndRender(dt);
+
+    if (result == ui::IngameMenu::UpdateResult::FinishedNeedsFadeout) {
+      mContext.mpServiceProvider->fadeOutScreen();
+      mWorld.render();
+      mContext.mpServiceProvider->fadeInScreen();
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+
+void GameRunner::handlePlayerKeyboardInput(const SDL_Event& event) {
   const auto isKeyEvent = event.type == SDL_KEYDOWN || event.type == SDL_KEYUP;
   if (!isKeyEvent || event.key.repeat != 0) {
     return;
@@ -492,7 +223,7 @@ void GameRunner::World::handlePlayerKeyboardInput(const SDL_Event& event) {
 }
 
 
-void GameRunner::World::handlePlayerGameControllerInput(const SDL_Event& event) {
+void GameRunner::handlePlayerGameControllerInput(const SDL_Event& event) {
   switch (event.type) {
     case SDL_CONTROLLERAXISMOTION:
       switch (event.caxis.axis) {
@@ -510,7 +241,7 @@ void GameRunner::World::handlePlayerGameControllerInput(const SDL_Event& event) 
             // up/down while flying. Therefore, we use a different vertical
             // deadzone when not in the ship.
             const auto deadZone =
-              mpWorld->mpState->mpSystems->player().stateIs<game_logic::InShip>()
+              mWorld.mpState->mpSystems->player().stateIs<game_logic::InShip>()
               ? ANALOG_STICK_DEADZONE_X
               : ANALOG_STICK_DEADZONE_Y;
 
@@ -593,27 +324,12 @@ void GameRunner::World::handlePlayerGameControllerInput(const SDL_Event& event) 
 }
 
 
-void GameRunner::World::renderDebugText() {
-  std::stringstream debugText;
-
-  if (mpWorld->mpState->mpSystems->player().mGodModeOn) {
-    debugText << "GOD MODE on\n";
-  }
-
-  if (mShowDebugText) {
-    mpWorld->printDebugText(debugText);
-  }
-
-  ui::drawText(debugText.str(), 0, 32, {255, 255, 255, 255});
-}
-
-
-void GameRunner::World::handleDebugKeys(const SDL_Event& event) {
-  if (!isNonRepeatKeyDown(event)) {
+void GameRunner::handleDebugKeys(const SDL_Event& event) {
+  if (event.type != SDL_KEYDOWN || event.key.repeat != 0) {
     return;
   }
 
-  auto& debuggingSystem = mpWorld->mpState->mpSystems->debuggingSystem();
+  auto& debuggingSystem = mWorld.mpState->mpSystems->debuggingSystem();
   switch (event.key.keysym.sym) {
     case SDLK_b:
       debuggingSystem.toggleBoundingBoxDisplay();
@@ -643,7 +359,7 @@ void GameRunner::World::handleDebugKeys(const SDL_Event& event) {
 
     case SDLK_F10:
       {
-        auto& player = mpWorld->mpState->mpSystems->player();
+        auto& player = mWorld.mpState->mpSystems->player();
         player.mGodModeOn = !player.mGodModeOn;
       }
       break;
@@ -651,18 +367,18 @@ void GameRunner::World::handleDebugKeys(const SDL_Event& event) {
 }
 
 
-GameRunner::SavedGameNameEntry::SavedGameNameEntry(
-  GameMode::Context context,
-  const int slotIndex
-)
-  : mTextEntryWidget(
-      context.mpUiRenderer,
-      SAVE_SLOT_NAME_ENTRY_POS_X,
-      SAVE_SLOT_NAME_ENTRY_START_POS_Y + slotIndex * SAVE_SLOT_NAME_HEIGHT,
-      MAX_SAVE_SLOT_NAME_LENGTH,
-      ui::TextEntryWidget::Style::BigText)
-  , mSlotIndex(slotIndex)
-{
+void GameRunner::renderDebugText() {
+  std::stringstream debugText;
+
+  if (mWorld.mpState->mpSystems->player().mGodModeOn) {
+    debugText << "GOD MODE on\n";
+  }
+
+  if (mShowDebugText) {
+    mWorld.printDebugText(debugText);
+  }
+
+  ui::drawText(debugText.str(), 0, 32, {255, 255, 255, 255});
 }
 
 }

--- a/src/game_runner.cpp
+++ b/src/game_runner.cpp
@@ -439,7 +439,7 @@ void GameRunner::World::updateWorld(const engine::TimeDelta dt) {
       update();
     }
 
-    mpWorld->mpSystems->updateBackdropAutoScrolling(dt);
+    mpWorld->mpState->mpSystems->updateBackdropAutoScrolling(dt);
   }
 }
 
@@ -510,7 +510,7 @@ void GameRunner::World::handlePlayerGameControllerInput(const SDL_Event& event) 
             // up/down while flying. Therefore, we use a different vertical
             // deadzone when not in the ship.
             const auto deadZone =
-              mpWorld->mpSystems->player().stateIs<game_logic::InShip>()
+              mpWorld->mpState->mpSystems->player().stateIs<game_logic::InShip>()
               ? ANALOG_STICK_DEADZONE_X
               : ANALOG_STICK_DEADZONE_Y;
 
@@ -596,7 +596,7 @@ void GameRunner::World::handlePlayerGameControllerInput(const SDL_Event& event) 
 void GameRunner::World::renderDebugText() {
   std::stringstream debugText;
 
-  if (mpWorld->mpSystems->player().mGodModeOn) {
+  if (mpWorld->mpState->mpSystems->player().mGodModeOn) {
     debugText << "GOD MODE on\n";
   }
 
@@ -613,7 +613,7 @@ void GameRunner::World::handleDebugKeys(const SDL_Event& event) {
     return;
   }
 
-  auto& debuggingSystem = mpWorld->mpSystems->debuggingSystem();
+  auto& debuggingSystem = mpWorld->mpState->mpSystems->debuggingSystem();
   switch (event.key.keysym.sym) {
     case SDLK_b:
       debuggingSystem.toggleBoundingBoxDisplay();
@@ -643,7 +643,7 @@ void GameRunner::World::handleDebugKeys(const SDL_Event& event) {
 
     case SDLK_F10:
       {
-        auto& player = mpWorld->mpSystems->player();
+        auto& player = mpWorld->mpState->mpSystems->player();
         player.mGodModeOn = !player.mGodModeOn;
       }
       break;

--- a/src/ui/duke_script_runner.cpp
+++ b/src/ui/duke_script_runner.cpp
@@ -563,8 +563,7 @@ void DukeScriptRunner::selectPreviousPage(PagerState& state) {
 void DukeScriptRunner::confirmOrSelectNextPage(PagerState& state) {
   if (mPagerState->mMode == PagingMode::Menu) {
     selectCurrentMenuItem(state);
-  }
-  else {
+  } else {
     selectNextPage(state);
   }
 }
@@ -575,8 +574,7 @@ void DukeScriptRunner::handleUnassignedButton(PagerState& state) {
     // Since we cleared the wait state previously, we have to go back
     // to the current page
     executeCurrentPageScript(state);
-  }
-  else {
+  } else {
     selectNextPage(state);
   }
 }

--- a/src/ui/duke_script_runner.cpp
+++ b/src/ui/duke_script_runner.cpp
@@ -59,20 +59,6 @@ const auto INITIAL_GAME_SPEED = 3;
 
 constexpr auto ANALOG_STICK_DEADZONE = 20'000;
 
-
-auto makeSpriteSheet(
-  renderer::Renderer* pRenderer,
-  const loader::ResourceLoader& resourceLoader,
-  const loader::Palette16& palette
-) {
-  return engine::TiledTexture{
-    renderer::OwningTexture{
-      pRenderer,
-      resourceLoader.loadTiledFullscreenImage(
-        "STATUS.MNI", palette)},
-    pRenderer};
-}
-
 }
 
 
@@ -88,7 +74,7 @@ DukeScriptRunner::DukeScriptRunner(
   , mpSaveSlots(pSaveSlots)
   , mpServices(pServiceProvider)
   , mUiSpriteSheetRenderer(
-      makeSpriteSheet(pRenderer, *pResourceLoader, mCurrentPalette))
+      makeUiSpriteSheet(pRenderer, *pResourceLoader, mCurrentPalette))
   , mMenuElementRenderer(&mUiSpriteSheetRenderer, pRenderer, *pResourceLoader)
   , mCanvas(
       pRenderer,
@@ -791,7 +777,7 @@ void DukeScriptRunner::updatePalette(const loader::Palette16& palette) {
 
   mCurrentPalette = palette;
   mUiSpriteSheetRenderer =
-    makeSpriteSheet(mpRenderer, *mpResourceBundle, mCurrentPalette);
+    makeUiSpriteSheet(mpRenderer, *mpResourceBundle, mCurrentPalette);
 }
 
 

--- a/src/ui/duke_script_runner.cpp
+++ b/src/ui/duke_script_runner.cpp
@@ -57,8 +57,6 @@ const auto GAME_SPEED_SLOT = 8;
 const auto INITIAL_SKILL_SELECTION = 1;
 const auto INITIAL_GAME_SPEED = 3;
 
-constexpr auto ANALOG_STICK_DEADZONE = 20'000;
-
 }
 
 
@@ -163,132 +161,41 @@ void DukeScriptRunner::handleEvent(const SDL_Event& event) {
     return;
   }
 
-  // Escape or controller button B always abort
-  if (
-    (event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_ESCAPE) ||
-    (event.type == SDL_CONTROLLERBUTTONDOWN &&
-     event.cbutton.button == SDL_CONTROLLER_BUTTON_B)
-  ) {
+  const auto navigationEvent = mNavigationHelper.convert(event);
+
+  if (navigationEvent == NavigationEvent::Cancel) {
     mState = State::ExecutionInterrupted;
     hideMenuSelectionIndicator();
     return;
   }
 
-  // Any key or controller button stops a wait state (Delay or WaitForInput)
-  if (
-    isInWaitState() &&
-    (event.type == SDL_KEYDOWN || event.type == SDL_CONTROLLERBUTTONDOWN)
-  ) {
+  if (isInWaitState() && navigationEvent != NavigationEvent::None) {
     clearWaitState();
   }
 
-  handleKeyboardEvent(event);
-  handleGameControllerEvent(event);
-}
-
-
-void DukeScriptRunner::handleKeyboardEvent(const SDL_Event& event) {
-  if (event.type != SDL_KEYDOWN) {
-    return;
-  }
-
-  // Arrow keys, Enter and Space are used for pager interaction
   if (hasMenuPages()) {
     auto& state = *mPagerState;
 
-    switch (event.key.keysym.sym) {
-      case SDLK_LEFT:
-      case SDLK_UP:
+    switch (navigationEvent) {
+      case NavigationEvent::NavigateUp:
         selectPreviousPage(state);
         break;
 
-      case SDLK_RIGHT:
-      case SDLK_DOWN:
+      case NavigationEvent::NavigateDown:
         selectNextPage(state);
         break;
 
-      case SDLK_RETURN:
-      case SDLK_SPACE:
-      case SDLK_KP_ENTER:
+      case NavigationEvent::Confirm:
         confirmOrSelectNextPage(state);
         break;
 
-      default:
+      case NavigationEvent::UnassignedButtonPress:
         handleUnassignedButton(state);
         break;
+
+      default:
+        break;
     }
-  }
-}
-
-void DukeScriptRunner::handleGameControllerEvent(const SDL_Event& event) {
-  if (!hasMenuPages()) {
-    return;
-  }
-
-  auto& state = *mPagerState;
-
-  auto handleAxisMotion = [&](
-    const int currentValue,
-    const std::int16_t newValueRaw
-  ) {
-    const auto newValue =
-      base::applyThreshold(newValueRaw, ANALOG_STICK_DEADZONE);
-    if (currentValue >= 0 && newValue < 0) {
-      selectPreviousPage(state);
-    }
-
-    if (currentValue <= 0 && newValue > 0) {
-      selectNextPage(state);
-    }
-
-    return newValue;
-  };
-
-  // The analog sticks and D-Pad select menu items/pages, the A button confirms
-  switch (event.type) {
-    case SDL_CONTROLLERAXISMOTION:
-      switch (event.caxis.axis) {
-        case SDL_CONTROLLER_AXIS_LEFTX:
-        case SDL_CONTROLLER_AXIS_RIGHTX:
-          mAnalogStickVector.x = handleAxisMotion(
-            mAnalogStickVector.x, event.caxis.value);
-          break;
-
-        case SDL_CONTROLLER_AXIS_LEFTY:
-        case SDL_CONTROLLER_AXIS_RIGHTY:
-          mAnalogStickVector.y = handleAxisMotion(
-            mAnalogStickVector.y, event.caxis.value);
-          break;
-
-        default:
-          break;
-      }
-      break;
-
-    case SDL_CONTROLLERBUTTONDOWN:
-      switch (event.cbutton.button) {
-        case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
-        case SDL_CONTROLLER_BUTTON_DPAD_UP:
-          selectPreviousPage(state);
-          break;
-
-        case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
-        case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
-          selectNextPage(state);
-          break;
-
-        case SDL_CONTROLLER_BUTTON_A:
-          confirmOrSelectNextPage(state);
-          break;
-
-        default:
-          handleUnassignedButton(state);
-          break;
-      }
-      break;
-
-    default:
-      break;
   }
 }
 

--- a/src/ui/duke_script_runner.hpp
+++ b/src/ui/duke_script_runner.hpp
@@ -25,6 +25,7 @@
 #include "loader/palette.hpp"
 #include "renderer/texture.hpp"
 #include "ui/menu_element_renderer.hpp"
+#include "ui/menu_navigation_helper.hpp"
 
 #include <cstddef>
 #include <optional>
@@ -165,9 +166,6 @@ private:
 
   void drawCurrentKeyBindings();
 
-  void handleKeyboardEvent(const SDL_Event& event);
-  void handleGameControllerEvent(const SDL_Event& event);
-
   bool hasMenuPages() const;
   void selectNextPage(PagerState& state);
   void selectPreviousPage(PagerState& state);
@@ -227,7 +225,7 @@ private:
 
   std::optional<CheckBoxesState> mCheckBoxStates;
 
-  base::Vector mAnalogStickVector;
+  MenuNavigationHelper mNavigationHelper;
 
   bool mFadeInBeforeNextWaitStateScheduled = false;
   bool mDisableMenuFunctionalityForNextPagesDefinition = false;

--- a/src/ui/ingame_menu.cpp
+++ b/src/ui/ingame_menu.cpp
@@ -122,7 +122,7 @@ void IngameMenu::handleEvent(const SDL_Event& event) {
     return;
   }
 
-  if (mStateStack.empty()) {
+  if (!isActive()) {
     handleMenuEnterEvent(event);
   } else {
     // We want to process menu navigation and similar events in updateAndRender,
@@ -133,6 +133,11 @@ void IngameMenu::handleEvent(const SDL_Event& event) {
 
 
 auto IngameMenu::updateAndRender(engine::TimeDelta dt) -> UpdateResult {
+  if (mMenuToEnter) {
+    enterMenu(*mMenuToEnter);
+    mMenuToEnter.reset();
+  }
+
   mFadeoutNeeded = false;
 
   handleMenuActiveEvents();
@@ -229,27 +234,27 @@ void IngameMenu::handleMenuEnterEvent(const SDL_Event& event) {
 
   switch (event.key.keysym.sym) {
     case SDLK_ESCAPE:
-      enterMenu(MenuType::ConfirmQuit);
+      mMenuToEnter = MenuType::ConfirmQuit;
       break;
 
     case SDLK_F1:
-      enterMenu(MenuType::Options);
+      mMenuToEnter = MenuType::Options;
       break;
 
     case SDLK_F2:
-      enterMenu(MenuType::SaveGame);
+      mMenuToEnter = MenuType::SaveGame;
       break;
 
     case SDLK_F3:
-      enterMenu(MenuType::LoadGame);
+      mMenuToEnter = MenuType::LoadGame;
       break;
 
     case SDLK_h:
-      enterMenu(MenuType::Help);
+      mMenuToEnter = MenuType::Help;
       break;
 
     case SDLK_p:
-      enterMenu(MenuType::Pause);
+      mMenuToEnter = MenuType::Pause;
       break;
 
     default:

--- a/src/ui/ingame_menu.cpp
+++ b/src/ui/ingame_menu.cpp
@@ -228,7 +228,7 @@ void IngameMenu::handleMenuEnterEvent(const SDL_Event& event) {
       return true;
     }
     if (ev.type == SDL_KEYUP && ev.key.keysym.sym == SDLK_y) {
-      mQuitRequested = ev.type == SDL_KEYUP;
+      mQuitRequested = true;
       return true;
     }
 

--- a/src/ui/ingame_menu.cpp
+++ b/src/ui/ingame_menu.cpp
@@ -223,6 +223,42 @@ void IngameMenu::saveGame(const int slotIndex, std::string_view name) {
 
 
 void IngameMenu::handleMenuEnterEvent(const SDL_Event& event) {
+  if (!isNonRepeatKeyDown(event)) {
+    return;
+  }
+
+  switch (event.key.keysym.sym) {
+    case SDLK_ESCAPE:
+      enterMenu(MenuType::ConfirmQuit);
+      break;
+
+    case SDLK_F1:
+      enterMenu(MenuType::Options);
+      break;
+
+    case SDLK_F2:
+      enterMenu(MenuType::SaveGame);
+      break;
+
+    case SDLK_F3:
+      enterMenu(MenuType::LoadGame);
+      break;
+
+    case SDLK_h:
+      enterMenu(MenuType::Help);
+      break;
+
+    case SDLK_p:
+      enterMenu(MenuType::Pause);
+      break;
+
+    default:
+      break;
+  }
+}
+
+
+void IngameMenu::enterMenu(const MenuType type) {
   auto leaveMenuHook = [this](const ExecutionResult&) {
     leaveMenu();
   };
@@ -261,44 +297,37 @@ void IngameMenu::handleMenuEnterEvent(const SDL_Event& event) {
   };
 
 
-  if (!isNonRepeatKeyDown(event)) {
-    return;
-  }
-
-  switch (event.key.keysym.sym) {
-    case SDLK_ESCAPE:
+  switch (type) {
+    case MenuType::ConfirmQuit:
       enterScriptedMenu(
         "2Quit_Select", leaveMenuHook, quitConfirmEventHook, true);
       break;
 
-    case SDLK_F1:
+    case MenuType::Options:
       mStateStack.push(ui::OptionsMenu{
         mContext.mpUserProfile,
         mContext.mpServiceProvider,
         ui::OptionsMenu::Type::InGame});
       break;
 
-    case SDLK_F2:
+    case MenuType::SaveGame:
       enterScriptedMenu(
         "Save_Game",
         [this](const auto& result) { onSaveGameMenuFinished(result); });
       break;
 
-    case SDLK_F3:
+    case MenuType::LoadGame:
       enterScriptedMenu(
         "Restore_Game",
         [this](const auto& result) { onRestoreGameMenuFinished(result); });
       break;
 
-    case SDLK_h:
+    case MenuType::Help:
       enterScriptedMenu("&Instructions", leaveMenuWithFadeHook);
       break;
 
-    case SDLK_p:
+    case MenuType::Pause:
       enterScriptedMenu("Paused", leaveMenuHook, noopEventHook, true);
-      break;
-
-    default:
       break;
   }
 }

--- a/src/ui/ingame_menu.cpp
+++ b/src/ui/ingame_menu.cpp
@@ -163,7 +163,7 @@ void IngameMenu::onRestoreGameMenuFinished(const ExecutionResult& result) {
     // then return to the save slot selection menu.  The latter stays on the
     // stack, we push another menu state on top of the stack for showing the
     // message.
-    enterMenu(
+    enterScriptedMenu(
       scriptName,
       [this](const auto&) {
         leaveMenu();
@@ -267,7 +267,8 @@ void IngameMenu::handleMenuEnterEvent(const SDL_Event& event) {
 
   switch (event.key.keysym.sym) {
     case SDLK_ESCAPE:
-      enterMenu("2Quit_Select", leaveMenuHook, quitConfirmEventHook, true);
+      enterScriptedMenu(
+        "2Quit_Select", leaveMenuHook, quitConfirmEventHook, true);
       break;
 
     case SDLK_F1:
@@ -278,23 +279,23 @@ void IngameMenu::handleMenuEnterEvent(const SDL_Event& event) {
       break;
 
     case SDLK_F2:
-      enterMenu(
+      enterScriptedMenu(
         "Save_Game",
         [this](const auto& result) { onSaveGameMenuFinished(result); });
       break;
 
     case SDLK_F3:
-      enterMenu(
+      enterScriptedMenu(
         "Restore_Game",
         [this](const auto& result) { onRestoreGameMenuFinished(result); });
       break;
 
     case SDLK_h:
-      enterMenu("&Instructions", leaveMenuWithFadeHook);
+      enterScriptedMenu("&Instructions", leaveMenuWithFadeHook);
       break;
 
     case SDLK_p:
-      enterMenu("Paused", leaveMenuHook, noopEventHook, true);
+      enterScriptedMenu("Paused", leaveMenuHook, noopEventHook, true);
       break;
 
     default:
@@ -357,7 +358,7 @@ void IngameMenu::handleMenuActiveEvents() {
 
 
 template <typename ScriptEndHook, typename EventHook>
-void IngameMenu::enterMenu(
+void IngameMenu::enterScriptedMenu(
   const char* scriptName,
   ScriptEndHook&& scriptEndedHook,
   EventHook&& eventHook,

--- a/src/ui/ingame_menu.cpp
+++ b/src/ui/ingame_menu.cpp
@@ -75,14 +75,14 @@ bool isCancelButton(const SDL_Event& event) {
 }
 
 
-void IngameMenu::Menu::handleEvent(const SDL_Event& event) {
+void IngameMenu::ScriptedMenu::handleEvent(const SDL_Event& event) {
   if (!mEventHook(event)) {
     mpScriptRunner->handleEvent(event);
   }
 }
 
 
-void IngameMenu::Menu::updateAndRender(const engine::TimeDelta dt) {
+void IngameMenu::ScriptedMenu::updateAndRender(const engine::TimeDelta dt) {
   mpScriptRunner->updateAndRender(dt);
 
   if (mpScriptRunner->hasFinishedExecution()) {
@@ -342,7 +342,7 @@ void IngameMenu::handleMenuActiveEvents() {
         handleSavedGameNameEntryEvent(state, event);
       },
 
-      [&event](Menu& state) {
+      [&event](ScriptedMenu& state) {
         state.handleEvent(event);
       },
 
@@ -370,7 +370,7 @@ void IngameMenu::enterScriptedMenu(
   }
 
   runScript(mContext, scriptName);
-  mStateStack.push(Menu{
+  mStateStack.push(ScriptedMenu{
     mContext.mpScriptRunner,
     std::forward<ScriptEndHook>(scriptEndedHook),
     std::forward<EventHook>(eventHook),

--- a/src/ui/ingame_menu.cpp
+++ b/src/ui/ingame_menu.cpp
@@ -284,7 +284,6 @@ void IngameMenu::onRestoreGameMenuFinished(const ExecutionResult& result) {
         runScript(mContext, "Restore_Game");
       },
       noopEventHook,
-      false, // isTransparent
       false); // shouldClearScriptCanvas
   };
 
@@ -421,13 +420,11 @@ void IngameMenu::enterMenu(const MenuType type) {
 
   switch (type) {
     case MenuType::ConfirmQuitInGame:
-      enterScriptedMenu(
-        "2Quit_Select", leaveMenuHook, quitConfirmEventHook, true);
+      enterScriptedMenu("2Quit_Select", leaveMenuHook, quitConfirmEventHook);
       break;
 
     case MenuType::ConfirmQuit:
-      enterScriptedMenu(
-        "Quit_Select", leaveMenuHook, quitConfirmEventHook, true);
+      enterScriptedMenu("Quit_Select", leaveMenuHook, quitConfirmEventHook);
       break;
 
     case MenuType::Options:
@@ -454,7 +451,7 @@ void IngameMenu::enterMenu(const MenuType type) {
       break;
 
     case MenuType::Pause:
-      enterScriptedMenu("Paused", leaveMenuHook, noopEventHook, true);
+      enterScriptedMenu("Paused", leaveMenuHook, noopEventHook);
       break;
 
     case MenuType::TopLevel:
@@ -566,7 +563,6 @@ void IngameMenu::enterScriptedMenu(
   const char* scriptName,
   ScriptEndHook&& scriptEndedHook,
   EventHook&& eventHook,
-  const bool isTransparent,
   const bool shouldClearScriptCanvas
 ) {
   if (shouldClearScriptCanvas) {
@@ -577,8 +573,7 @@ void IngameMenu::enterScriptedMenu(
   mStateStack.push(ScriptedMenu{
     mContext.mpScriptRunner,
     std::forward<ScriptEndHook>(scriptEndedHook),
-    std::forward<EventHook>(eventHook),
-    isTransparent});
+    std::forward<EventHook>(eventHook)});
 }
 
 

--- a/src/ui/ingame_menu.cpp
+++ b/src/ui/ingame_menu.cpp
@@ -1,0 +1,371 @@
+/* Copyright (C) 2020, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ingame_menu.hpp"
+
+#include "base/match.hpp"
+#include "common/game_service_provider.hpp"
+#include "common/user_profile.hpp"
+#include "loader/resource_loader.hpp"
+
+
+namespace rigel::ui {
+
+namespace {
+
+constexpr auto SAVE_SLOT_NAME_ENTRY_POS_X = 14;
+constexpr auto SAVE_SLOT_NAME_ENTRY_START_POS_Y = 6;
+constexpr auto SAVE_SLOT_NAME_HEIGHT = 2;
+constexpr auto MAX_SAVE_SLOT_NAME_LENGTH = 18;
+
+
+auto createSavedGame(
+  const data::GameSessionId& sessionId,
+  const data::PlayerModel& playerModel
+) {
+  return data::SavedGame{
+    sessionId,
+    playerModel.tutorialMessages(),
+    "", // will be filled in on saving
+    playerModel.weapon(),
+    playerModel.ammo(),
+    playerModel.score()
+  };
+}
+
+
+bool isNonRepeatKeyDown(const SDL_Event& event) {
+  return event.type == SDL_KEYDOWN && event.key.repeat == 0;
+}
+
+}
+
+
+void IngameMenu::Menu::handleEvent(const SDL_Event& event) {
+  if (!mEventHook(event)) {
+    mpScriptRunner->handleEvent(event);
+  }
+}
+
+
+void IngameMenu::Menu::updateAndRender(const engine::TimeDelta dt) {
+  mpScriptRunner->updateAndRender(dt);
+
+  if (mpScriptRunner->hasFinishedExecution()) {
+    mScriptFinishedHook(*mpScriptRunner->result());
+  }
+}
+
+
+IngameMenu::SavedGameNameEntry::SavedGameNameEntry(
+  GameMode::Context context,
+  const int slotIndex
+)
+  : mTextEntryWidget(
+      context.mpUiRenderer,
+      SAVE_SLOT_NAME_ENTRY_POS_X,
+      SAVE_SLOT_NAME_ENTRY_START_POS_Y + slotIndex * SAVE_SLOT_NAME_HEIGHT,
+      MAX_SAVE_SLOT_NAME_LENGTH,
+      ui::TextEntryWidget::Style::BigText)
+  , mSlotIndex(slotIndex)
+{
+}
+
+
+IngameMenu::IngameMenu(
+  GameMode::Context context,
+  const data::PlayerModel* pPlayerModel,
+  const data::GameSessionId& sessionId
+)
+  : mContext(context)
+  , mSavedGame(createSavedGame(sessionId, *pPlayerModel))
+{
+}
+
+
+void IngameMenu::handleEvent(const SDL_Event& event) {
+  if (mQuitRequested || mRequestedGameToLoad) {
+    return;
+  }
+
+  if (mStateStack.empty()) {
+    handleMenuEnterEvent(event);
+  } else {
+    // We want to process menu navigation and similar events in updateAndRender,
+    // so we only add them to a queue here.
+    mEventQueue.push_back(event);
+  }
+}
+
+
+auto IngameMenu::updateAndRender(engine::TimeDelta dt) -> UpdateResult {
+  mFadeoutNeeded = false;
+
+  handleMenuActiveEvents();
+
+  if (!mStateStack.empty()) {
+    base::match(mStateStack.top(),
+      [dt, this](SavedGameNameEntry& state) {
+        mContext.mpScriptRunner->updateAndRender(dt);
+        state.updateAndRender(dt);
+      },
+
+      [dt](auto& state) { state.updateAndRender(dt); });
+  }
+
+  if (mStateStack.empty()) {
+    return mFadeoutNeeded
+      ? UpdateResult::FinishedNeedsFadeout
+      : UpdateResult::Finished;
+  } else {
+    return UpdateResult::StillActive;
+  }
+}
+
+
+void IngameMenu::onRestoreGameMenuFinished(const ExecutionResult& result) {
+  auto showErrorMessageScript = [this](const char* scriptName) {
+    // When selecting a slot that can't be loaded, we show a message and
+    // then return to the save slot selection menu.  The latter stays on the
+    // stack, we push another menu state on top of the stack for showing the
+    // message.
+    enterMenu(
+      scriptName,
+      [this](const auto&) {
+        leaveMenu();
+        runScript(mContext, "Restore_Game");
+      },
+      noopEventHook,
+      false, // isTransparent
+      false); // shouldClearScriptCanvas
+  };
+
+
+  using STT = ui::DukeScriptRunner::ScriptTerminationType;
+
+  if (result.mTerminationType == STT::AbortedByUser) {
+    leaveMenu();
+    mFadeoutNeeded = true;
+  } else {
+    const auto slotIndex = result.mSelectedPage;
+    const auto& slot = mContext.mpUserProfile->mSaveSlots[*slotIndex];
+    if (slot) {
+      if (
+        mContext.mpServiceProvider->isShareWareVersion() &&
+        slot->mSessionId.needsRegisteredVersion()
+      ) {
+        showErrorMessageScript("No_Can_Order");
+      } else {
+        mRequestedGameToLoad = *slot;
+      }
+    } else {
+      showErrorMessageScript("No_Game_Restore");
+    }
+  }
+}
+
+
+void IngameMenu::onSaveGameMenuFinished(const ExecutionResult& result) {
+  using STT = ui::DukeScriptRunner::ScriptTerminationType;
+
+  if (result.mTerminationType == STT::AbortedByUser) {
+    leaveMenu();
+    mFadeoutNeeded = true;
+  } else {
+    const auto slotIndex = *result.mSelectedPage;
+    SDL_StartTextInput();
+    mStateStack.push(SavedGameNameEntry{mContext, slotIndex});
+  }
+}
+
+
+void IngameMenu::saveGame(const int slotIndex, std::string_view name) {
+  auto savedGame = mSavedGame;
+  savedGame.mName = name;
+
+  mContext.mpUserProfile->mSaveSlots[slotIndex] = savedGame;
+  mContext.mpUserProfile->saveToDisk();
+}
+
+
+void IngameMenu::handleMenuEnterEvent(const SDL_Event& event) {
+  auto leaveMenuHook = [this](const ExecutionResult&) {
+    leaveMenu();
+  };
+
+  auto leaveMenuWithFadeHook = [this](const ExecutionResult&) {
+    leaveMenu();
+    mFadeoutNeeded = true;
+  };
+
+  auto quitConfirmEventHook = [this](const SDL_Event& ev) {
+    // The user needs to press Y in order to confirm quitting the game, but we
+    // want the confirmation to happen when the key is released, not when it's
+    // pressed. This is because the "a new high score" screen may appear after
+    // quitting the game, and if we were to quit on key down, it's very likely
+    // for the key to still be pressed while the new screen appears. This in
+    // turn would lead to an undesired letter Y being entered into the high
+    // score name entry field, because the text input system would see the key
+    // being released and treated as an input.
+    //
+    // Therefore, we quit on key up. Nevertheless, we still need to prevent the
+    // key down event from reaching the script runner, as it would cancel out
+    // the quit confirmation dialog otherwise.
+    if (ev.type == SDL_KEYDOWN && ev.key.keysym.sym == SDLK_y) {
+      return true;
+    }
+    if (ev.type == SDL_KEYUP && ev.key.keysym.sym == SDLK_y) {
+      mQuitRequested = ev.type == SDL_KEYUP;
+      return true;
+    }
+
+    return false;
+  };
+
+
+  if (!isNonRepeatKeyDown(event)) {
+    return;
+  }
+
+  switch (event.key.keysym.sym) {
+    case SDLK_ESCAPE:
+      enterMenu("2Quit_Select", leaveMenuHook, quitConfirmEventHook, true);
+      break;
+
+    case SDLK_F1:
+      mStateStack.push(ui::OptionsMenu{
+        mContext.mpUserProfile,
+        mContext.mpServiceProvider,
+        ui::OptionsMenu::Type::InGame});
+      break;
+
+    case SDLK_F2:
+      enterMenu(
+        "Save_Game",
+        [this](const auto& result) { onSaveGameMenuFinished(result); });
+      break;
+
+    case SDLK_F3:
+      enterMenu(
+        "Restore_Game",
+        [this](const auto& result) { onRestoreGameMenuFinished(result); });
+      break;
+
+    case SDLK_h:
+      enterMenu("&Instructions", leaveMenuWithFadeHook);
+      break;
+
+    case SDLK_p:
+      enterMenu("Paused", leaveMenuHook, noopEventHook, true);
+      break;
+
+    default:
+      break;
+  }
+}
+
+
+void IngameMenu::handleMenuActiveEvents() {
+  auto handleSavedGameNameEntryEvent = [this](
+    SavedGameNameEntry& state,
+    const SDL_Event& event
+  ) {
+    auto leaveTextEntry = [&, this]() {
+      SDL_StopTextInput();
+
+      // Render one last time so we have something to fade out from
+      mContext.mpScriptRunner->updateAndRender(0.0);
+      state.updateAndRender(0.0);
+
+      mStateStack.pop();
+      mStateStack.pop();
+      mFadeoutNeeded = true;
+    };
+
+    if (isNonRepeatKeyDown(event)) {
+      switch (event.key.keysym.sym) {
+        case SDLK_ESCAPE:
+          leaveTextEntry();
+          return;
+
+        case SDLK_RETURN:
+        case SDLK_KP_ENTER:
+          saveGame(state.mSlotIndex, state.mTextEntryWidget.text());
+          leaveTextEntry();
+          return;
+
+        default:
+          break;
+      }
+    }
+
+    state.mTextEntryWidget.handleEvent(event);
+  };
+
+
+  for (const auto& event : mEventQueue) {
+    if (mStateStack.empty()) {
+      break;
+    }
+
+    base::match(mStateStack.top(),
+      [&, this](SavedGameNameEntry& state) {
+        handleSavedGameNameEntryEvent(state, event);
+      },
+
+      [&event](Menu& state) {
+        state.handleEvent(event);
+      },
+
+      [&, this](const ui::OptionsMenu& options) {
+        const auto escapePressed = isNonRepeatKeyDown(event) &&
+          event.key.keysym.sym == SDLK_ESCAPE;
+        if (escapePressed || options.isFinished()) {
+          mStateStack.pop();
+        }
+      });
+  }
+
+  mEventQueue.clear();
+}
+
+
+template <typename ScriptEndHook, typename EventHook>
+void IngameMenu::enterMenu(
+  const char* scriptName,
+  ScriptEndHook&& scriptEndedHook,
+  EventHook&& eventHook,
+  const bool isTransparent,
+  const bool shouldClearScriptCanvas
+) {
+  if (shouldClearScriptCanvas) {
+    mContext.mpScriptRunner->clearCanvas();
+  }
+
+  runScript(mContext, scriptName);
+  mStateStack.push(Menu{
+    mContext.mpScriptRunner,
+    std::forward<ScriptEndHook>(scriptEndedHook),
+    std::forward<EventHook>(eventHook),
+    isTransparent});
+}
+
+
+void IngameMenu::leaveMenu() {
+  mStateStack.pop();
+}
+
+}

--- a/src/ui/ingame_menu.hpp
+++ b/src/ui/ingame_menu.hpp
@@ -111,7 +111,7 @@ private:
   static bool noopEventHook(const SDL_Event&) { return false; }
 
   template <typename ScriptEndHook, typename EventHook = decltype(noopEventHook)>
-  void enterMenu(
+  void enterScriptedMenu(
     const char* scriptName,
     ScriptEndHook&& scriptEndedHook,
     EventHook&& eventHook = noopEventHook,

--- a/src/ui/ingame_menu.hpp
+++ b/src/ui/ingame_menu.hpp
@@ -65,7 +65,7 @@ public:
   }
 
   bool isActive() const {
-    return !mStateStack.empty();
+    return !mStateStack.empty() || mMenuToEnter;
   }
 
 private:
@@ -140,6 +140,7 @@ private:
   std::optional<data::SavedGame> mRequestedGameToLoad;
   std::stack<State, std::vector<State>> mStateStack;
   std::vector<SDL_Event> mEventQueue;
+  std::optional<MenuType> mMenuToEnter;
   bool mQuitRequested = false;
   bool mFadeoutNeeded = false;
 };

--- a/src/ui/ingame_menu.hpp
+++ b/src/ui/ingame_menu.hpp
@@ -1,0 +1,137 @@
+/* Copyright (C) 2020, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "base/spatial_types.hpp"
+#include "base/warnings.hpp"
+#include "common/game_mode.hpp"
+#include "data/bonus.hpp"
+#include "data/saved_game.hpp"
+#include "game_logic/game_world.hpp"
+#include "game_logic/input.hpp"
+#include "ui/duke_script_runner.hpp"
+#include "ui/options_menu.hpp"
+#include "ui/text_entry_widget.hpp"
+
+RIGEL_DISABLE_WARNINGS
+#include <SDL.h>
+RIGEL_RESTORE_WARNINGS
+
+#include <functional>
+#include <optional>
+#include <stack>
+#include <variant>
+#include <vector>
+
+
+namespace rigel::ui {
+
+class IngameMenu {
+public:
+  enum class UpdateResult {
+    StillActive,
+    Finished,
+    FinishedNeedsFadeout
+  };
+
+  IngameMenu(
+    GameMode::Context context,
+    const data::PlayerModel* pPlayerModel,
+    const data::GameSessionId& sessionId);
+
+  void handleEvent(const SDL_Event& event);
+  UpdateResult updateAndRender(engine::TimeDelta dt);
+
+  bool quitRequested() const {
+    return mQuitRequested;
+  }
+
+  std::optional<data::SavedGame> requestedGameToLoad() const {
+    return mRequestedGameToLoad;
+  }
+
+  bool isActive() const {
+    return !mStateStack.empty();
+  }
+
+private:
+  using ExecutionResult = ui::DukeScriptRunner::ExecutionResult;
+
+  struct Menu {
+    template <typename ScriptEndHook, typename EventHook>
+    Menu(
+      ui::DukeScriptRunner* pScriptRunner,
+      ScriptEndHook&& scriptEndHook,
+      EventHook&& eventHook,
+      const bool isTransparent
+    )
+      : mScriptFinishedHook(std::forward<ScriptEndHook>(scriptEndHook))
+      , mEventHook(std::forward<EventHook>(eventHook))
+      , mpScriptRunner(pScriptRunner)
+      , mIsTransparent(isTransparent)
+    {
+    }
+
+    void handleEvent(const SDL_Event& event);
+    void updateAndRender(engine::TimeDelta dt);
+
+    std::function<void(const ExecutionResult&)> mScriptFinishedHook;
+    std::function<bool(const SDL_Event&)> mEventHook;
+    ui::DukeScriptRunner* mpScriptRunner;
+    bool mIsTransparent;
+  };
+
+  struct SavedGameNameEntry {
+    SavedGameNameEntry(GameMode::Context context, const int slotIndex);
+
+    void updateAndRender(engine::TimeDelta dt) {
+      mTextEntryWidget.updateAndRender(dt);
+    }
+
+    ui::TextEntryWidget mTextEntryWidget;
+    int mSlotIndex;
+  };
+
+  using State = std::variant<Menu, SavedGameNameEntry, ui::OptionsMenu>;
+
+  static bool noopEventHook(const SDL_Event&) { return false; }
+
+  template <typename ScriptEndHook, typename EventHook = decltype(noopEventHook)>
+  void enterMenu(
+    const char* scriptName,
+    ScriptEndHook&& scriptEndedHook,
+    EventHook&& eventHook = noopEventHook,
+    bool isTransparent = false,
+    bool shouldClearScriptCanvas = true);
+  void leaveMenu();
+
+  void onRestoreGameMenuFinished(const ExecutionResult& result);
+  void onSaveGameMenuFinished(const ExecutionResult& result);
+  void saveGame(int slotIndex, std::string_view name);
+  void handleMenuEnterEvent(const SDL_Event& event);
+  void handleMenuActiveEvents();
+
+  GameMode::Context mContext;
+  data::SavedGame mSavedGame;
+  std::optional<data::SavedGame> mRequestedGameToLoad;
+  std::stack<State, std::vector<State>> mStateStack;
+  std::vector<SDL_Event> mEventQueue;
+  bool mQuitRequested = false;
+  bool mFadeoutNeeded = false;
+};
+
+}

--- a/src/ui/ingame_menu.hpp
+++ b/src/ui/ingame_menu.hpp
@@ -108,6 +108,15 @@ private:
 
   using State = std::variant<ScriptedMenu, SavedGameNameEntry, ui::OptionsMenu>;
 
+  enum class MenuType {
+    ConfirmQuit,
+    Options,
+    SaveGame,
+    LoadGame,
+    Help,
+    Pause
+  };
+
   static bool noopEventHook(const SDL_Event&) { return false; }
 
   template <typename ScriptEndHook, typename EventHook = decltype(noopEventHook)>
@@ -117,6 +126,7 @@ private:
     EventHook&& eventHook = noopEventHook,
     bool isTransparent = false,
     bool shouldClearScriptCanvas = true);
+  void enterMenu(MenuType type);
   void leaveMenu();
 
   void onRestoreGameMenuFinished(const ExecutionResult& result);

--- a/src/ui/ingame_menu.hpp
+++ b/src/ui/ingame_menu.hpp
@@ -96,13 +96,11 @@ private:
     ScriptedMenu(
       ui::DukeScriptRunner* pScriptRunner,
       ScriptEndHook&& scriptEndHook,
-      EventHook&& eventHook,
-      const bool isTransparent
+      EventHook&& eventHook
     )
       : mScriptFinishedHook(std::forward<ScriptEndHook>(scriptEndHook))
       , mEventHook(std::forward<EventHook>(eventHook))
       , mpScriptRunner(pScriptRunner)
-      , mIsTransparent(isTransparent)
     {
     }
 
@@ -112,7 +110,6 @@ private:
     std::function<void(const ExecutionResult&)> mScriptFinishedHook;
     std::function<bool(const SDL_Event&)> mEventHook;
     ui::DukeScriptRunner* mpScriptRunner;
-    bool mIsTransparent;
   };
 
   struct SavedGameNameEntry {
@@ -150,7 +147,6 @@ private:
     const char* scriptName,
     ScriptEndHook&& scriptEndedHook,
     EventHook&& eventHook = noopEventHook,
-    bool isTransparent = false,
     bool shouldClearScriptCanvas = true);
   void enterMenu(MenuType type);
   void leaveMenu();

--- a/src/ui/ingame_menu.hpp
+++ b/src/ui/ingame_menu.hpp
@@ -71,9 +71,9 @@ public:
 private:
   using ExecutionResult = ui::DukeScriptRunner::ExecutionResult;
 
-  struct Menu {
+  struct ScriptedMenu {
     template <typename ScriptEndHook, typename EventHook>
-    Menu(
+    ScriptedMenu(
       ui::DukeScriptRunner* pScriptRunner,
       ScriptEndHook&& scriptEndHook,
       EventHook&& eventHook,
@@ -106,7 +106,7 @@ private:
     int mSlotIndex;
   };
 
-  using State = std::variant<Menu, SavedGameNameEntry, ui::OptionsMenu>;
+  using State = std::variant<ScriptedMenu, SavedGameNameEntry, ui::OptionsMenu>;
 
   static bool noopEventHook(const SDL_Event&) { return false; }
 

--- a/src/ui/menu_navigation_helper.cpp
+++ b/src/ui/menu_navigation_helper.cpp
@@ -1,0 +1,113 @@
+/* Copyright (C) 2020, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "menu_navigation_helper.hpp"
+
+
+namespace rigel::ui {
+
+namespace {
+
+constexpr auto ANALOG_STICK_DEADZONE = 20'000;
+
+}
+
+
+NavigationEvent MenuNavigationHelper::convert(const SDL_Event& event) {
+  auto handleAxisMotion = [&](int& value, const std::int16_t newValueRaw) {
+    auto result = NavigationEvent::None;
+
+    const auto newValue =
+      base::applyThreshold(newValueRaw, ANALOG_STICK_DEADZONE);
+    if (value >= 0 && newValue < 0) {
+      result = NavigationEvent::NavigateUp;
+    }
+    if (value <= 0 && newValue > 0) {
+      result = NavigationEvent::NavigateDown;
+    }
+
+    value = newValue;
+
+    return result;
+  };
+
+
+  switch (event.type) {
+    case SDL_KEYDOWN:
+      switch (event.key.keysym.sym) {
+        case SDLK_LEFT:
+        case SDLK_UP:
+          return NavigationEvent::NavigateUp;
+
+        case SDLK_RIGHT:
+        case SDLK_DOWN:
+          return NavigationEvent::NavigateDown;
+
+        case SDLK_RETURN:
+        case SDLK_SPACE:
+        case SDLK_KP_ENTER:
+          return NavigationEvent::Confirm;
+
+        case SDLK_ESCAPE:
+          return NavigationEvent::Cancel;
+
+        default:
+          return NavigationEvent::UnassignedButtonPress;
+      }
+
+    case SDL_CONTROLLERAXISMOTION:
+      switch (event.caxis.axis) {
+        case SDL_CONTROLLER_AXIS_LEFTX:
+        case SDL_CONTROLLER_AXIS_RIGHTX:
+          return handleAxisMotion(mAnalogStickVector.x, event.caxis.value);
+
+        case SDL_CONTROLLER_AXIS_LEFTY:
+        case SDL_CONTROLLER_AXIS_RIGHTY:
+          return handleAxisMotion(mAnalogStickVector.y, event.caxis.value);
+
+        default:
+          break;
+      }
+      break;
+
+    case SDL_CONTROLLERBUTTONDOWN:
+      switch (event.cbutton.button) {
+        case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
+        case SDL_CONTROLLER_BUTTON_DPAD_UP:
+          return NavigationEvent::NavigateUp;
+
+        case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
+        case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
+          return NavigationEvent::NavigateDown;
+
+        case SDL_CONTROLLER_BUTTON_A:
+          return NavigationEvent::Confirm;
+
+        case SDL_CONTROLLER_BUTTON_B:
+          return NavigationEvent::Cancel;
+
+        default:
+          return NavigationEvent::UnassignedButtonPress;
+      }
+
+    default:
+      break;
+  }
+
+  return NavigationEvent::None;
+}
+
+}

--- a/src/ui/menu_navigation_helper.hpp
+++ b/src/ui/menu_navigation_helper.hpp
@@ -1,0 +1,47 @@
+/* Copyright (C) 2020, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "base/spatial_types.hpp"
+#include "base/warnings.hpp"
+
+RIGEL_DISABLE_WARNINGS
+#include <SDL.h>
+RIGEL_RESTORE_WARNINGS
+
+
+namespace rigel::ui {
+
+enum class NavigationEvent {
+  None,
+  NavigateUp,
+  NavigateDown,
+  Confirm,
+  Cancel,
+  UnassignedButtonPress
+};
+
+
+class MenuNavigationHelper {
+public:
+  NavigationEvent convert(const SDL_Event& event);
+
+private:
+  base::Vector mAnalogStickVector;
+};
+
+}

--- a/src/ui/utils.cpp
+++ b/src/ui/utils.cpp
@@ -48,6 +48,20 @@ renderer::OwningTexture fullScreenImageAsTexture(
 }
 
 
+engine::TiledTexture makeUiSpriteSheet(
+  renderer::Renderer* pRenderer,
+  const loader::ResourceLoader& resourceLoader,
+  const loader::Palette16& palette
+) {
+  return engine::TiledTexture{
+    renderer::OwningTexture{
+      pRenderer,
+      resourceLoader.loadTiledFullscreenImage(
+        "STATUS.MNI", palette)},
+    pRenderer};
+}
+
+
 void drawText(
   const std::string_view text,
   const int x,

--- a/src/ui/utils.hpp
+++ b/src/ui/utils.hpp
@@ -17,6 +17,8 @@
 #pragma once
 
 #include "base/color.hpp"
+#include "engine/tiled_texture.hpp"
+#include "loader/palette.hpp"
 #include "renderer/texture.hpp"
 
 #include <string_view>
@@ -33,6 +35,10 @@ renderer::OwningTexture fullScreenImageAsTexture(
   const loader::ResourceLoader& resources,
   const std::string& imageName);
 
+engine::TiledTexture makeUiSpriteSheet(
+  renderer::Renderer* pRenderer,
+  const loader::ResourceLoader& resourceLoader,
+  const loader::Palette16& palette);
 
 void drawText(std::string_view text, int x, int y, const base::Color& color);
 


### PR DESCRIPTION
Closes #477 
Closes #487

Also fixes music not resetting when dying in a boss level.

Also includes a whole bunch of refactoring, needs thorough testing.

Todo:

* [x] Remove now unused `ScriptedMenu::mIsTransparent`
* [x] Store `WorldState` as pointer from its introduction on for less noisy commit diff?
* [x] Make some constants for the magic numbers in the menu rendering
* [ ] Handle all NavigationEvents inside `TopLevelMenu`? Will do this later, when extracting a reusable menu class.
* [x] Fix https://github.com/lethal-guitar/RigelEngine/pull/553/commits/b9da7f0656af0312288cb55eff5792a8fce43dd0#diff-d6d493717ed12b651a399f85b6a91634L232 - it should not yet change to `ComfirmQuitIngame`