### PR TITLE
Implement asset overrides for tilesets and backdrops

### DIFF
--- a/src/engine/map_renderer.cpp
+++ b/src/engine/map_renderer.cpp
@@ -27,7 +27,6 @@
 namespace rigel::engine
 {
 
-using namespace std;
 using namespace data;
 
 using data::map::BackdropScrollMode;

--- a/src/engine/map_renderer.cpp
+++ b/src/engine/map_renderer.cpp
@@ -169,23 +169,29 @@ void MapRenderer::renderBackdrop(
   const base::Vector& cameraPosition,
   const base::Extents& viewPortSize) const
 {
+  const auto numRepetitions = base::integerDivCeil(
+    tilesToPixels(viewPortSize.width), GameTraits::viewPortWidthPx);
+
+  const auto sourceRectSize = base::Extents{
+    mBackdropTexture.width() * numRepetitions, mBackdropTexture.height()};
+  const auto destRectSize = base::Extents{
+    GameTraits::viewPortWidthPx * numRepetitions, GameTraits::viewPortHeightPx};
+
+  const auto widthFactor =
+    mBackdropTexture.width() / GameTraits::viewPortWidthPx;
   const auto offset =
-    backdropOffset(cameraPosition, mScrollMode, mBackdropAutoScrollOffset);
-
-  const auto backdropWidth = mBackdropTexture.width();
-  const auto numRepetitions =
-    base::integerDivCeil(tilesToPixels(viewPortSize.width), backdropWidth);
-
-  const auto sourceRectSize =
-    base::Extents{backdropWidth * numRepetitions, mBackdropTexture.height()};
+    backdropOffset(cameraPosition, mScrollMode, mBackdropAutoScrollOffset) *
+    widthFactor;
 
   const auto saved = renderer::saveState(mpRenderer);
   mpRenderer->setTextureRepeatEnabled(true);
   mpRenderer->drawTexture(
     mBackdropTexture.data(),
     renderer::toTexCoords(
-      {offset, sourceRectSize}, backdropWidth, mBackdropTexture.height()),
-    {{}, sourceRectSize});
+      {offset, sourceRectSize},
+      mBackdropTexture.width(),
+      mBackdropTexture.height()),
+    {{}, destRectSize});
 }
 
 

--- a/src/loader/level_loader.cpp
+++ b/src/loader/level_loader.cpp
@@ -621,11 +621,11 @@ LevelData loadLevel(
     }
   }
 
