### PR TITLE
More Raspberry Pi improvements

### DIFF
--- a/3rd_party/imgui/imgui_impl_opengl3.cpp
+++ b/3rd_party/imgui/imgui_impl_opengl3.cpp
@@ -420,8 +420,8 @@ bool ImGui_ImplOpenGL3_CreateFontsTexture()
     glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);
     glGenTextures(1, &g_FontTexture);
     glBindTexture(GL_TEXTURE_2D, g_FontTexture);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 #ifdef GL_UNPACK_ROW_LENGTH
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
 #endif

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -75,6 +75,7 @@ These are:
 * [JSON for modern C++](https://github.com/nlohmann/json)
 * Speex Resampler (taken from [libspeex](http://www.speex.org/))
 * [STB image](https://github.com/nothings/stb) image reading/writing library
+* [STB rect_pack](https://github.com/nothings/stb) rectangle packer for building texture atlases
 
 
 ### <a name="linux-build-instructions">Linux builds</a>
@@ -173,7 +174,7 @@ This also assumes that `make`, `gcc` and `gcc-c++` are already installed.
 
 ### <a name="raspi-build-instructions">Raspberry Pi builds</a>
 
-:warning: Note that Raspberry Pi support is still work in progress, and there are [some issues](https://github.com/lethal-guitar/RigelEngine/labels/raspberry-pi-support).
+:exclamation: Make sure to read [Running on Raspberry Pi](https://github.com/lethal-guitar/RigelEngine/wiki/Running-on-Raspberry-Pi-and-Odroid-Go-Advance#raspberry-pi) for information on how to achieve best performance!
 
 To build on the Pi itself, I recommend Raspbian (aka Raspberry Pi OS) _Buster_.
 Older versions like Stretch don't have recent enough versions of CMake, Boost and Gcc.
@@ -185,12 +186,9 @@ When building, you need to enable OpenGL ES Support:
 ```bash
 mkdir build
 cd build
-cmake .. -DUSE_GL_ES=ON -DWARNINGS_AS_ERRORS=OFF
+cmake .. -DUSE_GL_ES=ON -DCMAKE_BUILD_TYPE=Release -DWARNINGS_AS_ERRORS=OFF
 make
 ```
-
-To get playable performance, I had to run the game outside of the Desktop environment (X server).
-To do that, switch to a new terminal using Ctrl+Alt+F1 and launch the game there.
 
 ### <a name="mac-build-instructions">OS X builds</a>
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ The project overall is far from finished, though. There are still some pieces mi
 
 RigelEngine runs on Windows, Linux, and Mac OS X.
 
-It also runs on the Raspberry Pi, but that's work in progress as there are still [some issues](https://github.com/lethal-guitar/RigelEngine/labels/raspberry-pi-support) to be sorted out. See [build instructions](BUILDING.md#raspi-build-instructions).
+The Linux version also runs well on small single-board computers (SBCs) like the Raspberry Pi and Odroid Go Advance.
+See [Running on Raspberry Pi and Odroid Go Advance](https://github.com/lethal-guitar/RigelEngine/wiki/Running-on-Raspberry-Pi-and-Odroid-Go-Advance).
 
 Android and iOS versions might happen someday, but there are no concrete plans at the moment.
 

--- a/src/frontend/game.cpp
+++ b/src/frontend/game.cpp
@@ -240,19 +240,8 @@ Game::Game(
       return !hasRegisteredVersionFiles;
     }())
   , mFpsLimiter(createLimiter(pUserProfile->mOptions))
-  , mRenderTarget([&]() {
-      if (pUserProfile->mOptions.mPerElementUpscalingEnabled) {
-        return renderer::RenderTargetTexture{
-          &mRenderer,
-          size_t(mRenderer.maxWindowSize().width),
-          size_t(mRenderer.maxWindowSize().height)};
-      } else {
-        return renderer::RenderTargetTexture{
-          &mRenderer,
-          size_t(renderer::determineWidescreenViewPort(&mRenderer).mWidthPx),
-          size_t(data::GameTraits::viewPortHeightPx)};
-      }
-    }())
+  , mRenderTarget(renderer::createFullscreenRenderTarget(
+      &mRenderer, pUserProfile->mOptions))
   , mIsRunning(true)
   , mIsMinimized(false)
   , mCommandLineOptions(commandLineOptions)
@@ -547,6 +536,11 @@ void Game::applyChangedOptions() {
         : 0.0f;
       mpSoundSystem->setSoundVolume(newVolume);
     }
+  }
+
+  if (currentOptions.mWidescreenModeOn != mPreviousOptions.mWidescreenModeOn) {
+    mRenderTarget = renderer::createFullscreenRenderTarget(
+      &mRenderer, mpUserProfile->mOptions);
   }
 
   mPreviousOptions = mpUserProfile->mOptions;

--- a/src/frontend/game.cpp
+++ b/src/frontend/game.cpp
@@ -432,14 +432,6 @@ bool Game::handleEvent(const SDL_Event& event) {
 void Game::performScreenFadeBlocking(const FadeType type) {
   using namespace std::chrono;
 
-  if (
-    (type == FadeType::In && mAlphaMod == 255) ||
-    (type == FadeType::Out && mAlphaMod == 0)
-  ) {
-    // Already faded in/out, nothing to do
-    return;
-  }
-
   renderer::DefaultRenderTargetBinder bindDefaultRenderTarget(&mRenderer);
   auto defaultStateGuard = renderer::setupDefaultState(&mRenderer);
   auto presentationStateGuard = setupPresentationViewport(
@@ -564,6 +556,11 @@ void Game::enumerateGameControllers() {
 
 
 void Game::fadeOutScreen() {
+  if (mAlphaMod == 0) {
+    // Already faded out
+    return;
+  }
+
   performScreenFadeBlocking(FadeType::Out);
 
   // Clear render canvas after a fade-out
@@ -577,6 +574,11 @@ void Game::fadeOutScreen() {
 
 
 void Game::fadeInScreen() {
+  if (mAlphaMod == 255) {
+    // Already faded in
+    return;
+  }
+
   performScreenFadeBlocking(FadeType::In);
 }
 

--- a/src/frontend/game.hpp
+++ b/src/frontend/game.hpp
@@ -125,7 +125,7 @@ private:
 
   std::optional<renderer::FpsLimiter> mFpsLimiter;
   renderer::RenderTargetTexture mRenderTarget;
-  std::uint8_t mAlphaMod = 255;
+  std::uint8_t mAlphaMod = 0;
   bool mCurrentFrameIsWidescreen = false;
 
   std::unique_ptr<GameMode> mpCurrentGameMode;

--- a/src/game_logic/game_world.hpp
+++ b/src/game_logic/game_world.hpp
@@ -143,7 +143,7 @@ private:
   ui::IngameMessageDisplay mMessageDisplay;
   renderer::RenderTargetTexture mWaterEffectBuffer;
   renderer::RenderTargetTexture mLowResLayer;
-  bool mWidescreenModeWasOn = false;
+  bool mWidescreenModeWasOn;
 
   std::unique_ptr<WorldState> mpState;
   std::unique_ptr<QuickSaveData> mpQuickSave;

--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -509,9 +509,6 @@ Renderer::Renderer(SDL_Window* pWindow)
   onRenderTargetChanged();
 
   setColorModulation({255, 255, 255, 255});
-
-  clear();
-  swapBuffers();
 }
 
 

--- a/src/renderer/upscaling_utils.cpp
+++ b/src/renderer/upscaling_utils.cpp
@@ -17,6 +17,7 @@
 #include "upscaling_utils.hpp"
 
 #include "base/math_tools.hpp"
+#include "data/game_options.hpp"
 #include "data/game_traits.hpp"
 #include "renderer/renderer.hpp"
 
@@ -115,6 +116,28 @@ base::Extents scaleSize(
   const base::Point<float>& scale
 ) {
   return asSize(scaleVec(asVec(size), scale));
+}
+
+
+RenderTargetTexture createFullscreenRenderTarget(
+  Renderer* pRenderer,
+  const data::GameOptions& options
+) {
+  if (options.mPerElementUpscalingEnabled) {
+    return RenderTargetTexture{
+      pRenderer,
+      size_t(pRenderer->maxWindowSize().width),
+      size_t(pRenderer->maxWindowSize().height)};
+  } else {
+    const auto width =
+      options.mWidescreenModeOn && canUseWidescreenMode(pRenderer)
+        ? determineWidescreenViewPort(pRenderer).mWidthPx
+        : data::GameTraits::viewPortWidthPx;
+    return RenderTargetTexture{
+      pRenderer,
+      size_t(width),
+      size_t(data::GameTraits::viewPortHeightPx)};
+  }
 }
 
 }

--- a/src/renderer/upscaling_utils.hpp
+++ b/src/renderer/upscaling_utils.hpp
@@ -17,6 +17,10 @@
 #pragma once
 
 #include "base/spatial_types.hpp"
+#include "renderer/texture.hpp"
+
+
+namespace rigel::data { struct GameOptions; }
 
 
 namespace rigel::renderer {
@@ -53,5 +57,8 @@ base::Extents scaleSize(
   const base::Extents& size,
   const base::Point<float>& scale);
 
+RenderTargetTexture createFullscreenRenderTarget(
+  Renderer* pRenderer,
+  const data::GameOptions& options);
 
 }

--- a/src/ui/utils.cpp
+++ b/src/ui/utils.cpp
@@ -16,24 +16,15 @@
 
 #include "utils.hpp"
 
-#include "base/warnings.hpp"
 #include "loader/resource_loader.hpp"
-
-RIGEL_DISABLE_WARNINGS
-#include <imgui.h>
-RIGEL_RESTORE_WARNINGS
 
 
 namespace rigel::ui {
 
-namespace {
-
-auto toImgui(const base::Color& color) {
+ImU32 toImgui(const base::Color& color) {
 RIGEL_DISABLE_WARNINGS
   return IM_COL32(color.r, color.g, color.b, color.a);
 RIGEL_RESTORE_WARNINGS
-}
-
 }
 
 

--- a/src/ui/utils.hpp
+++ b/src/ui/utils.hpp
@@ -17,9 +17,14 @@
 #pragma once
 
 #include "base/color.hpp"
+#include "base/warnings.hpp"
 #include "engine/tiled_texture.hpp"
 #include "loader/palette.hpp"
 #include "renderer/texture.hpp"
+
+RIGEL_DISABLE_WARNINGS
+#include <imgui.h>
+RIGEL_RESTORE_WARNINGS
 
 #include <string_view>
 
@@ -29,6 +34,8 @@ namespace rigel::loader {
 }
 
 namespace rigel::ui {
+
+ImU32 toImgui(const base::Color& color);
 
 renderer::OwningTexture fullScreenImageAsTexture(
   renderer::Renderer* pRenderer,


### PR DESCRIPTION
We can now maintain a stable 60 FPS at 1080p on a Raspberry Pi 3 model B, even when water effects are on screen. 

Also new is a loading screen shown at startup, since the game does take a few seconds to start on less powerful machines.