### PR TITLE
Saved game auto naming

### DIFF
--- a/src/ui/ingame_menu.hpp
+++ b/src/ui/ingame_menu.hpp
@@ -124,7 +124,10 @@ private:
   };
 
   struct SavedGameNameEntry {
-    SavedGameNameEntry(GameMode::Context context, const int slotIndex);
+    SavedGameNameEntry(
+      GameMode::Context context,
+      int slotIndex,
+      std::string_view initialName);
 
     void updateAndRender(engine::TimeDelta dt) {
       mTextEntryWidget.updateAndRender(dt);
@@ -165,7 +168,6 @@ private:
   void fadeout();
 
   void onRestoreGameMenuFinished(const ExecutionResult& result);
-  void onSaveGameMenuFinished(const ExecutionResult& result);
   void saveGame(int slotIndex, std::string_view name);
   void handleMenuEnterEvent(const SDL_Event& event);
   void handleMenuActiveEvents();

--- a/src/ui/text_entry_widget.cpp
+++ b/src/ui/text_entry_widget.cpp
@@ -40,9 +40,11 @@ TextEntryWidget::TextEntryWidget(
   const int posX,
   const int posY,
   const int maxTextLength,
-  const Style textStyle
+  const Style textStyle,
+  const std::string_view initialText
 )
-  : mpUiRenderer(pUiRenderer)
+  : mText(initialText)
+  , mpUiRenderer(pUiRenderer)
   , mPosX(posX)
   , mPosY(posY)
   , mMaxTextLength(maxTextLength)

--- a/src/ui/text_entry_widget.hpp
+++ b/src/ui/text_entry_widget.hpp
@@ -43,7 +43,8 @@ public:
     int posX,
     int posY,
     int maxTextLength,
-    Style textStyle);
+    Style textStyle,
+    std::string_view initialText = "");
 
   void handleEvent(const SDL_Event& event);
   void updateAndRender(engine::TimeDelta dt);


### PR DESCRIPTION
Automatically inserts a name when saving the game using a gamepad. This improves the experience for console-like platforms where a keyboard is not available.

Closes #558 