### PR TITLE
Implement demo playback facilities

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,6 +99,8 @@ set(core_sources
     game_logic/damage_infliction_system.hpp
     game_logic/debugging_system.cpp
     game_logic/debugging_system.hpp
+    game_logic/demo_player.cpp
+    game_logic/demo_player.hpp
     game_logic/dynamic_geometry_components.hpp
     game_logic/dynamic_geometry_system.cpp
     game_logic/dynamic_geometry_system.hpp

--- a/src/common/command_line_options.hpp
+++ b/src/common/command_line_options.hpp
@@ -41,6 +41,7 @@ struct CommandLineOptions {
   std::optional<data::GameSessionId> mLevelToJumpTo;
   bool mSkipIntro = false;
   bool mDebugModeEnabled = false;
+  bool mPlayDemo = false;
   std::optional<base::Vector> mPlayerPosition;
 };
 

--- a/src/frontend/game.cpp
+++ b/src/frontend/game.cpp
@@ -21,6 +21,7 @@
 #include "data/duke_script.hpp"
 #include "data/game_traits.hpp"
 #include "engine/timing.hpp"
+#include "game_logic/demo_player.hpp"
 #include "loader/duke_script_loader.hpp"
 #include "renderer/upscaling_utils.hpp"
 #include "ui/imgui_integration.hpp"
@@ -117,6 +118,25 @@ std::unique_ptr<GameMode> createInitialGameMode(
   const bool isShareWareVersion,
   const bool isFirstLaunch)
 {
+  class DemoTestMode : public GameMode {
+  public:
+    explicit DemoTestMode(Context context)
+      : mDemoPlayer(context)
+    {
+    }
+
+    std::unique_ptr<GameMode> updateAndRender(
+      engine::TimeDelta dt,
+      const std::vector<SDL_Event>&
+    ) override {
+      mDemoPlayer.updateAndRender(dt);
+      return nullptr;
+    }
+
+  private:
+    game_logic::DemoPlayer mDemoPlayer;
+  };
+
   if (commandLineOptions.mLevelToJumpTo)
   {
     return std::make_unique<GameSessionMode>(
@@ -127,6 +147,9 @@ std::unique_ptr<GameMode> createInitialGameMode(
   else if (commandLineOptions.mSkipIntro)
   {
     return std::make_unique<MenuMode>(context);
+  }
+  else if (commandLineOptions.mPlayDemo) {
+    return std::make_unique<DemoTestMode>(context);
   }
 
   if (!isShareWareVersion) {

--- a/src/frontend/game_runner.cpp
+++ b/src/frontend/game_runner.cpp
@@ -28,16 +28,6 @@ namespace rigel {
 
 namespace {
 
-// Update game logic at 15 FPS. This is not exactly the speed at which the
-// game runs on period-appropriate hardware, but it's very close, and it nicely
-// fits into 60 FPS, giving us 4 render frames for 1 logic update.
-//
-// On a 486 with a fast graphics card, the game runs at roughly 15.5 FPS, with
-// a slower (non-VLB) graphics card, it's roughly 14 FPS. On a fast 386 (40 MHz),
-// it's roughly 13 FPS. With 15 FPS, the feel should therefore be very close to
-// playing the game on a 486 at the default game speed setting.
-constexpr auto GAME_LOGIC_UPDATE_DELAY = 1.0/15.0;
-
 // Controller handling stuff.
 // TODO: This should move into its own file at some point.
 constexpr auto ANALOG_STICK_DEADZONE_X = 10'000;
@@ -141,8 +131,8 @@ void GameRunner::updateWorld(const engine::TimeDelta dt) {
   } else {
     mAccumulatedTime += dt;
     for (;
-      mAccumulatedTime >= GAME_LOGIC_UPDATE_DELAY;
-      mAccumulatedTime -= GAME_LOGIC_UPDATE_DELAY
+      mAccumulatedTime >= game_logic::GAME_LOGIC_UPDATE_DELAY;
+      mAccumulatedTime -= game_logic::GAME_LOGIC_UPDATE_DELAY
     ) {
       update();
     }

--- a/src/game_logic/demo_player.cpp
+++ b/src/game_logic/demo_player.cpp
@@ -1,0 +1,140 @@
+/* Copyright (C) 2020, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "demo_player.hpp"
+
+#include "common/game_service_provider.hpp"
+#include "game_logic/game_world.hpp"
+#include "loader/resource_loader.hpp"
+
+
+namespace rigel::game_logic {
+
+namespace {
+
+constexpr int DEMO_EPISODE = 0;
+constexpr int DEMO_LEVELS[] = {0, 2, 4, 6};
+constexpr auto DEMO_DIFFICULTY = data::Difficulty::Hard;
+constexpr std::uint8_t END_OF_DEMO_MARKER = 0xFF;
+
+
+PlayerInput parseInput(
+  const std::uint8_t byte,
+  const PlayerInput& previousInput
+) {
+  PlayerInput result;
+
+  result.mUp = (byte & 0b1) != 0;
+  result.mDown = (byte & 0b10) != 0;
+  result.mLeft = (byte & 0b100) != 0;
+  result.mRight = (byte & 0b1000) != 0;
+  result.mJump.mIsPressed = (byte & 0b10000) != 0;
+  result.mFire.mIsPressed = (byte & 0b100000) != 0;
+  result.mInteract.mIsPressed = (byte & 0b1) != 0;
+
+  result.mJump.mWasTriggered = result.mJump.mIsPressed &&
+    !previousInput.mJump.mIsPressed;
+  result.mFire.mWasTriggered = result.mFire.mIsPressed &&
+    !previousInput.mFire.mIsPressed;
+  result.mInteract.mWasTriggered = result.mInteract.mIsPressed &&
+    !previousInput.mInteract.mIsPressed;
+
+  return result;
+}
+
+
+std::vector<DemoInput> loadDemo(const loader::ResourceLoader& resources) {
+  PlayerInput previousInput;
+  std::vector<DemoInput> result;
+
+  const auto demoData = resources.file("NUKEM2.MNI");
+  for (const auto byte : demoData) {
+    if (byte == END_OF_DEMO_MARKER) {
+      break;
+    }
+
+    const auto currentInput = parseInput(byte, previousInput);
+    const auto switchToNextLevel = (byte & 0b10000000) != 0;
+    result.push_back({currentInput, switchToNextLevel});
+
+    previousInput = currentInput;
+  }
+
+  return result;
+}
+
+
+data::GameSessionId demoSessionId(const std::size_t levelIndex) {
+  return {DEMO_EPISODE, DEMO_LEVELS[levelIndex], DEMO_DIFFICULTY};
+}
+
+}
+
+
+DemoPlayer::DemoPlayer(GameMode::Context context)
+  : mContext(context)
+  , mpWorld(std::make_unique<GameWorld>(
+      &mPlayerModel,
+      demoSessionId(0),
+      context,
+      std::nullopt,
+      true))
+  , mFrames(loadDemo(*context.mpResources))
+{
+}
+
+
+void DemoPlayer::updateAndRender(const engine::TimeDelta dt) {
+  if (isFinished()) {
+    return;
+  }
+
+  mElapsedTime += dt;
+
+  if (mElapsedTime >= GAME_LOGIC_UPDATE_DELAY) {
+    mpWorld->updateGameLogic(mFrames[mCurrentFrameIndex].mInput);
+    ++mCurrentFrameIndex;
+
+    mElapsedTime -= GAME_LOGIC_UPDATE_DELAY;
+  }
+
+  mpWorld->render();
+  mpWorld->processEndOfFrameActions();
+
+  if (
+    mCurrentFrameIndex < mFrames.size() &&
+    mFrames[mCurrentFrameIndex].mNextLevel
+  ) {
+    mContext.mpServiceProvider->fadeOutScreen();
+
+    ++mCurrentFrameIndex;
+    ++mLevelIndex;
+    mPlayerModel.resetForNewLevel();
+    mpWorld = std::make_unique<GameWorld>(
+      &mPlayerModel,
+      demoSessionId(mLevelIndex),
+      mContext);
+
+    mContext.mpServiceProvider->fadeInScreen();
+  }
+}
+
+
+bool DemoPlayer::isFinished() const {
+  return mCurrentFrameIndex >= mFrames.size();
+}
+
+}

--- a/src/game_logic/demo_player.hpp
+++ b/src/game_logic/demo_player.hpp
@@ -1,0 +1,59 @@
+/* Copyright (C) 2020, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/game_mode.hpp"
+#include "data/player_model.hpp"
+#include "engine/timing.hpp"
+#include "game_logic/input.hpp"
+
+#include <memory>
+#include <vector>
+
+
+namespace rigel::game_logic {
+
+class GameWorld;
+
+
+struct DemoInput {
+  PlayerInput mInput;
+  bool mNextLevel;
+};
+
+
+class DemoPlayer {
+public:
+  explicit DemoPlayer(GameMode::Context context);
+
+  void updateAndRender(engine::TimeDelta dt);
+
+  bool isFinished() const;
+
+private:
+  GameMode::Context mContext;
+  data::PlayerModel mPlayerModel;
+  std::unique_ptr<GameWorld> mpWorld;
+
+  std::vector<DemoInput> mFrames;
+  std::size_t mCurrentFrameIndex = 0;
+  std::size_t mLevelIndex = 0;
+
+  engine::TimeDelta mElapsedTime = 0;
+};
+
+}

--- a/src/game_logic/entity_configuration.ipp
+++ b/src/game_logic/entity_configuration.ipp
@@ -1327,6 +1327,7 @@ void EntityFactory::configureEntity(
       entity.assign<BoundingBox>(BoundingBox{{1, -2}, {3, 3}});
       entity.assign<BehaviorController>(behaviors::SlimeContainer{});
       entity.assign<DestructionEffects>(SLIME_CONTAINER_KILL_EFFECT_SPEC);
+      entity.assign<ActivationSettings>(ActivationSettings::Policy::Always);
       entity.assign<AppearsOnRadar>();
       break;
 
@@ -1655,6 +1656,7 @@ void EntityFactory::configureEntity(
     case ActorID::Passive_prisoner: // Monster in prison cell, passive
       entity.assign<BehaviorController>(behaviors::PassivePrisoner{});
       entity.assign<BoundingBox>(boundingBox);
+      entity.assign<ActivationSettings>(ActivationSettings::Policy::Always);
       entity.assign<AppearsOnRadar>();
       break;
 

--- a/src/game_logic/game_world.hpp
+++ b/src/game_logic/game_world.hpp
@@ -46,6 +46,17 @@ namespace rigel::data::map { struct LevelData; }
 
 namespace rigel::game_logic {
 
+// Update game logic at 15 FPS. This is not exactly the speed at which the
+// game runs on period-appropriate hardware, but it's very close, and it nicely
+// fits into 60 FPS, giving us 4 render frames for 1 logic update.
+//
+// On a 486 with a fast graphics card, the game runs at roughly 15.5 FPS, with
+// a slower (non-VLB) graphics card, it's roughly 14 FPS. On a fast 386 (40 MHz),
+// it's roughly 13 FPS. With 15 FPS, the feel should therefore be very close to
+// playing the game on a 486 at the default game speed setting.
+constexpr auto GAME_LOGIC_UPDATE_DELAY = 1.0/15.0;
+
+
 struct WorldState;
 
 class GameWorld : public entityx::Receiver<GameWorld> {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,6 +137,9 @@ int main(int argc, char** argv) {
     ("debug-mode,d",
      po::bool_switch(&config.mDebugModeEnabled),
      "Enable debugging features")
+    ("play-demo",
+     po::bool_switch(&config.mPlayDemo),
+     "Play pre-recorded demo")
     ("game-path",
      po::value<std::string>(&config.mGamePath)->default_value(""),
      "Path to original game's installation. Can also be given as positional "


### PR DESCRIPTION
Adds a `DemoPlayer` class, which implements demo playback. Due to a few correctness issues that currently prevent the demo from matching the original game, demo playback is not integrated yet into the intro/demo loop.

A command-line option `--play-demo` is added to allow testing demo playback.

First step towards #45 