### PR TITLE
Remove boost strings split usage

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,7 +31,7 @@ before_build:
 
     - mkdir build
     - cd build
-    - cmake .. -G "Visual Studio 16 2019"
+    - cmake .. -G "Visual Studio 16 2019" -DBUILD_BENCHMARKS=ON
     - cd ..
 
 build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Run CMake (debug)
       run: CC=gcc-8 CXX=g++-8 cmake -H. -Bbuild_dbg -DCMAKE_BUILD_TYPE=Debug
     - name: Run CMake (release)
-      run: CC=gcc-8 CXX=g++-8 cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release
+      run: CC=gcc-8 CXX=g++-8 cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DBUILD_BENCHMARKS=ON
     - name: Build (debug)
       run: cd build_dbg && make -j2
     - name: Build (release)
@@ -74,7 +74,7 @@ jobs:
     - name: Run CMake (debug)
       run: cmake -H. -Bbuild_dbg -DCMAKE_BUILD_TYPE=Debug
     - name: Run CMake (release)
-      run: cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release
+      run: cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DBUILD_BENCHMARKS=ON
     - name: Build (debug)
       run: cd build_dbg && make -j2
     - name: Build (release)

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -60,8 +60,8 @@ to find for the build to work:
 * SDL\_mixer >= 2.0.1
 * Boost >= 1.65
 
-All other dependencies are already provided as submodules or source
-code (in the `3rd_party` directory), and will be built along with RigelEngine.
+All other dependencies are already provided as submodules, source
+code (in the `3rd_party` directory) or fetched on configuration, and will be built along with RigelEngine.
 In other words, you don't need to worry about providing these dependencies.
 
 These are:
