### PR TITLE
Removing implicit type conversion from int to size_t

### DIFF
--- a/src/renderer/renderer.cpp
+++ b/src/renderer/renderer.cpp
@@ -256,7 +256,7 @@ data::Image createWaterEffectColorMapImage() {
     pixels.push_back(loader::INGAME_PALETTE[index]);
   }
 
-  return data::Image{std::move(pixels), NUM_COLORS, NUM_ROWS};
+  return data::Image{std::move(pixels), static_cast<size_t>(NUM_COLORS), static_cast<size_t>(NUM_ROWS)};
 }
 
 

--- a/src/renderer/texture_atlas.cpp
+++ b/src/renderer/texture_atlas.cpp
@@ -74,7 +74,7 @@ TextureAtlas::TextureAtlas(
     throw std::runtime_error("Failed to build texture atlas");
   }
 
-  data::Image atlas{ATLAS_WIDTH, ATLAS_HEIGHT};
+  data::Image atlas{static_cast<size_t>(ATLAS_WIDTH), static_cast<size_t>(ATLAS_HEIGHT)};
 
   for (const auto& packedRect : rects) {
     atlas.insertImage(packedRect.x, packedRect.y, images[packedRect.id]);


### PR DESCRIPTION
VS was not compiling because of implicit conversion from int to size_t for these variables. I made them static_cast and the errors went away