### PR TITLE
Fix visual glitch when quick loading via gamepad

### DIFF
--- a/src/game_logic/game_world.cpp
+++ b/src/game_logic/game_world.cpp
@@ -904,6 +904,13 @@ void GameWorld::quickLoad() {
     mpPlayerModel,
     mSessionId);
   mMessageDisplay.setMessage("Quick save restored.");
+
+  const auto& viewPortSize =
+    mpOptions->mWidescreenModeOn && renderer::canUseWidescreenMode(mpRenderer)
+      ? viewPortSizeWideScreen(mpRenderer)
+      : data::GameTraits::mapViewPortSize;
+  mpState->mSpriteRenderingSystem.update(
+    mpState->mEntities, viewPortSize, mpState->mCamera.position());
 }
 
 


### PR DESCRIPTION
Quick loading via gamepad menu would briefly show the previous frames sprites on top of  the map from the loaded state.