@@ -78,6 +78,7 @@ These are:
 * [STB image](https://github.com/nothings/stb) image reading/writing library
 * [STB rect_pack](https://github.com/nothings/stb) rectangle packer for building texture atlases
 
+If you want to build benchmarks, you need to enable `BUILD_BENCHMARKS` (via CMake's `-DBUILD_BENCHMARKS=ON`). Doing so will automatically fetch googlebenchmark. You can then build the `benchmarks` target (this will also build googlebenchmark). Make sure you build in `Release` and disable CPU scaling (see: [link](https://github.com/google/benchmark#disabling-cpu-frequency-scaling) for more details).
 
 ### <a name="linux-build-instructions">Linux builds</a>
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 
 option(USE_GL_ES "Use OpenGL ES instead of regular OpenGL" OFF)
 option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" ON)
-
+option(BUILD_BENCHMARKS "Build benchmarks" OFF)
 
 # Dependencies
 ###############################################################################
@@ -93,4 +93,8 @@ if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
 
     add_subdirectory(modding_tools)
     add_subdirectory(test)
+endif()
+
+if(BUILD_BENCHMARKS)
+    add_subdirectory(benchmark)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,8 +84,6 @@ endif()
 ###############################################################################
 
 add_subdirectory(3rd_party)
-
-rigel_configure_compiler_warnings()
 add_subdirectory(src)
 
 if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,0 +1,24 @@
+include(FetchContent)
+
+FetchContent_Declare(
+    benchmark
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG        v1.5.3
+)
+FetchContent_GetProperties(benchmark)
+if(NOT benchmark_POPULATED)
+    set(BENCHMARK_ENABLE_GTEST_TESTS OFF)
+    set(BENCHMARK_ENABLE_INSTALL OFF)
+    set(BENCHMARK_ENABLE_TESTING OFF)
+    FetchContent_Populate(benchmark)
+    add_subdirectory(${benchmark_SOURCE_DIR} ${benchmark_BINARY_DIR})
+endif()
+
+add_executable(benchmarks
+    bench_string_utils.cpp
+)
+
+target_link_libraries(benchmarks PRIVATE
+    rigel_core
+    benchmark::benchmark_main
+)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -22,3 +22,5 @@ target_link_libraries(benchmarks PRIVATE
     rigel_core
     benchmark::benchmark_main
 )
+
+rigel_enable_warnings(benchmarks)

--- a/benchmark/bench_string_utils.cpp
+++ b/benchmark/bench_string_utils.cpp
@@ -1,0 +1,146 @@
+/* Copyright (C) 2021, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <benchmark/benchmark.h>
+
+#include <base/string_utils.hpp>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/algorithm.hpp>
+
+static void BMStringSplit(benchmark::State &state) {
+  std::string const kInputString = "Hello, world";
+  for (auto _ : state) {
+    const auto v = rigel::strings::split(kInputString, ',');
+    benchmark::DoNotOptimize(v);
+    benchmark::ClobberMemory();
+  }
+}
+
+BENCHMARK(BMStringSplit);
+
+static void BMBoostStringSplit(benchmark::State &state) {
+  const std::string kInputString = "Hello, world";
+  for (auto _ : state) {
+    state.PauseTiming();
+    std::vector<std::string> v;
+    state.ResumeTiming();
+    boost::split(v, kInputString, boost::is_any_of(","));
+    benchmark::DoNotOptimize(v);
+    benchmark::ClobberMemory();
+  }
+}
+
+BENCHMARK(BMBoostStringSplit);
+
+static void BMStartsWithTrueCase(benchmark::State &state) {
+  const std::string kInputString = "12341234";
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(
+      rigel::strings::startsWith(kInputString, "1234"));
+  }
+}
+
+BENCHMARK(BMStartsWithTrueCase);
+
+
+static void BMStartsWithTrueCaseLongString(benchmark::State &state) {
+  const std::string kInputString = "Iid7tUoNzQaGQjb9QqmuvqVQU9XbPmOvVbOI5ozuKdQN9bdHeP";
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(
+      rigel::strings::startsWith(kInputString, "Iid7tUoNzQaGQjb9QqmuvqVQU9Xb"));
+  }
+}
+
+BENCHMARK(BMStartsWithTrueCaseLongString);
+
+static void BMStartsWithFalseCase(benchmark::State &state) {
+  const std::string kInputString = "12341234";
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(
+      rigel::strings::startsWith(kInputString, "234"));
+  }
+}
+
+BENCHMARK(BMStartsWithFalseCase);
+
+
+static void BMBoostStartsWithTrueCase(benchmark::State &state) {
+  const std::string kInputString = "12341234";
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(
+      boost::starts_with(kInputString, "1234"));
+  }
+}
+
+BENCHMARK(BMBoostStartsWithTrueCase);
+
+static void BMBoostStartsWithFalseCase(benchmark::State &state) {
+  const std::string kInputString = "12341234";
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(
+      boost::starts_with(kInputString, "234"));
+  }
+}
+
+BENCHMARK(BMBoostStartsWithFalseCase);
+
+static void BMTrimLeft(benchmark::State &state) {
+  for (auto _ : state) {
+    state.PauseTiming();
+    std::string kInputString = "  1234  ";
+    state.ResumeTiming();
+    benchmark::DoNotOptimize(
+      rigel::strings::trimLeft(kInputString));
+  }
+}
+
+BENCHMARK(BMTrimLeft);
+
+static void BMTrimRight(benchmark::State &state) {
+  for (auto _ : state) {
+    state.PauseTiming();
+    std::string kInputString = "  1234  ";
+    state.ResumeTiming();
+    benchmark::DoNotOptimize(
+      rigel::strings::trimRight(kInputString));
+  }
+}
+
+BENCHMARK(BMTrimRight);
+
+static void BMTrim(benchmark::State &state) {
+  for (auto _ : state) {
+    state.PauseTiming();
+    std::string kInputString = "  1234  ";
+    state.ResumeTiming();
+    benchmark::DoNotOptimize(
+      rigel::strings::trim(kInputString));
+  }
+}
+
+BENCHMARK(BMTrim);
+
+static void BMBoostTrim(benchmark::State &state) {
+  for (auto _ : state) {
+    state.PauseTiming();
+    std::string kInputString = "  1234  ";
+    state.ResumeTiming();
+    boost::trim(kInputString);
+  }
+}
+
+BENCHMARK(BMBoostTrim);

--- a/cmake/rigel.cmake
+++ b/cmake/rigel.cmake
@@ -19,9 +19,9 @@ function(rigel_define_wasm_targets_for_dependencies)
 endfunction()
 
 
-function(rigel_configure_compiler_warnings)
+function(rigel_enable_warnings target)
     if(MSVC)
-        add_compile_options(
+        target_compile_options(${target} PRIVATE
             /W4
             /wd4100 # Unused parameter
             /wd4503 # Decorated name length exceeded
@@ -30,10 +30,10 @@ function(rigel_configure_compiler_warnings)
         add_definitions(-D_SCL_SECURE_NO_WARNINGS)
 
         if (WARNINGS_AS_ERRORS)
-            add_compile_options(/WX)
+            target_compile_options(${target} PRIVATE /WX)
         endif()
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        add_compile_options(
+        target_compile_options(${target} PRIVATE
             -Weverything
             -Wno-unknown-warning-option
             -Wno-c++98-compat
@@ -58,10 +58,10 @@ function(rigel_configure_compiler_warnings)
         )
 
         if (WARNINGS_AS_ERRORS)
-            add_compile_options(-Werror)
+            target_compile_options(${target} PRIVATE -Werror)
         endif()
     elseif(CMAKE_COMPILER_IS_GNUCXX)
-        add_compile_options(
+        target_compile_options(${target} PRIVATE
             -Wall
             -Wextra
             -pedantic
@@ -70,7 +70,7 @@ function(rigel_configure_compiler_warnings)
         )
 
         if (WARNINGS_AS_ERRORS)
-            add_compile_options(-Werror)
+            target_compile_options(${target} PRIVATE -Werror)
         endif()
     else()
         message(FATAL_ERROR "Unrecognized compiler")

--- a/modding_tools/CMakeLists.txt
+++ b/modding_tools/CMakeLists.txt
@@ -3,3 +3,4 @@ target_link_libraries(UserProfileTool PRIVATE
     SDL2::Main
     rigel_core
 )
+rigel_enable_warnings(UserProfileTool)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,8 @@ set(core_sources
     common/global.hpp
     common/json_utils.cpp
     common/json_utils.hpp
+    base/string_utils.cpp
+    base/string_utils.hpp
     common/user_profile.cpp
     common/user_profile.hpp
     data/actor_ids.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -353,6 +353,8 @@ target_link_libraries(rigel_core
     static_vector
 )
 
+rigel_enable_warnings(rigel_core)
+
 if(USE_GL_ES)
     target_compile_definitions(rigel_core PUBLIC
         RIGEL_USE_GL_ES=1
@@ -394,3 +396,5 @@ else()
         Boost::disable_autolinking
     )
 endif()
+
+rigel_enable_warnings(RigelEngine)

--- a/src/base/string_utils.cpp
+++ b/src/base/string_utils.cpp
@@ -1,0 +1,23 @@
+#include "string_utils.hpp"
+
+#include <algorithm>
+#include <cassert>
+
+namespace rigel::strings {
+
+std::vector<std::string> split(std::string_view input, char delimiter) {
+  assert(static_cast<int>(delimiter) < 127 && "We only accept ASCII delimiters");
+
+  std::vector<std::string> output;
+  auto start = std::begin(input);
+  auto end = std::end(input);
+  decltype(start) next;
+  while ((next = std::find(start, end, delimiter)) != end) {
+    output.emplace_back(start, next);
+    start = std::next(next, 1);
+  }
+  output.emplace_back(start, next);
+  return output;
+}
+
+} // namespace rigel::strings

--- a/src/base/string_utils.cpp
+++ b/src/base/string_utils.cpp
@@ -20,4 +20,9 @@ std::vector<std::string> split(std::string_view input, char delimiter) {
   return output;
 }
 
+bool startsWith(std::string_view input, std::string_view prefix) noexcept {
+  return input.size() >= prefix.size() &&
+    std::equal(std::begin(prefix), std::end(prefix), std::begin(input));
+}
+
 } // namespace rigel::strings

--- a/src/base/string_utils.cpp
+++ b/src/base/string_utils.cpp
@@ -25,4 +25,19 @@ bool startsWith(std::string_view input, std::string_view prefix) noexcept {
     std::equal(std::begin(prefix), std::end(prefix), std::begin(input));
 }
 
+std::string& trimLeft(std::string& input, const char* what) noexcept {
+  input.erase(0, input.find_first_not_of(what));
+  return input;
+}
+
+std::string& trimRight(std::string& input, const char* what) noexcept {
+  input.erase(input.find_last_not_of(what) + 1);
+  return input;
+}
+
+std::string& trim(std::string& input, const char* what) noexcept {
+  trimLeft(trimRight(input, what), what);
+  return input;
+}
+
 } // namespace rigel::strings

--- a/src/base/string_utils.hpp
+++ b/src/base/string_utils.hpp
@@ -26,4 +26,8 @@ namespace rigel::strings {
  */
 [[nodiscard]] std::vector<std::string> split(std::string_view input, char delimiter);
 
+/** Checks if an input string has the given prefix
+ */
+[[nodiscard]] bool startsWith(std::string_view input, std::string_view prefix) noexcept;
+
 } // namespace rigel::strings

--- a/src/base/string_utils.hpp
+++ b/src/base/string_utils.hpp
@@ -30,4 +30,19 @@ namespace rigel::strings {
  */
 [[nodiscard]] bool startsWith(std::string_view input, std::string_view prefix) noexcept;
 
+/** Removes all occurences of 'what' from the left of the input, until any non-'what' is found
+ * Does everything inplace
+ */
+std::string& trimLeft(std::string& input, const char* what = "\n\r\t ") noexcept;
+
+/** Removes all occurences of 'what' from the right of the input, until any non-'what' is found
+ * Does everything inplace
+ */
+std::string& trimRight(std::string& input, const char* what = "\n\r\t ") noexcept;
+
+/** Removes all occurences of 'what' from the right and left of the input, until any non-'what' is found
+ * Does everything inplace
+ */
+std::string& trim(std::string& input, const char* what = "\n\r\t ") noexcept;
+
 } // namespace rigel::strings

--- a/src/base/string_utils.hpp
+++ b/src/base/string_utils.hpp
@@ -1,0 +1,29 @@
+/* Copyright (C) 2021, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace rigel::strings {
+
+/** Split a string based on a single char delimiter and return the output
+ */
+[[nodiscard]] std::vector<std::string> split(std::string_view input, char delimiter);
+
+} // namespace rigel::strings

--- a/src/loader/duke_script_loader.cpp
+++ b/src/loader/duke_script_loader.cpp
@@ -20,7 +20,6 @@
 #include "data/game_traits.hpp"
 
 RIGEL_DISABLE_WARNINGS
-#include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/trim.hpp>
 RIGEL_RESTORE_WARNINGS

--- a/src/loader/duke_script_loader.cpp
+++ b/src/loader/duke_script_loader.cpp
@@ -16,11 +16,11 @@
 
 #include "duke_script_loader.hpp"
 
+#include "base/string_utils.hpp"
 #include "base/warnings.hpp"
 #include "data/game_traits.hpp"
 
 RIGEL_DISABLE_WARNINGS
-#include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/trim.hpp>
 RIGEL_RESTORE_WARNINGS
 
@@ -63,7 +63,7 @@ void skipWhiteSpace(istream& sourceStream) {
 
 
 bool isCommand(const string& line) {
-  return b::starts_with(line, "//");
+  return strings::startsWith(line, "//");
 }
 
 

--- a/src/loader/duke_script_loader.cpp
+++ b/src/loader/duke_script_loader.cpp
@@ -20,10 +20,8 @@
 #include "base/warnings.hpp"
 #include "data/game_traits.hpp"
 
-RIGEL_DISABLE_WARNINGS
-#include <boost/algorithm/string/trim.hpp>
-RIGEL_RESTORE_WARNINGS
-
+#include <algorithm>
+#include <cassert>
 #include <cctype>
 #include <optional>
 #include <sstream>
@@ -47,7 +45,6 @@ RIGEL_RESTORE_WARNINGS
 
 namespace rigel::loader {
 
-namespace b = boost;
 using namespace std;
 using namespace data::script;
 using data::GameTraits;
@@ -68,7 +65,7 @@ bool isCommand(const string& line) {
 
 
 void stripCommandPrefix(string& line) {
-  b::trim_left_if(line, [](const auto c) { return c == '/'; });
+  strings::trimLeft(line, "/");
 }
 
 
@@ -80,9 +77,9 @@ void parseScriptLines(
 ) {
   skipWhiteSpace(sourceTextStream);
   for (string line; getline(sourceTextStream, line, '\n');) {
-    b::trim(line);
+    strings::trim(line);
     if (isCommand(line)) {
-      b::trim_left_if(line, [](const auto c) { return c == '/'; });
+      strings::trimLeft(line, "/");
       if (line == endMarker) {
         return;
       }
@@ -90,7 +87,7 @@ void parseScriptLines(
       istringstream lineTextStream(line);
       string command;
       lineTextStream >> command;
-      b::trim(command);
+      strings::trim(command);
       consumeLine(command, lineTextStream);
     }
   }
@@ -109,13 +106,13 @@ vector<string> parseMessageBoxTextDefinition(istream& sourceStream) {
   // we assume the message box is complete and return to regular parsing.
   auto startOfLine = sourceStream.tellg();
   for (string line; getline(sourceStream, line, '\n');) {
-    b::trim(line);
+    strings::trim(line);
     if (isCommand(line)) {
       stripCommandPrefix(line);
       istringstream lineTextStream(line);
       string command;
       lineTextStream >> command;
-      b::trim(command);
+      strings::trim(command);
 
       if (command == "CWTEXT") {
         lineTextStream.get();
@@ -124,7 +121,7 @@ vector<string> parseMessageBoxTextDefinition(istream& sourceStream) {
         if (messageLine.empty()) {
           throw invalid_argument("Corrupt Duke Script file");
         }
-        b::trim_right(messageLine);
+        strings::trimRight(messageLine);
         messageLines.emplace_back(messageLine);
       } else if (command == "SKLINE") {
         messageLines.emplace_back("");
@@ -204,7 +201,7 @@ std::optional<Action> parseSingleActionCommand(
   {
     string imageName;
     lineTextStream >> imageName;
-    b::trim(imageName);
+    strings::trim(imageName);
     if (imageName.empty()) {
       throw invalid_argument("Invalid LOADRAW command in Duke Script file");
     }
@@ -220,7 +217,7 @@ std::optional<Action> parseSingleActionCommand(
   {
     string paletteFile;
     lineTextStream >> paletteFile;
-    b::trim(paletteFile);
+    strings::trim(paletteFile);
     if (paletteFile.empty()) {
       throw invalid_argument("Invalid LOADRAW command in Duke Script file");
     }
@@ -477,7 +474,7 @@ bool skipToHintsSection(istream& sourceTextStream) {
 
     string sectionName;
     sourceTextStream >> sectionName;
-    b::trim(sectionName);
+    strings::trim(sectionName);
 
     if (sectionName == "Hints") {
       skipWhiteSpace(sourceTextStream);
@@ -500,7 +497,7 @@ ScriptBundle loadScripts(const string& scriptSource) {
 
     string scriptName;
     sourceStream >> scriptName;
-    b::trim(scriptName);
+    strings::trim(scriptName);
 
     if (!scriptName.empty()) {
       bundle.emplace(scriptName, parseScript(sourceStream));
@@ -528,7 +525,7 @@ data::LevelHints loadHintMessages(const std::string& scriptSource) {
       continue;
     }
 
-    b::trim(line);
+    strings::trim(line);
 
     istringstream lineTextStream(line);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,13 +23,12 @@
 // you might want to hop over to game_main.cpp instead of looking at this file
 // here.
 
+#include "base/string_utils.hpp"
 #include "base/warnings.hpp"
 
 #include "game_main.hpp"
 
 RIGEL_DISABLE_WARNINGS
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
 #include <boost/program_options.hpp>
 RIGEL_RESTORE_WARNINGS
 
@@ -40,7 +39,6 @@ RIGEL_RESTORE_WARNINGS
 
 using namespace rigel;
 
-namespace ba = boost::algorithm;
 namespace po = boost::program_options;
 
 
@@ -96,8 +94,7 @@ auto parseDifficulty(const std::string& difficultySpec) {
 
 
 base::Vector parsePlayerPosition(const std::string& playerPosString) {
-  std::vector<std::string> positionParts;
-  ba::split(positionParts, playerPosString, ba::is_any_of(","));
+  const std::vector<std::string> positionParts = strings::split(playerPosString, ',');
 
   if (
     positionParts.size() != 2 ||

--- a/src/ui/menu_element_renderer.cpp
+++ b/src/ui/menu_element_renderer.cpp
@@ -17,16 +17,12 @@
 #include "menu_element_renderer.hpp"
 
 #include "base/math_tools.hpp"
+#include "base/string_utils.hpp"
 #include "base/warnings.hpp"
 #include "data/game_traits.hpp"
 #include "data/unit_conversions.hpp"
 #include "engine/timing.hpp"
 #include "loader/resource_loader.hpp"
-
-RIGEL_DISABLE_WARNINGS
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
-RIGEL_RESTORE_WARNINGS
 
 #include <cassert>
 #include <stdexcept>
@@ -248,10 +244,7 @@ void MenuElementRenderer::drawMultiLineText(
   const int y,
   const std::string& text
 ) const {
-  namespace ba = boost::algorithm;
-
-  std::vector<std::string> lines;
-  ba::split(lines, text, ba::is_any_of("\n"));
+  const std::vector<std::string> lines = strings::split(text, '\n');
   for (int i = 0; i < int(lines.size()); ++i) {
     drawText(x, y + i, lines[i]);
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(tests
     test_player.cpp
     test_rng.cpp
     test_spike_ball.cpp
+    test_string_utils.cpp
     test_timing.cpp
 )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,4 +19,6 @@ target_link_libraries(tests
     catch2
 )
 
+rigel_enable_warnings(tests)
+
 add_test(all-tests tests)

--- a/test/test_string_utils.cpp
+++ b/test/test_string_utils.cpp
@@ -48,3 +48,30 @@ TEST_CASE("String split") {
     CHECK(v == expected);
   }
 }
+
+TEST_CASE("String prefix check (startsWith)") {
+  SECTION("Empty string is prefix of itself") {
+    const bool hasPrefix = rigel::strings::startsWith("", "");
+    CHECK(hasPrefix);
+  }
+  SECTION("Empty string is a prefix for any string") {
+    const bool hasPrefix = rigel::strings::startsWith("1234", "");
+    CHECK(hasPrefix);
+  }
+  SECTION("String with no prefix") {
+    const bool hasPrefix = rigel::strings::startsWith("hello", "bye");
+    CHECK(!hasPrefix);
+  }
+  SECTION("String with prefix") {
+    const bool hasPrefix = rigel::strings::startsWith("1234", "12");
+    CHECK(hasPrefix);
+  }
+  SECTION("String with prefix longer than string") {
+    const bool hasPrefix = rigel::strings::startsWith("1234", "12345");
+    CHECK(!hasPrefix);
+  }
+  SECTION("String contains the desired substring, but not as a prefix") {
+    const bool hasPrefix = rigel::strings::startsWith("1234", "234");
+    CHECK(!hasPrefix);
+  }
+}

--- a/test/test_string_utils.cpp
+++ b/test/test_string_utils.cpp
@@ -75,3 +75,98 @@ TEST_CASE("String prefix check (startsWith)") {
     CHECK(!hasPrefix);
   }
 }
+
+
+TEST_CASE("String trim inplace") {
+  SECTION("Trim left") {
+    SECTION("Empty string still empty after trim left") {
+      std::string trimmed = "";
+      rigel::strings::trimLeft(trimmed);
+      CHECK(trimmed == "");
+    }
+    SECTION("Trim whitespace from the left of the string") {
+      std::string trimmed = " hello ";
+      rigel::strings::trimLeft(trimmed);
+      CHECK(trimmed == "hello ");
+    }
+    SECTION("Trim whitespace from the left of the string but don't change inside it") {
+      std::string trimmed = " hello world";
+      rigel::strings::trimLeft(trimmed);
+      CHECK(trimmed == "hello world");
+    }
+    SECTION("Trim whitespace from the left of the string and don't change the right side") {
+      std::string trimmed = "hello ";
+      rigel::strings::trimLeft(trimmed);
+      CHECK(trimmed == "hello ");
+    }
+    SECTION("Trim all whitespaces from the left of the string") {
+      std::string trimmed = "  \n\thello ";
+      rigel::strings::trimLeft(trimmed);
+      CHECK(trimmed == "hello ");
+    }
+    SECTION("Trims other characters from the left of the string") {
+      std::string trimmed = "//hello ";
+      rigel::strings::trimLeft(trimmed, "/");
+      CHECK(trimmed == "hello ");
+    }
+    SECTION("Empties an all whitespace string") {
+      std::string trimmed = " \t\n\r";
+      rigel::strings::trimLeft(trimmed);
+      CHECK(trimmed == "");
+    }
+  }
+  SECTION("Trim right") {
+    SECTION("Empty string still empty after trim right") {
+      std::string trimmed = "";
+      rigel::strings::trimRight(trimmed);
+      CHECK(trimmed == "");
+    }
+    SECTION("Trim whitespace from the right of the string") {
+      std::string trimmed = " hello ";
+      rigel::strings::trimRight(trimmed);
+      CHECK(trimmed == " hello");
+    }
+    SECTION("Trim whitespace from the right of the string but don't change inside it") {
+      std::string trimmed = "hello world ";
+      rigel::strings::trimRight(trimmed);
+      CHECK(trimmed == "hello world");
+    }
+    SECTION("Trim whitespace from the right of the string and don't change the left side") {
+      std::string trimmed = " hello";
+      rigel::strings::trimRight(trimmed);
+      CHECK(trimmed == " hello");
+    }
+    SECTION("Trim all whitespaces from the right of the string") {
+      std::string trimmed = "  \n\thello\n\t ";
+      rigel::strings::trimRight(trimmed);
+      CHECK(trimmed == "  \n\thello");
+    }
+    SECTION("Trims other characters from the right of the string") {
+      std::string trimmed = "//hello//";
+      rigel::strings::trimRight(trimmed, "/");
+      CHECK(trimmed == "//hello");
+    }
+  }
+  SECTION("Trim all") {
+    SECTION("Empty string still empty after trim") {
+      std::string trimmed = "";
+      rigel::strings::trim(trimmed);
+      CHECK(trimmed == "");
+    }
+    SECTION("Trim whitespace from the right/left of the string") {
+      std::string trimmed = " hello ";
+      rigel::strings::trim(trimmed);
+      CHECK(trimmed == "hello");
+    }
+    SECTION("Trim whitespace from the right/left of the string and don't change the inside") {
+      std::string trimmed = " hello world ";
+      rigel::strings::trim(trimmed);
+      CHECK(trimmed == "hello world");
+    }
+    SECTION("Trims other characters from the string") {
+      std::string trimmed = "//hello//";
+      rigel::strings::trim(trimmed, "/");
+      CHECK(trimmed == "hello");
+    }
+  }
+}

--- a/test/test_string_utils.cpp
+++ b/test/test_string_utils.cpp
@@ -1,0 +1,50 @@
+/* Copyright (C) 2021, Nikolai Wuttke. All rights reserved.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <base/string_utils.hpp>
+#include <base/warnings.hpp>
+
+RIGEL_DISABLE_WARNINGS
+#include <catch.hpp>
+RIGEL_RESTORE_WARNINGS
+
+TEST_CASE("String split") {
+  SECTION("Empty string") {
+    const std::vector<std::string> v = rigel::strings::split("", ' ');
+    const std::vector<std::string> expected{""};
+    CHECK(v == expected);
+  }
+  SECTION("String with no delimiter") {
+    const std::vector<std::string> v = rigel::strings::split("hello", ' ');
+    const std::vector<std::string> expected{"hello"};
+    CHECK(v == expected);
+  }
+  SECTION("String with delimiter") {
+    const std::vector<std::string> v = rigel::strings::split("hello, world", ',');
+    const std::vector<std::string> expected{"hello", " world"};
+    CHECK(v == expected);
+  }
+  SECTION("String with other white space delimiters") {
+    const std::vector<std::string> v = rigel::strings::split("hello\nworld", '\n');
+    const std::vector<std::string> expected{"hello", "world"};
+    CHECK(v == expected);
+  }
+  SECTION("String with delimiter at the end") {
+    const std::vector<std::string> v = rigel::strings::split("hello,", ',');
+    const std::vector<std::string> expected{"hello", ""};
+    CHECK(v == expected);
+  }
+}


### PR DESCRIPTION
Hello,

This one resolves #662, partially.
I've started with string `split` since I knew how to implement that.
Funny bit is that it ended up a bit faster than boost's version..

You should check out the benchmarks. I guess that's understandable since this version I added is much simpler and only uses a simple delimiter (one char).

But hey, I'll take it.

EDIT: add `trim[Right|Left]` and `startsWith`

Cheers!