### PR TITLE
Wasm improvements

### DIFF
--- a/emscripten/shell.html
+++ b/emscripten/shell.html
@@ -27,7 +27,14 @@
         font-family: sans-serif;
       }
 
-      #thankyoubox {
+      #welcomebox {
+        background-color: #000000DD;
+        font-size: 1em;
+        text-align: left;
+        padding: 0.2em;
+      }
+
+      #thankyoubox, #welcomebox {
         display: none;
       }
     </style>
@@ -38,6 +45,14 @@
       Module = {
         canvas: document.getElementById('canvas')
       }
+
+      window.addEventListener('load', function(load_event) {
+        document.getElementById('close_welcomebox').addEventListener('click',
+          function(e) {
+            var welcomeBox = document.getElementById('welcomebox');
+            welcomebox.parentNode.removeChild(welcomebox);
+          });
+        });
     </script>
     {{{ SCRIPT }}}
     <div id="loadingbox" class="info_msg">
@@ -48,6 +63,40 @@
       <p>
         You can now close this tab, or reload the page to start again.
       </p>
+    </div>
+    <div id="welcomebox" class="info_msg">
+      <h1>Welcome to &nbsp;<a href="https://github.com/lethal-guitar/RigelEngine" target="_blank">RigelEngine</a>&nbsp;(web version)!</h1>
+
+      <h2>Known issues/limitations</h2>
+      <p>
+      <strong>Please note:</strong>&nbsp;This version is still work in progress and has a few limitations that don't exist in the&nbsp;<a href="https://github.com/lethal-guitar/RigelEngine/releases" target="_blank">native version</a>:
+      </p>
+
+      <ul>
+        <li>On Mac OS, the default controls are in conflict with some system-wide shortcuts (e.g. Ctrl + Up arrow for switching between applications etc.) I'd recommend reconfiguring the controls (see below) if you're on a Mac so that the Ctrl key is not used. This is not a problem in the native Mac version as it can use true fullscreen mode, but that doesn't work in the web version unfortunately.</li>
+        <li>Saved games, high scores, and options can't be saved permanently and are lost when reloading or closing the page.</li>
+        <li>It's not possible to play the registered version.</li>
+        <li>Due to missing touch input support, there is no way to interact with the game on mobile devices (unless you plug in a USB keyboard), so it will just run through the intro loop forever.</li>
+        <li>Screen fade-in and fade-out effects are missig.</li>
+      </ul>
+
+      <p>
+      If you find any problems not mentioned in the list above, please&nbsp;<a href="https://github.com/lethal-guitar/RigelEngine/issues/new/choose" target="_blank">open an issue</a>&nbsp;on GitHub!
+      </p>
+
+      <h2>Controls</h2>
+      <p>
+      Press Esc to enter the main menu, then use arrow keys and Enter/Esc to navigate the menus.
+      Default in-game controls are arrow keys for movement, Ctrl to jump and Alt to shoot.
+      Pressing F1 while in-game brings up an options menu, where you can customize controls.
+      To go back to the main menu press Esc and then Y to confirm.
+      </p>
+
+      <p>
+      Enjoy the game! :)
+      </p>
+
+      <button id="close_welcomebox">Close this message</button>
     </div>
   </body>
 </html>

--- a/emscripten/shell.html
+++ b/emscripten/shell.html
@@ -12,6 +12,20 @@
         padding: 0;
         background-color: black;
       }
+
+      .info_msg {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        -moz-transform: translateX(-50%) translateY(-50%);
+        -webkit-transform: translateX(-50%) translateY(-50%);
+        transform: translateX(-50%) translateY(-50%);
+        text-align: center;
+
+        color: white;
+        font-size: 3em;
+        font-family: sans-serif;
+      }
     </style>
   </head>
   <body>
@@ -22,5 +36,8 @@
       }
     </script>
     {{{ SCRIPT }}}
+    <div id="loadingbox" class="info_msg">
+      <h1>Loading...</h1>
+    </div>
   </body>
 </html>

--- a/emscripten/shell.html
+++ b/emscripten/shell.html
@@ -26,6 +26,10 @@
         font-size: 3em;
         font-family: sans-serif;
       }
+
+      #thankyoubox {
+        display: none;
+      }
     </style>
   </head>
   <body>
@@ -38,6 +42,12 @@
     {{{ SCRIPT }}}
     <div id="loadingbox" class="info_msg">
       <h1>Loading...</h1>
+    </div>
+    <div id="thankyoubox" class="info_msg">
+      <h1>Thanks for playing!</h1>
+      <p>
+        You can now close this tab, or reload the page to start again.
+      </p>
     </div>
   </body>
 </html>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -370,8 +370,8 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
         "SHELL:-s MIN_WEBGL_VERSION=1"
         "SHELL:-s MAX_WEBGL_VERSION=2"
         "SHELL:-s FULL_ES2=1"
