### PR TITLE
FindFilesystem.cmake: Fix passing CMAKE_CXX_STANDARD to try_compile

### DIFF
--- a/cmake/Modules/FindFilesystem.cmake
+++ b/cmake/Modules/FindFilesystem.cmake
@@ -105,6 +105,13 @@ if(TARGET std::filesystem)
     return()
 endif()
 
+cmake_policy(PUSH)
+if(POLICY CMP0067)
+    # pass CMAKE_CXX_STANDARD to check_cxx_source_compiles()
+    # has to appear before including CheckCXXSourceCompiles module
+    cmake_policy(SET CMP0067 NEW)
+endif()
+
 include(CMakePushCheckState)
 include(CheckIncludeFileCXX)
 include(CheckCXXSourceCompiles)
@@ -229,3 +236,4 @@ if(Filesystem_FIND_REQUIRED AND NOT Filesystem_FOUND)
     message(FATAL_ERROR "Cannot Compile simple program using std::filesystem")
 endif()
 
+cmake_policy(POP)


### PR DESCRIPTION
This is needed e.g. with gcc 8.3 which defaults to c++14. Without this fix, FindFilesystem.cmake fails to find any valid configuration.

See https://stackoverflow.com/a/47218035/1076564 .