### PR TITLE
Webassembly changes for running Rigel Engine in a web browser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,51 @@ option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
-set(Boost_USE_STATIC_LIBS ON)
-find_package(Boost 1.65 COMPONENTS program_options REQUIRED)
-find_package(SDL2 REQUIRED)
-find_package(SDL2_mixer REQUIRED)
+
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
+    set(WEBASSEMBLY_GAME_PATH "" CACHE PATH "Path to folder containing Duke Nukem II files")
+    set(USE_GL_ES ON)
+
+    if (NOT WEBASSEMBLY_GAME_PATH)
+        message(FATAL_ERROR
+            "WEBASSEMBLY_GAME_PATH not defined. This is required for a Webassembly build. Point it to a folder containing Duke Nukem II data files. Remove any trailing '/' from the path.")
+    else()
+        message(STATUS "Bundling game data from path: ${WEBASSEMBLY_GAME_PATH}")
+    endif()
+
+    add_compile_options(
+        "SHELL:-s WASM=1"
+        -O3
+    )
+
+    add_library(SDL2::Core INTERFACE IMPORTED)
+    set_target_properties(SDL2::Core PROPERTIES
+        INTERFACE_COMPILE_OPTIONS
+        "SHELL:-s USE_SDL=2"
+        INTERFACE_LINK_OPTIONS
+        "SHELL:-s USE_SDL=2"
+    )
+
+    add_library(SDL2::Mixer INTERFACE IMPORTED)
+    set_target_properties(SDL2::Mixer PROPERTIES
+        INTERFACE_COMPILE_OPTIONS
+        "SHELL:-s USE_SDL_MIXER=2"
+        INTERFACE_LINK_OPTIONS
+        "SHELL:-s USE_SDL_MIXER=2"
+    )
+
+    add_library(Boost::boost INTERFACE IMPORTED)
+    set_target_properties(Boost::boost PROPERTIES
+        INTERFACE_COMPILE_OPTIONS
+        "SHELL:-s USE_BOOST_HEADERS=1"
+    )
+else()
+    set(Boost_USE_STATIC_LIBS ON)
+    find_package(Boost 1.65 COMPONENTS program_options REQUIRED)
+    find_package(SDL2 REQUIRED)
+    find_package(SDL2_mixer REQUIRED)
+endif()
+
 find_package(Filesystem REQUIRED)
 
 