-        "SHELL:--preload-file ${WEBASSEMBLY_GAME_PATH}/@/duke"
-        "SHELL:--shell-file ${CMAKE_SOURCE_DIR}/emscripten/shell.html"
+        "SHELL:--preload-file \"${WEBASSEMBLY_GAME_PATH}/@/duke\""
+        "SHELL:--shell-file \"${CMAKE_SOURCE_DIR}/emscripten/shell.html\""
         --no-heap-copy
     )
     set_target_properties(RigelEngine PROPERTIES

--- a/src/emscripten_main.cpp
+++ b/src/emscripten_main.cpp
@@ -53,7 +53,17 @@ namespace {
 constexpr auto WASM_GAME_PATH = "/duke/";
 
 void runOneFrameWrapper(void *pData) {
-  static_cast<Game*>(pData)->runOneFrame();
+  auto pGame = static_cast<Game*>(pData);
+  if (const auto result = pGame->runOneFrame();
+      result && *result == Game::StopReason::GameEnded)
+  {
+    EM_ASM(
+      document.getElementById("canvas").style.display = "none";
+      document.getElementById("thankyoubox").style.display = "block";
+    );
+
+    emscripten_cancel_main_loop();
+  }
 }
 
 }

--- a/src/emscripten_main.cpp
+++ b/src/emscripten_main.cpp
@@ -67,6 +67,9 @@ int main()
   platform::setGLAttributes();
 
   auto userProfile = loadOrCreateUserProfile();
+  userProfile.mOptions.mMusicVolume = 0.5f;
+  userProfile.mOptions.mSoundVolume = 0.5f;
+
   auto pWindow = platform::createWindow(userProfile.mOptions);
   SDL_GLContext pGlContext =
     sdl_utils::check(SDL_GL_CreateContext(pWindow.get()));

--- a/src/emscripten_main.cpp
+++ b/src/emscripten_main.cpp
@@ -37,6 +37,10 @@ RIGEL_RESTORE_WARNINGS
 
 #include <iostream>
 
+// This is needed for EM_ASM
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+
 
 using namespace rigel;
 
@@ -89,7 +93,15 @@ int main()
   options.mGamePath = WASM_GAME_PATH;
 
   Game game(options, &userProfile, pWindow.get(), false);
+
+  EM_ASM(
+    var loadingBox = document.getElementById("loadingbox");
+    loadingBox.parentNode.removeChild(loadingBox);
+  );
+
   emscripten_set_main_loop_arg(runOneFrameWrapper, &game, 0, true);
 
   return 0;
 }
+
+#pragma clang diagnostic pop

--- a/src/emscripten_main.cpp
+++ b/src/emscripten_main.cpp
@@ -107,6 +107,8 @@ int main()
   EM_ASM(
     var loadingBox = document.getElementById("loadingbox");
     loadingBox.parentNode.removeChild(loadingBox);
+
+    document.getElementById("welcomebox").style.display = "block";
   );
 
   emscripten_set_main_loop_arg(runOneFrameWrapper, &game, 0, true);

--- a/src/frontend/game.cpp
+++ b/src/frontend/game.cpp
@@ -268,6 +268,7 @@ auto Game::runOneFrame() -> std::optional<StopReason> {
 
   pumpEvents();
   if (!mIsRunning) {
+    stopMusic();
     return StopReason::GameEnded;
   }
 

--- a/src/frontend/game.cpp
+++ b/src/frontend/game.cpp
@@ -422,6 +422,17 @@ bool Game::handleEvent(const SDL_Event& event) {
 
 
 void Game::performScreenFadeBlocking(const FadeType type) {
+#ifdef __EMSCRIPTEN__
+  // TODO: Implement screen fades for the Emscripten version.
+  // This is not so easy because we can't simply do a loop that renders
+  // multiple frames when running in the browser, as it just blocks the
+  // browser's main thread and the intermediate (faded) frames are not
+  // shown until the current requestAnimationFrame() callback returns.
+  // So we'd need to either find a way to suspend and then resume C++ code
+  // execution during the fade, or rewrite all client code to be stateful
+  // instead of relying on a blocking fade() function.
+  mAlphaMod = type == FadeType::In ? 255 : 0;
+#else
   using namespace std::chrono;
 
   auto saved = renderer::saveState(&mRenderer);
@@ -455,6 +466,7 @@ void Game::performScreenFadeBlocking(const FadeType type) {
 
   // Pretend that the fade didn't take any time
   mLastTime = base::Clock::now();
+#endif
 }
 
 

--- a/src/ui/options_menu.cpp
+++ b/src/ui/options_menu.cpp
@@ -316,6 +316,7 @@ void OptionsMenu::updateAndRender(engine::TimeDelta dt) {
     endRebinding();
   }
 
+#ifndef __EMSCRIPTEN__
   if (mType == Type::Main)
   {
     ImGui::Spacing();
@@ -382,6 +383,7 @@ Going back to a registered version will make them work again.)");
       ImGui::EndPopup();
     }
   }
+#endif
 
   ImGui::EndPopup();
 }


### PR DESCRIPTION
Fixes #570 
Closes #647 
Closes #648 

And implements "quitting" the game in the wasm version, and a welcome screen with some information:

<img width="1366" alt="welcome" src="https://user-images.githubusercontent.com/1821027/107153519-47643280-696e-11eb-969f-94e9be4f25b5.png">
<img width="1027" alt="quit" src="https://user-images.githubusercontent.com/1821027/107153533-5a770280-696e-11eb-9e0c-0ece25c0828b.png">
