### PR TITLE
More Wasm improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Rigel Engine can be built to run on a web browser using [Emscripten](https://ems
 Note that this is still work in progress, as there are some [issues](https://github.com/lethal-guitar/RigelEngine/milestone/16) to resolve.
 
 Refer to Emscripten's [README](https://github.com/emscripten-core/emsdk) for instructions on how to install and activate Emscripten.
-You can verify the installation by running the `emcc` command. If it executes then everything is configured correctly.
+You can verify the installation by running the `emcc` command. If it executes without errors then everything is configured correctly.
 
 The instructions to build are the same as above, except for the CMake part:
 
@@ -342,8 +342,8 @@ make
 
 This will produce a couple of files in the `<path-to-cmake-build-dir>/src` folder.
 To run the game, you need to run a web server to host the files in that folder,
-and then open `Rigel.html` in your browser.
-Just opening `Rigel.html` directly will not work, as the web page needs to load the wasm code and data, which most browsers don't allow when using the local `file:///` protocol.
+and then open `RigelEngine.html` in your browser.
+Just opening `RigelEngine.html` directly will not work, as the web page needs to load the wasm code and data, which most browsers don't allow when using the local `file:///` protocol.
 
 The easiest way to host the files is using Python. In the CMake build directory, run:
 
@@ -355,4 +355,4 @@ python -m SimpleHTTPServer
 python3 -m http.server
 ```
 
-This will host the game at `localhost:8000/src/Rigel.html`.
+This will host the game at `localhost:8000/src/RigelEngine.html`.

--- a/emscripten/shell.html
+++ b/emscripten/shell.html
@@ -21,6 +21,6 @@
         canvas: document.getElementById('canvas')
       }
     </script>
-    <script async type="text/javascript" src="RigelEngine.js"></script>
+    {{{ SCRIPT }}}
   </body>
 </html>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -364,13 +364,13 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
         "SHELL:-s MAX_WEBGL_VERSION=2"
         "SHELL:-s FULL_ES2=1"
         "SHELL:--preload-file ${WEBASSEMBLY_GAME_PATH}/@/duke"
+        "SHELL:--shell-file ${CMAKE_SOURCE_DIR}/emscripten/shell.html"
         --no-heap-copy
     )
-
-    # copy html file for hosting wasm and generated js to destination
-    # a better solution will be to find out a way for emscripten to generate html file instead of js file
-    # and use --shell-file to provide a custom html template
-    file(COPY "${CMAKE_SOURCE_DIR}/emscripten/Rigel.html" DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+    set_target_properties(RigelEngine PROPERTIES
+        SUFFIX
+        ".html"
+    )
 else()
     add_executable(${main_exe_name} main.cpp)
     target_link_libraries(${main_exe_name} PRIVATE

--- a/src/data/game_options.hpp
+++ b/src/data/game_options.hpp
@@ -42,7 +42,9 @@ enum class WindowMode {
   Windowed
 };
 
-#if defined(__APPLE__) || defined(RIGEL_USE_GL_ES)
+#if defined(__EMSCRIPTEN__)
+  constexpr auto DEFAULT_WINDOW_MODE = WindowMode::Windowed;
+#elif defined(__APPLE__) || defined(RIGEL_USE_GL_ES)
   constexpr auto DEFAULT_WINDOW_MODE = WindowMode::ExclusiveFullscreen;
 #else
   constexpr auto DEFAULT_WINDOW_MODE = WindowMode::Fullscreen;


### PR DESCRIPTION
This changes the default window mode to windowed for Emscripten builds, fixing the problem where the game view was partially cut off in the browser window. Switching to fullscreen mode still does not do the right thing currently, leading to a cut off view and mouse position being offset in the options menu. But windowed mode works quite well.

In addition, we are now using the `--shell-file` option instead of a fully handwritten HTML file.

Fixes #569 