@@ -114,8 +155,11 @@ target_compile_options(entityx PRIVATE
 # RigelEngine build targets
 ###############################################################################
 
-enable_testing()
-
-add_subdirectory(modding_tools)
 add_subdirectory(src)
-add_subdirectory(test)
+
+if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
+    enable_testing()
+
+    add_subdirectory(modding_tools)
+    add_subdirectory(test)
+endif()

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ I'm planning to provide binaries for OS X, Ubuntu/Debian, and Raspberry Pi in th
 * [Raspberry Pi builds](#raspi-build-instructions)
 * [OS X builds](#mac-build-instructions)
 * [Windows builds](#windows-build-instructions)
+* [Webassembly (Emscripten) builds](#wasm-build-instructions)
 
 ### Get the sources
 
@@ -324,3 +325,34 @@ cmake .. -DWARNINGS_AS_ERRORS=OFF -DCMAKE_TOOLCHAIN_FILE=<vckpkg_root>/scripts/b
 # This will open the generated Visual Studio solution
 start RigelEngine.sln
 ```
+### <a name="wasm-build-instructions">Webassembly (Emscripten) build </a>
+
+Rigel Engine can be built to run on a web browser using [Emscripten](https://emscripten.org/).
+Note that this is still work in progress, as there are some [issues](https://github.com/lethal-guitar/RigelEngine/milestone/16) to resolve.
+
+Refer to Emscripten's [README](https://github.com/emscripten-core/emsdk) for instructions on how to install and activate Emscripten.
+You can verify the installation by running the `emcc` command. If it executes then everything is configured correctly.
+
+The instructions to build are the same as above, except for the CMake part:
+
+```bash
+emcmake cmake .. -DWARNINGS_AS_ERRORS=OFF -DWEBASSEMBLY_GAME_PATH=<path-to-duke2-folder>
+make
+```
+
+This will produce a couple of files in the `<path-to-cmake-build-dir>/src` folder.
+To run the game, you need to run a web server to host the files in that folder,
+and then open `Rigel.html` in your browser.
+Just opening `Rigel.html` directly will not work, as the web page needs to load the wasm code and data, which most browsers don't allow when using the local `file:///` protocol.
+
+The easiest way to host the files is using Python. In the CMake build directory, run:
+
+```bash
+# Python 2
+python -m SimpleHTTPServer
+
+# Python 3
+python3 -m http.server
+```
+
+This will host the game at `localhost:8000/src/Rigel.html`.

--- a/emscripten/Rigel.html
+++ b/emscripten/Rigel.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+      html, body, canvas {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+        background-color: black;
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="canvas" oncontextmenu="event.preventDefault()"></canvas>
+    <script>
+      Module = {
+        canvas: document.getElementById('canvas')
+      }
+    </script>
+    <script async type="text/javascript" src="RigelEngine.js"></script>
+  </body>
+</html>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -353,12 +353,31 @@ endif()
 
 
 # Main executable
-add_executable(${main_exe_name} main.cpp)
-target_link_libraries(${main_exe_name} PRIVATE
-    SDL2::Main
-    rigel_core
-    Boost::boost
-    Boost::program_options
-    Boost::disable_autolinking
-)
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
+    add_executable(${main_exe_name} emscripten_main.cpp)
+    target_link_libraries(${main_exe_name} PRIVATE
+      rigel_core
+    )
+    target_link_options(${main_exe_name} PRIVATE
+        "SHELL:-s ALLOW_MEMORY_GROWTH=1"
+        "SHELL:-s MIN_WEBGL_VERSION=1"
+        "SHELL:-s MAX_WEBGL_VERSION=2"
+        "SHELL:-s FULL_ES2=1"
+        "SHELL:--preload-file ${WEBASSEMBLY_GAME_PATH}/@/duke"
+        --no-heap-copy
+    )
 
+    # copy html file for hosting wasm and generated js to destination
+    # a better solution will be to find out a way for emscripten to generate html file instead of js file
+    # and use --shell-file to provide a custom html template
+    file(COPY "${CMAKE_SOURCE_DIR}/emscripten/Rigel.html" DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+else()
+    add_executable(${main_exe_name} main.cpp)
+    target_link_libraries(${main_exe_name} PRIVATE
+        SDL2::Main
+        rigel_core
+        Boost::boost
+        Boost::program_options
+        Boost::disable_autolinking
+    )
+endif()

--- a/src/emscripten_main.cpp
+++ b/src/emscripten_main.cpp
@@ -1,0 +1,91 @@
+/* Copyright (C) 2016, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Welcome to the RigelEngine code base! If you are looking for the place in
+// the code where everything starts, that would be in main.cpp. This file contains the
+// main() function entry point for running RigelEngine in webassembly using emscripten.
+// During all non-webassembly compilations, this file is ignored.
+
+#include "base/warnings.hpp"
+
+#include "base/defer.hpp"
+#include "common/user_profile.hpp"
+#include "renderer/opengl.hpp"
+#include "sdl_utils/error.hpp"
+#include "ui/imgui_integration.hpp"
+
+#include "platform.hpp"
+#include "game_main.hpp"
+
+RIGEL_DISABLE_WARNINGS
+#include <emscripten.h>
+#include <SDL.h>
+RIGEL_RESTORE_WARNINGS
+
+#include <iostream>
+
+
+using namespace rigel;
+
+namespace {
+
+// This is the path in the virtual file system (provided by emscripten, defined in cmake)
+// where Duke Nukem II game data can be found.
+// A path to valid data has to be given to cmake via the WEBASSEMBLY_GAME_PATH argument,
+// and will be included in the build output.
+constexpr auto WASM_GAME_PATH = "/duke/";
+
+void runOneFrameWrapper(void *pData) {
+  runOneFrame(static_cast<Game*>(pData));
+}
+
+}
+
+
+int main()
+{
+  using base::defer;
+
+  sdl_utils::check(SDL_Init(
+    SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER));
+  auto sdlGuard = defer([]() { SDL_Quit(); });
+
+  sdl_utils::check(SDL_GL_LoadLibrary(nullptr));
+  platform::setGLAttributes();
+
+  auto userProfile = loadOrCreateUserProfile();
+  auto pWindow = platform::createWindow(userProfile.mOptions);
+  SDL_GLContext pGlContext =
+    sdl_utils::check(SDL_GL_CreateContext(pWindow.get()));
+  auto glGuard = defer([pGlContext]() { SDL_GL_DeleteContext(pGlContext); });
+
+  renderer::loadGlFunctions();
+
+  SDL_DisableScreenSaver();
+  SDL_ShowCursor(SDL_DISABLE);
+
+  ui::imgui_integration::init(
+    pWindow.get(), pGlContext, createOrGetPreferencesPath());
+  auto imGuiGuard = defer([]() { ui::imgui_integration::shutdown(); });
+
+  CommandLineOptions options;
+  options.mGamePath = WASM_GAME_PATH;
+
+  auto pGame = createGame(pWindow.get(), &userProfile, options);
+  emscripten_set_main_loop_arg(runOneFrameWrapper, pGame.get(), 0, true);
+
+  return 0;
+}


### PR DESCRIPTION
This PR is a refactored and reduced version of #531 where it enabled Rigel Engine to run on the web using webassembly. It uses emscripten library to cross compile to webassembly. The compilation targets are cleanly separated. webassembly related files are only compiled when running under emscripten. A new entry point is provided in emscripten_main.cpp when running under emscripten. More changes are newer variable WEBASSEMBLY_GAME_PATH for providing path of folder containing Duke Nukem II resources. Currently, an html file Rigel.html is copied to build folder which loads the js and wasm. There are more options in Emscripten which can skip this part by directly creating an html file and using a template using --shell-file. It can be explored in the future
Image of rigel engine running in webassembly : https://imgur.com/gallery/vtbxjVo