### PR TITLE
Fix clock skipping issue on some platforms

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(core_sources
     base/array_view.hpp
+    base/clock.hpp
     base/container_utils.hpp
     base/defer.hpp
     base/grid.hpp

--- a/src/base/clock.hpp
+++ b/src/base/clock.hpp
@@ -14,35 +14,13 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "fps_limiter.hpp"
+#pragma once
 
-#include <SDL_timer.h>
-
-
-namespace rigel::renderer {
-
-FpsLimiter::FpsLimiter(const int targetFps)
-  : mLastTime(base::Clock::now())
-  , mTargetFrameTime(1.0 / targetFps)
-{
-}
+#include <chrono>
 
 
-void FpsLimiter::updateAndWait() {
-  using namespace std::chrono;
+namespace rigel::base {
 
-  const auto now = base::Clock::now();
-  const auto delta = duration<double>(now - mLastTime).count();
-  mLastTime = now;
-
-  mError += mTargetFrameTime - delta;
-
-  const auto timeToWaitFor = mTargetFrameTime + mError;
-  if (timeToWaitFor > 0.0) {
-    // We use SDL_Delay instead of std::this_thread::sleep_for, because the
-    // former is more accurate on some platforms.
-    SDL_Delay(static_cast<Uint32>(timeToWaitFor * 1000.0));
-  }
-}
+using Clock = std::chrono::high_resolution_clock;
 
 }

--- a/src/base/clock.hpp
+++ b/src/base/clock.hpp
@@ -21,6 +21,6 @@
 
 namespace rigel::base {
 
-using Clock = std::chrono::high_resolution_clock;
+using Clock = std::chrono::steady_clock;
 
 }

--- a/src/frontend/game.cpp
+++ b/src/frontend/game.cpp
@@ -231,7 +231,7 @@ Game::Game(
 
   enumerateGameControllers();
 
-  mLastTime = std::chrono::high_resolution_clock::now();
+  mLastTime = base::Clock::now();
 }
 
 
@@ -239,7 +239,7 @@ auto Game::runOneFrame() -> std::optional<StopReason> {
   using namespace std::chrono;
   using base::defer;
 
-  const auto startOfFrame = high_resolution_clock::now();
+  const auto startOfFrame = base::Clock::now();
   const auto elapsed =
     duration<entityx::TimeDelta>(startOfFrame - mLastTime).count();
   mLastTime = startOfFrame;
@@ -401,10 +401,10 @@ void Game::performScreenFadeBlocking(const FadeType type) {
   renderer::DefaultRenderTargetBinder bindDefaultRenderTarget(&mRenderer);
   auto saved = renderer::setupDefaultState(&mRenderer);
 
-  auto startTime = high_resolution_clock::now();
+  auto startTime = base::Clock::now();
 
   while (mIsRunning) {
-    const auto now = high_resolution_clock::now();
+    const auto now = base::Clock::now();
     const auto elapsedTime = duration<double>(now - startTime).count();
     const auto fastTicksElapsed = engine::timeToFastTicks(elapsedTime);
     const auto fadeFactor =
@@ -427,7 +427,7 @@ void Game::performScreenFadeBlocking(const FadeType type) {
   mRenderer.setColorModulation({255, 255, 255, 255});
 
   // Pretend that the fade didn't take any time
-  mLastTime = high_resolution_clock::now();
+  mLastTime = base::Clock::now();
 }
 
 

--- a/src/frontend/game.hpp
+++ b/src/frontend/game.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "base/clock.hpp"
 #include "base/spatial_types.hpp"
 #include "base/warnings.hpp"
 #include "common/game_mode.hpp"
@@ -35,7 +36,6 @@
 
 #include <SDL_gamecontroller.h>
 
-#include <chrono>
 #include <memory>
 #include <optional>
 #include <string>
@@ -126,7 +126,7 @@ private:
 
   bool mIsRunning;
   bool mIsMinimized;
-  std::chrono::high_resolution_clock::time_point mLastTime;
+  base::Clock::time_point mLastTime;
 
   CommandLineOptions mCommandLineOptions;
   UserProfile* mpUserProfile;

--- a/src/renderer/fps_limiter.hpp
+++ b/src/renderer/fps_limiter.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <chrono>
+#include "base/clock.hpp"
 
 
 namespace rigel::renderer {
@@ -28,7 +28,7 @@ public:
   void updateAndWait();
 
 private:
-  std::chrono::high_resolution_clock::time_point mLastTime = {};
+  base::Clock::time_point mLastTime = {};
   double mTargetFrameTime;
   double mError = 0.0;
 };


### PR DESCRIPTION
Noticed on the Odroid Go Advance, were the game would skip ahead a couple of frames occasionally. I couldn't get this to happen when using `steady_clock`.