### PR TITLE
Full gamepad & keyboard navigation

### DIFF
--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -771,12 +771,18 @@ void Game::applyChangedOptions() {
   const auto& currentOptions = mpUserProfile->mOptions;
 
   if (currentOptions.mWindowMode != mPreviousOptions.mWindowMode) {
-    SDL_SetWindowFullscreen(
+    const auto result = SDL_SetWindowFullscreen(
       mpWindow, flagsForWindowMode(currentOptions.mWindowMode));
 
-    if (currentOptions.mWindowMode == data::WindowMode::Windowed) {
-      SDL_SetWindowSize(
-        mpWindow, currentOptions.mWindowWidth, currentOptions.mWindowHeight);
+    if (result != 0) {
+      std::cerr <<
+        "WARNING: Failed to set window mode: " << SDL_GetError() << '\n';
+      mpUserProfile->mOptions.mWindowMode = mPreviousOptions.mWindowMode;
+    } else {
+      if (currentOptions.mWindowMode == data::WindowMode::Windowed) {
+        SDL_SetWindowSize(
+          mpWindow, currentOptions.mWindowWidth, currentOptions.mWindowHeight);
+      }
     }
   }
 

--- a/src/game_runner.cpp
+++ b/src/game_runner.cpp
@@ -154,11 +154,11 @@ void GameRunner::updateWorld(const engine::TimeDelta dt) {
 
 bool GameRunner::updateMenu(const engine::TimeDelta dt) {
   if (mMenu.isActive()) {
-    // Still render the world if the menu is active, as some menus don't cover
-    // the entire screen. But we don't update the world, since the game is
-    // paused when the menu is active.
     mPlayerInput = {};
-    mWorld.render();
+
+    if (mMenu.isTransparent()) {
+      mWorld.render();
+    }
 
     const auto result = mMenu.updateAndRender(dt);
 

--- a/src/menu_mode.cpp
+++ b/src/menu_mode.cpp
@@ -61,11 +61,6 @@ MenuMode::MenuMode(Context context)
 
 
 void MenuMode::handleEvent(const SDL_Event& event) {
-  if (mOptionsMenu && ui::isCancelButton(event)) {
-    mOptionsMenu = std::nullopt;
-    return;
-  }
-
   if (mOptionsMenu) {
     // Options menu blocks all input
     return;

--- a/src/ui/imgui_integration.cpp
+++ b/src/ui/imgui_integration.cpp
@@ -81,6 +81,9 @@ void init(
   ImGui::CreateContext();
   ImGui::StyleColorsDark();
 
+  ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+  ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
+
   {
     // We rasterize the font at a size that looks good at a 4k resolution, and
     // then scale it down for smaller screen sizes.

--- a/src/ui/imgui_integration.cpp
+++ b/src/ui/imgui_integration.cpp
@@ -62,7 +62,10 @@ void updateUiScale(const int, const int newHeight) {
   // (3840 x 2160) represents "full" size, and smaller vertical resolutions are
   // scaled down accordingly, i.e. half of 4k resolution (1080) would result in
   // a scale factor of 0.5.
-  const auto scaleFactor = std::clamp(newHeight / VERTICAL_4K_RES, 0.0f, 1.0f);
+  const auto scaleFactor = std::clamp(
+    newHeight / VERTICAL_4K_RES,
+    1.0f / INITIAL_UI_SCALE,
+    1.0f);
 
   ImGui::GetIO().FontGlobalScale = scaleFactor;
   ImGui::GetStyle() = ImGuiStyle{};

--- a/src/ui/ingame_menu.cpp
+++ b/src/ui/ingame_menu.cpp
@@ -521,14 +521,21 @@ void IngameMenu::handleMenuActiveEvents() {
         state.handleEvent(event);
       },
 
-      [&, this](const ui::OptionsMenu& options) {
-        if (isCancelButton(event) || options.isFinished()) {
-          mStateStack.pop();
-        }
+      [&](const ui::OptionsMenu&) {
+        // handled by Dear ImGui
       });
   }
 
   mEventQueue.clear();
+
+  // Handle options menu being closed
+  if (
+    !mStateStack.empty() &&
+    std::holds_alternative<ui::OptionsMenu>(mStateStack.top()) &&
+    std::get<ui::OptionsMenu>(mStateStack.top()).isFinished()
+  ) {
+    mStateStack.pop();
+  }
 }
 
 

--- a/src/ui/ingame_menu.cpp
+++ b/src/ui/ingame_menu.cpp
@@ -193,6 +193,22 @@ IngameMenu::IngameMenu(
 }
 
 
+bool IngameMenu::isTransparent() const {
+  if (mStateStack.empty()) {
+    return true;
+  }
+
+  if (mpTopLevelMenu) {
+    return false;
+  }
+
+  return base::match(mStateStack.top(),
+    [](const ScriptedMenu& state) { return state.mIsTransparent; },
+    [](const ui::OptionsMenu&) { return true; },
+    [](const auto&) { return false; });
+}
+
+
 void IngameMenu::handleEvent(const SDL_Event& event) {
   if (mQuitRequested || mRequestedGameToLoad) {
     return;
@@ -259,6 +275,7 @@ void IngameMenu::onRestoreGameMenuFinished(const ExecutionResult& result) {
         runScript(mContext, "Restore_Game");
       },
       noopEventHook,
+      false, // isTransparent
       false); // shouldClearScriptCanvas
   };
 
@@ -395,7 +412,8 @@ void IngameMenu::enterMenu(const MenuType type) {
 
   switch (type) {
     case MenuType::ConfirmQuitInGame:
-      enterScriptedMenu("2Quit_Select", leaveMenuHook, quitConfirmEventHook);
+      enterScriptedMenu(
+        "2Quit_Select", leaveMenuHook, quitConfirmEventHook, true);
       break;
 
     case MenuType::ConfirmQuit:
@@ -426,7 +444,7 @@ void IngameMenu::enterMenu(const MenuType type) {
       break;
 
     case MenuType::Pause:
-      enterScriptedMenu("Paused", leaveMenuHook, noopEventHook);
+      enterScriptedMenu("Paused", leaveMenuHook, noopEventHook, true);
       break;
 
     case MenuType::TopLevel:
@@ -549,6 +567,7 @@ void IngameMenu::enterScriptedMenu(
   const char* scriptName,
   ScriptEndHook&& scriptEndedHook,
   EventHook&& eventHook,
+  const bool isTransparent,
   const bool shouldClearScriptCanvas
 ) {
   if (shouldClearScriptCanvas) {
@@ -559,7 +578,8 @@ void IngameMenu::enterScriptedMenu(
   mStateStack.push(ScriptedMenu{
     mContext.mpScriptRunner,
     std::forward<ScriptEndHook>(scriptEndedHook),
-    std::forward<EventHook>(eventHook)});
+    std::forward<EventHook>(eventHook),
+    isTransparent});
 }
 
 

--- a/src/ui/ingame_menu.cpp
+++ b/src/ui/ingame_menu.cpp
@@ -42,6 +42,7 @@ constexpr auto MAX_SAVE_SLOT_NAME_LENGTH = 18;
 constexpr auto TOP_LEVEL_MENU_ITEMS = std::array{
   "Save Game",
   "Restore Game",
+  "Options",
   "Help",
   "Quit Game"
 };
@@ -493,6 +494,10 @@ void IngameMenu::handleMenuActiveEvents() {
 
             case itemIndex("Restore Game"):
               enterMenu(MenuType::LoadGame);
+              break;
+
+            case itemIndex("Options"):
+              enterMenu(MenuType::Options);
               break;
 
             case itemIndex("Help"):

--- a/src/ui/ingame_menu.hpp
+++ b/src/ui/ingame_menu.hpp
@@ -54,6 +54,14 @@ public:
     const data::PlayerModel* pPlayerModel,
     const data::GameSessionId& sessionId);
 
+  /** Indicates that the game should be rendered before rendering the menu
+   *
+   * If this returns true, the menu is currently using only parts of the
+   * screen. The game world should be rendered before rendering the menu, in
+   * order to make the menu appear overlaid on top of the gameplay.
+   */
+  bool isTransparent() const;
+
   void handleEvent(const SDL_Event& event);
   UpdateResult updateAndRender(engine::TimeDelta dt);
 
@@ -96,11 +104,13 @@ private:
     ScriptedMenu(
       ui::DukeScriptRunner* pScriptRunner,
       ScriptEndHook&& scriptEndHook,
-      EventHook&& eventHook
+      EventHook&& eventHook,
+      const bool isTransparent
     )
       : mScriptFinishedHook(std::forward<ScriptEndHook>(scriptEndHook))
       , mEventHook(std::forward<EventHook>(eventHook))
       , mpScriptRunner(pScriptRunner)
+      , mIsTransparent(isTransparent)
     {
     }
 
@@ -110,6 +120,7 @@ private:
     std::function<void(const ExecutionResult&)> mScriptFinishedHook;
     std::function<bool(const SDL_Event&)> mEventHook;
     ui::DukeScriptRunner* mpScriptRunner;
+    bool mIsTransparent;
   };
 
   struct SavedGameNameEntry {
@@ -147,6 +158,7 @@ private:
     const char* scriptName,
     ScriptEndHook&& scriptEndedHook,
     EventHook&& eventHook = noopEventHook,
+    bool isTransparent = false,
     bool shouldClearScriptCanvas = true);
   void enterMenu(MenuType type);
   void leaveMenu();

--- a/src/ui/options_menu.cpp
+++ b/src/ui/options_menu.cpp
@@ -116,8 +116,18 @@ void OptionsMenu::updateAndRender(engine::TimeDelta dt) {
 
   ImGui::SetMouseCursor(ImGuiMouseCursor_Arrow);
 
-  const auto& io = ImGui::GetIO();
+  if (mPopupOpened && !ImGui::IsPopupOpen("Options")) {
+    // Popup was closed, quit the options menu
+    mMenuOpen = false;
+    return;
+  }
 
+  if (mMenuOpen && !mPopupOpened) {
+    ImGui::OpenPopup("Options");
+    mPopupOpened = true;
+  }
+
+  const auto& io = ImGui::GetIO();
   const auto windowSize = io.DisplaySize;
   const auto sizeToUse = ImVec2{windowSize.x * SCALE, windowSize.y * SCALE};
   const auto offset = ImVec2{
@@ -126,11 +136,14 @@ void OptionsMenu::updateAndRender(engine::TimeDelta dt) {
 
   ImGui::SetNextWindowSize(sizeToUse);
   ImGui::SetNextWindowPos(offset);
-  ImGui::Begin(
+
+  if (!ImGui::BeginPopup(
     "Options",
-    &mMenuOpen,
     ImGuiWindowFlags_NoCollapse |
-    ImGuiWindowFlags_NoResize);
+    ImGuiWindowFlags_NoResize))
+  {
+    return;
+  }
 
   if (ImGui::BeginTabBar("Tabs"))
   {
@@ -253,7 +266,7 @@ Going back to a registered version will make them work again.)");
     }
   }
 
-  ImGui::End();
+  ImGui::EndPopup();
 }
 
 

--- a/src/ui/options_menu.hpp
+++ b/src/ui/options_menu.hpp
@@ -55,6 +55,7 @@ private:
   IGameServiceProvider* mpServiceProvider;
   Type mType;
   bool mMenuOpen = true;
+  bool mPopupOpened = false;
   bool mShowErrorBox = false;
 };
 


### PR DESCRIPTION
* All ImGui-based menus are now usable with gamepad and keyboard: Options menu, game path browser, error message display.
* Limits the minimum UI scale in order to make the UI readable on a small screen, like on the Odroid Go Advance.
* Fixes a regression where the game would show left and right of in-game menus when wide-screen mode is on.

In the menus, use D-Pad or arrow keys to select UI elements, confirm/cancel buttons to interact (spacebar/escape on keyboard, A/B or equivalent buttons on gamepad). The UI isn't optimized for small screen sizes yet and looks a bit wonky, but is already perfectly usable on my Odroid. The options menu will see a big overhaul in the future (#404), which should also make it nicer for gamepad navigation, so it doesn't make so much sense to polish it too much now.

Closes #420 
Closes #555 