### PR TITLE
Use uint8 wraparound for RNG

### DIFF
--- a/src/engine/random_number_generator.cpp
+++ b/src/engine/random_number_generator.cpp
@@ -16,6 +16,8 @@
 
 #include "random_number_generator.hpp"
 
+#include <limits>
+#include <type_traits>
 
 namespace rigel::engine {
 
@@ -47,6 +49,10 @@ const std::array<int, 256> RANDOM_NUMBER_TABLE{
 
 
 int RandomNumberGenerator::gen() {
+  static_assert(std::is_unsigned_v<decltype(mNextNumberIndex)>, "We rely on unsigned wraparound");
+  static_assert(RANDOM_NUMBER_TABLE.size() == static_cast<size_t>(std::numeric_limits<decltype(mNextNumberIndex)>::max()) + 1u,
+    "mNextNumberIndex must cover all values in the array"
+  );
   return RANDOM_NUMBER_TABLE[++mNextNumberIndex];
 }
 

--- a/src/engine/random_number_generator.cpp
+++ b/src/engine/random_number_generator.cpp
@@ -47,12 +47,7 @@ const std::array<int, 256> RANDOM_NUMBER_TABLE{
 
 
 int RandomNumberGenerator::gen() {
-  ++mNextNumberIndex;
-  if (mNextNumberIndex >= RANDOM_NUMBER_TABLE.size()) {
-    mNextNumberIndex = 0;
-  }
-
-  return RANDOM_NUMBER_TABLE[mNextNumberIndex];
+  return RANDOM_NUMBER_TABLE[++mNextNumberIndex];
 }
 
 }

--- a/src/engine/random_number_generator.hpp
+++ b/src/engine/random_number_generator.hpp
@@ -30,7 +30,7 @@ public:
   int gen();
 
 private:
-  std::size_t mNextNumberIndex = 0;
+  std::uint8_t mNextNumberIndex = 0;
 };
 
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(test_sources
     test_letter_collection.cpp
     test_physics_system.cpp
     test_player.cpp
+    test_rng.cpp
     test_spike_ball.cpp
     test_timing.cpp
 )

--- a/test/test_rng.cpp
+++ b/test/test_rng.cpp
@@ -1,0 +1,54 @@
+/* Copyright (C) 2021, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <base/warnings.hpp>
+#include <engine/random_number_generator.hpp>
+
+RIGEL_DISABLE_WARNINGS
+#include <catch.hpp>
+RIGEL_RESTORE_WARNINGS
+
+#include <algorithm>
+
+TEST_CASE("Random number generator works the same as the original") {
+  rigel::engine::RandomNumberGenerator rng;
+  SECTION("Values are generated in this particular order") {
+    SECTION("First generated value is 8 (the 1st one in the array)") {
+      CHECK(rng.gen() == 8u);
+    }
+    SECTION("The period of the RNG is the original array's size") {
+      const auto firstRandomValue = rng.gen();
+      for(unsigned i = 0u; i < rigel::engine::RANDOM_NUMBER_TABLE.size() - 1; ++i) {
+        (void)rng.gen(); // ignore these
+      }
+      const auto randomValueAfterPeriod = rng.gen();
+      CHECK(firstRandomValue == randomValueAfterPeriod);
+    }
+    SECTION("Test RNG generates in the same order") {
+      std::vector<int> randomNumbers(rigel::engine::RANDOM_NUMBER_TABLE.size() * 2, std::numeric_limits<int>::min());
+      auto beg = std::begin(randomNumbers);
+      auto end = std::end(randomNumbers);
+      std::generate(beg, end, [&rng]() { return rng.gen(); });
+      // since we start from the 1st index in the original array, rotate once
+      std::rotate(randomNumbers.rbegin(), randomNumbers.rbegin() + 1, randomNumbers.rend());
+      auto half = std::next(std::begin(randomNumbers), randomNumbers.size() / 2);
+      const auto halfDistance = std::distance(beg, half);
+      CHECK(halfDistance == std::distance(half, end));
+      CHECK(static_cast<size_t>(halfDistance) == rigel::engine::RANDOM_NUMBER_TABLE.size());
+      CHECK(std::equal(beg, half, half));
+    }
+  }
+}


### PR DESCRIPTION
Hello,

Your CONTRIBUTING.md states that unsigned overflow is usable when useful.
Looks to me like the RNG is quite alright with a uint8_t since it has exactly 256 values (0-255).
Avoids a branch.

Do tell me if I've missed something and that IF has some other reason for being there.
I've also thought about adding a UT for the RNG (since I haven't found one). Just to make sure I didn't break anything. It would largely be doing a 1-1 check against the array tho..

Also, does it intentionally start at 1? i.e. that ++ before the access is there for a good reason right? It confused me a bit!<

Have a good one!