-  auto backdropImage = resources.loadTiledFullscreenImage(header.backdrop);
+  auto backdropImage = resources.loadBackdrop(header.backdrop);
   std::optional<data::Image> alternativeBackdropImage;
   if (header.flagBitSet(0x40) || header.flagBitSet(0x80))
   {
-    alternativeBackdropImage = resources.loadTiledFullscreenImage(
+    alternativeBackdropImage = resources.loadBackdrop(
       backdropNameFromNumber(header.alternativeBackdropNumber));
   }
 

--- a/src/loader/level_loader.cpp
+++ b/src/loader/level_loader.cpp
@@ -46,7 +46,6 @@
 namespace rigel::loader
 {
 
-using namespace std;
 using data::ActorID;
 using data::Difficulty;
 using data::GameTraits;
@@ -61,7 +60,7 @@ namespace
 using ActorList = std::vector<LevelData::Actor>;
 
 
-string stripSpaces(string str)
+std::string stripSpaces(std::string str)
 {
   const auto it = str.find(' ');
   if (it != str.npos)
@@ -104,9 +103,9 @@ struct LevelHeader
   bool flagBitSet(const uint8_t bitMask) { return (flags & bitMask) != 0; }
 
   const uint16_t dataOffset;
-  const string CZone;
-  const string backdrop;
-  const string music;
+  const std::string CZone;
+  const std::string backdrop;
+  const std::string music;
   const uint8_t flags;
   const uint8_t alternativeBackdropNumber;
   const uint16_t unknown;
@@ -138,10 +137,10 @@ ByteBuffer readExtraMaskedTileBits(const LeStreamReader& levelReader)
 }
 
 
-string backdropNameFromNumber(const uint8_t backdropNumber)
+std::string backdropNameFromNumber(const uint8_t backdropNumber)
 {
-  auto name = string("DROP");
-  name += to_string(backdropNumber);
+  auto name = std::string("DROP");
+  name += std::to_string(backdropNumber);
   name += ".MNI";
   return name;
 }
@@ -511,8 +510,8 @@ std::tuple<ActorList, base::Vector, bool> preProcessActorDescriptions(
 void sortByDrawIndex(ActorList& actors, const ResourceLoader& resources)
 {
   std::stable_sort(
-    begin(actors),
-    end(actors),
+    std::begin(actors),
+    std::end(actors),
     [&](const LevelData::Actor& lhs, const LevelData::Actor& rhs) {
       return resources.mActorImagePackage.drawIndexFor(lhs.mID) <
         resources.mActorImagePackage.drawIndexFor(rhs.mID);
@@ -523,7 +522,7 @@ void sortByDrawIndex(ActorList& actors, const ResourceLoader& resources)
 
 
 LevelData loadLevel(
-  const string& mapName,
+  const std::string& mapName,
   const ResourceLoader& resources,
   const Difficulty chosenDifficulty)
 {

--- a/src/loader/level_loader.cpp
+++ b/src/loader/level_loader.cpp
@@ -19,6 +19,7 @@
 #include "base/container_utils.hpp"
 #include "base/grid.hpp"
 #include "base/math_tools.hpp"
+#include "base/string_utils.hpp"
 #include "data/game_traits.hpp"
 #include "data/unit_conversions.hpp"
 #include "loader/bitwise_iter.hpp"
@@ -62,11 +63,7 @@ using ActorList = std::vector<LevelData::Actor>;
 
 std::string stripSpaces(std::string str)
 {
-  const auto it = str.find(' ');
-  if (it != str.npos)
-  {
-    str.erase(it);
-  }
+  strings::trimRight(str);
   return str;
 }
 

--- a/src/loader/resource_loader.cpp
+++ b/src/loader/resource_loader.cpp
@@ -55,15 +55,23 @@ const auto FULL_SCREEN_IMAGE_DATA_SIZE =
 // name exists at the replacements path, and if it does, it will load this file
 // and use it instead of the asset from the original data file (NUKEM2.CMP).
 //
-// At the moment, this is only implemented for sprites/actors. The expected
-// format for replacement files is:
+// At the moment, this is implemented for sprites/actors, backdrops, and
+// tilesets. The expected format for replacement files is:
+//
+//   backdrop<num>.png
+//
+//   tileset<num>.png
 //
 //   actor<actor_id>_frame<animation_frame>.png
 //
-// Where <actor_id> and <animation_frame> should be replaced with the
+// Where <num>, <actor_id> and <animation_frame> should be replaced with the
 // corresponding numbers. For example, to replace the images used for the
 // "blue guard" enemy, files named "actor159_frame0.png" up to
 // "actor159_frame12.png" should be provided.
+//
+// For tilesets and backdrops, <num> should be the same number as in the
+// original asset filename. E.g. to replace CZONE1.MNI, provide a file named
+// tileset_1.png, etc.
 //
 // The files can contain full 32-bit RGBA values, there are no limitations.
 const auto ASSET_REPLACEMENTS_PATH = "asset_replacements";

--- a/src/loader/resource_loader.cpp
+++ b/src/loader/resource_loader.cpp
@@ -37,7 +37,6 @@ namespace rigel::loader
 {
 
 using namespace data;
-using namespace std;
 
 
 namespace
@@ -200,7 +199,7 @@ TileSet ResourceLoader::loadCZone(const std::string& name) const
     tilesToPixels(GameTraits::CZone::solidTilesImageHeight),
     maskedTilesImage);
 
-  return {move(fullImage), TileAttributeDict{move(attributes)}};
+  return {std::move(fullImage), TileAttributeDict{std::move(attributes)}};
 }
 
 
@@ -235,7 +234,7 @@ data::AudioBuffer ResourceLoader::loadSound(const data::SoundId id) const
   }
 
   const auto digitizedSoundFileName =
-    string("SB_") + to_string(static_cast<int>(id) + 1) + ".MNI";
+    std::string("SB_") + std::to_string(static_cast<int>(id) + 1) + ".MNI";
   if (hasFile(digitizedSoundFileName))
   {
     return loadSound(digitizedSoundFileName);

--- a/src/loader/resource_loader.hpp
+++ b/src/loader/resource_loader.hpp
@@ -58,6 +58,7 @@ public:
 
   data::Image loadAntiPiracyImage() const;
 
+  data::Image loadBackdrop(const std::string& name) const;
   TileSet loadCZone(const std::string& name) const;
   data::Movie loadMovie(const std::string& name) const;
   data::Song loadMusic(const std::string& name) const;


### PR DESCRIPTION
This makes it possible to override tileset and parallax background graphics with png images, in addition to the already existing support for replacing sprite graphics. For now, the replacements still need to be the same size as the original textures, but can contain arbitrary colors. Making it possible to provide higher resolution replacements is the next step.