### PR TITLE
Add missing include

### DIFF
--- a/src/engine/random_number_generator.cpp
+++ b/src/engine/random_number_generator.cpp
@@ -16,8 +16,10 @@
 
 #include "random_number_generator.hpp"
 
+#include <cstddef>
 #include <limits>
 #include <type_traits>
+
 
 namespace rigel::engine {
 


### PR DESCRIPTION
gcc versions up to 9, and all other compilers we use, provide `size_t`
when including `<array>`. This changed with gcc 10, which needs an
explicit include in order for `size_t` to be defined.

Fixes #669 