### PR TITLE
Finish asset replacement for graphics 

### DIFF
--- a/src/common/game_mode.hpp
+++ b/src/common/game_mode.hpp
@@ -74,6 +74,8 @@ struct GameMode
   virtual std::unique_ptr<GameMode> updateAndRender(
     engine::TimeDelta dt,
     const std::vector<SDL_Event>& events) = 0;
+
+  virtual bool needsPerElementUpscaling() const { return false; }
 };
 
 

--- a/src/engine/map_renderer.cpp
+++ b/src/engine/map_renderer.cpp
@@ -150,6 +150,14 @@ MapRenderer::MapRenderer(
 }
 
 
+bool MapRenderer::hasHighResReplacements() const
+{
+  return mBackdropTexture.width() > data::GameTraits::viewPortWidthPx ||
+    mBackdropTexture.height() > data::GameTraits::viewPortHeightPx ||
+    mTileSetTexture.isHighRes();
+}
+
+
 void MapRenderer::switchBackdrops()
 {
   std::swap(mBackdropTexture, mAlternativeBackdropTexture);

--- a/src/engine/map_renderer.cpp
+++ b/src/engine/map_renderer.cpp
@@ -121,7 +121,13 @@ float maxOffsetForScrollMode(const BackdropScrollMode mode)
   }
 }
 
+
+constexpr auto TILE_SET_IMAGE_LOGICAL_SIZE = base::Extents{
+  tilesToPixels(data::GameTraits::CZone::tileSetImageWidth),
+  tilesToPixels(data::GameTraits::CZone::tileSetImageHeight)};
+
 } // namespace
+
 
 MapRenderer::MapRenderer(
   renderer::Renderer* pRenderer,
@@ -131,6 +137,7 @@ MapRenderer::MapRenderer(
   , mpMap(pMap)
   , mTileSetTexture(
       renderer::Texture(pRenderer, renderData.mTileSetImage),
+      TILE_SET_IMAGE_LOGICAL_SIZE,
       pRenderer)
   , mBackdropTexture(mpRenderer, renderData.mBackdropImage)
   , mScrollMode(renderData.mBackdropScrollMode)

--- a/src/engine/map_renderer.hpp
+++ b/src/engine/map_renderer.hpp
@@ -43,6 +43,8 @@ public:
     const data::map::Map* pMap,
     MapRenderData&& renderData);
 
+  bool hasHighResReplacements() const;
+
   void switchBackdrops();
 
   void renderBackdrop(

--- a/src/engine/sprite_factory.cpp
+++ b/src/engine/sprite_factory.cpp
@@ -833,6 +833,7 @@ SpriteFactory::SpriteFactory(
 SpriteFactory::SpriteFactory(CtorArgs args)
   : mSpriteDataMap(std::move(std::get<0>(args)))
   , mSpritesTextureAtlas(std::move(std::get<1>(args)))
+  , mHasHighResReplacements(std::get<2>(args))
 {
 }
 
@@ -841,6 +842,8 @@ auto SpriteFactory::construct(
   renderer::Renderer* pRenderer,
   const loader::ActorImagePackage* pSpritePackage) -> CtorArgs
 {
+  bool highResReplacementsFound = false;
+
   std::unordered_map<data::ActorID, SpriteData> spriteDataMap;
 
   std::vector<data::Image> spriteImages;
@@ -876,6 +879,15 @@ auto SpriteFactory::construct(
           frameData.mDrawOffset,
           frameData.mLogicalSize});
 
+        if (
+          data::tilesToPixels(frameData.mLogicalSize.width) <
+            int(image.width()) ||
+          data::tilesToPixels(frameData.mLogicalSize.height) <
+            int(image.height()))
+        {
+          highResReplacementsFound = true;
+        }
+
         spriteImages.emplace_back(std::move(image));
       }
 
@@ -894,7 +906,9 @@ auto SpriteFactory::construct(
   }
 
   return {
-    std::move(spriteDataMap), renderer::TextureAtlas{pRenderer, spriteImages}};
+    std::move(spriteDataMap),
+    renderer::TextureAtlas{pRenderer, spriteImages},
+    highResReplacementsFound};
 }
 
 

--- a/src/engine/sprite_factory.cpp
+++ b/src/engine/sprite_factory.cpp
@@ -871,11 +871,10 @@ auto SpriteFactory::construct(
       for (auto& frameData : actorData.mFrames)
       {
         auto& image = frameData.mFrameImage;
-        const auto dimensionsInTiles = data::pixelExtentsToTileExtents(
-          {int(image.width()), int(image.height())});
-
         drawData.mFrames.emplace_back(engine::SpriteFrame{
-          int(spriteImages.size()), frameData.mDrawOffset, dimensionsInTiles});
+          int(spriteImages.size()),
+          frameData.mDrawOffset,
+          frameData.mLogicalSize});
 
         spriteImages.emplace_back(std::move(image));
       }

--- a/src/engine/sprite_factory.hpp
+++ b/src/engine/sprite_factory.hpp
@@ -59,6 +59,8 @@ public:
   engine::components::Sprite createSprite(data::ActorID id) override;
   base::Rect<int> actorFrameRect(data::ActorID id, int frame) const override;
 
+  bool hasHighResReplacements() const { return mHasHighResReplacements; }
+
   const renderer::TextureAtlas& textureAtlas() const
   {
     return mSpritesTextureAtlas;
@@ -73,7 +75,8 @@ private:
 
   using CtorArgs = std::tuple<
     std::unordered_map<data::ActorID, SpriteData>,
-    renderer::TextureAtlas>;
+    renderer::TextureAtlas,
+    bool>;
 
   SpriteFactory(CtorArgs args);
   static CtorArgs construct(
@@ -82,6 +85,7 @@ private:
 
   std::unordered_map<data::ActorID, SpriteData> mSpriteDataMap;
   renderer::TextureAtlas mSpritesTextureAtlas;
+  bool mHasHighResReplacements;
 };
 
 } // namespace rigel::engine

--- a/src/engine/tiled_texture.cpp
+++ b/src/engine/tiled_texture.cpp
@@ -97,6 +97,12 @@ int TiledTexture::tilesPerRow() const
 }
 
 
+bool TiledTexture::isHighRes() const
+{
+  return mScaleX > 1 || mScaleY > 1;
+}
+
+
 void TiledTexture::renderTileGroup(
   const int index,
   const int posX,

--- a/src/engine/tiled_texture.cpp
+++ b/src/engine/tiled_texture.cpp
@@ -35,6 +35,18 @@ TiledTexture::TiledTexture(Texture&& tileSet, Renderer* pRenderer)
 }
 
 
+TiledTexture::TiledTexture(
+  Texture&& tileSet,
+  const base::Extents logicalSize,
+  Renderer* pRenderer)
+  : mTileSetTexture(std::move(tileSet))
+  , mpRenderer(pRenderer)
+  , mScaleX(mTileSetTexture.width() / logicalSize.width)
+  , mScaleY(mTileSetTexture.height() / logicalSize.height)
+{
+}
+
+
 void TiledTexture::renderTileStretched(
   const int index,
   const base::Rect<int>& destRect) const
@@ -81,7 +93,7 @@ void TiledTexture::renderTileDoubleQuad(
 
 int TiledTexture::tilesPerRow() const
 {
-  return data::pixelsToTiles(mTileSetTexture.width());
+  return data::pixelsToTiles(mTileSetTexture.width() / mScaleX);
 }
 
 
@@ -92,9 +104,14 @@ void TiledTexture::renderTileGroup(
   const int tileSpanX,
   const int tileSpanY) const
 {
-  mTileSetTexture.render(
-    tileVectorToPixelVector({posX, posY}),
-    sourceRect(index, tileSpanX, tileSpanY));
+  mpRenderer->drawTexture(
+    mTileSetTexture.data(),
+    renderer::toTexCoords(
+      sourceRect(index, tileSpanX, tileSpanY),
+      mTileSetTexture.width(),
+      mTileSetTexture.height()),
+    {tileVectorToPixelVector({posX, posY}),
+     tileExtentsToPixelExtents({tileSpanX, tileSpanY})});
 }
 
 
@@ -105,9 +122,12 @@ base::Rect<int> TiledTexture::sourceRect(
 {
   const base::Vector tileSetStartPosition{
     index % tilesPerRow(), index / tilesPerRow()};
+  const auto topLeft = tileVectorToPixelVector(tileSetStartPosition);
+  const auto size = tileExtentsToPixelExtents({tileSpanX, tileSpanY});
+
   return {
-    tileVectorToPixelVector(tileSetStartPosition),
-    tileExtentsToPixelExtents({tileSpanX, tileSpanY})};
+    {topLeft.x * mScaleX, topLeft.y * mScaleY},
+    {size.width * mScaleX, size.height * mScaleY}};
 }
 
 } // namespace rigel::engine

--- a/src/engine/tiled_texture.hpp
+++ b/src/engine/tiled_texture.hpp
@@ -51,6 +51,8 @@ public:
 
   int tilesPerRow() const;
 
+  bool isHighRes() const;
+
 private:
   void renderTileGroup(
     const int index,

--- a/src/engine/tiled_texture.hpp
+++ b/src/engine/tiled_texture.hpp
@@ -26,6 +26,10 @@ class TiledTexture
 {
 public:
   TiledTexture(renderer::Texture&& tileSet, renderer::Renderer* pRenderer);
+  TiledTexture(
+    renderer::Texture&& tileSet,
+    const base::Extents logicalSize,
+    renderer::Renderer* pRenderer);
 
   void renderTileStretched(int index, const base::Rect<int>& destRect) const;
 
@@ -61,6 +65,8 @@ private:
 private:
   renderer::Texture mTileSetTexture;
   renderer::Renderer* mpRenderer;
+  int mScaleX = 1;
+  int mScaleY = 1;
 };
 
 } // namespace rigel::engine

--- a/src/frontend/game.cpp
+++ b/src/frontend/game.cpp
@@ -585,7 +585,10 @@ void Game::applyChangedOptions()
     }
   }
 
-  if (currentOptions.mWidescreenModeOn != mPreviousOptions.mWidescreenModeOn)
+  if (
+    currentOptions.mWidescreenModeOn != mPreviousOptions.mWidescreenModeOn ||
+    currentOptions.mPerElementUpscalingEnabled !=
+      mPreviousOptions.mPerElementUpscalingEnabled)
   {
     mRenderTarget = renderer::createFullscreenRenderTarget(
       &mRenderer, mpUserProfile->mOptions);

--- a/src/frontend/game.cpp
+++ b/src/frontend/game.cpp
@@ -383,6 +383,9 @@ void Game::updateAndRender(const entityx::TimeDelta elapsed)
       mFpsDisplay.updateAndRender(elapsed);
     }
   }
+
+  mpUserProfile->mOptions.mPerElementUpscalingEnabled =
+    mpCurrentGameMode->needsPerElementUpscaling();
 }
 
 

--- a/src/frontend/game_runner.cpp
+++ b/src/frontend/game_runner.cpp
@@ -110,6 +110,12 @@ void GameRunner::updateAndRender(engine::TimeDelta dt)
 }
 
 
+bool GameRunner::needsPerElementUpscaling() const
+{
+  return mWorld.needsPerElementUpscaling();
+}
+
+
 void GameRunner::updateWorld(const engine::TimeDelta dt)
 {
   auto update = [this]() {

--- a/src/frontend/game_runner.hpp
+++ b/src/frontend/game_runner.hpp
@@ -46,6 +46,7 @@ public:
 
   void handleEvent(const SDL_Event& event);
   void updateAndRender(engine::TimeDelta dt);
+  bool needsPerElementUpscaling() const;
 
   bool levelFinished() const;
   bool gameQuit() const;

--- a/src/frontend/game_session_mode.cpp
+++ b/src/frontend/game_session_mode.cpp
@@ -216,6 +216,18 @@ std::unique_ptr<GameMode> GameSessionMode::updateAndRender(
 }
 
 
+bool GameSessionMode::needsPerElementUpscaling() const
+{
+  return base::match(
+    mCurrentStage,
+    [this](const std::unique_ptr<GameRunner>& pIngameMode) {
+      return pIngameMode->needsPerElementUpscaling();
+    },
+
+    [](auto&&) { return false; });
+}
+
+
 template <typename StageT>
 void GameSessionMode::fadeToNewStage(StageT& stage)
 {

--- a/src/frontend/game_session_mode.hpp
+++ b/src/frontend/game_session_mode.hpp
@@ -48,6 +48,8 @@ public:
     engine::TimeDelta dt,
     const std::vector<SDL_Event>& events) override;
 
+  bool needsPerElementUpscaling() const override;
+
 private:
   void handleEvent(const SDL_Event& event);
   template <typename StageT>

--- a/src/game_logic/game_world.cpp
+++ b/src/game_logic/game_world.cpp
@@ -292,6 +292,7 @@ GameWorld::GameWorld(
   , mWidescreenModeWasOn(
       mpOptions->mWidescreenModeOn &&
       renderer::canUseWidescreenMode(mpRenderer))
+  , mPerElementUpscalingWasEnabled(mpOptions->mPerElementUpscalingEnabled)
 {
   using namespace std::chrono;
   auto before = high_resolution_clock::now();
@@ -679,7 +680,9 @@ void GameWorld::render()
   const auto widescreenModeOn =
     mpOptions->mWidescreenModeOn && renderer::canUseWidescreenMode(mpRenderer);
 
-  if (widescreenModeOn != mWidescreenModeWasOn)
+  if (
+    widescreenModeOn != mWidescreenModeWasOn ||
+    mpOptions->mPerElementUpscalingEnabled != mPerElementUpscalingWasEnabled)
   {
     mWaterEffectBuffer =
       renderer::createFullscreenRenderTarget(mpRenderer, *mpOptions);
@@ -809,6 +812,7 @@ void GameWorld::render()
   }
 
   mWidescreenModeWasOn = widescreenModeOn;
+  mPerElementUpscalingWasEnabled = mpOptions->mPerElementUpscalingEnabled;
 }
 
 

--- a/src/game_logic/game_world.cpp
+++ b/src/game_logic/game_world.cpp
@@ -591,6 +591,13 @@ void GameWorld::unsubscribe(entityx::EventManager& eventManager)
 }
 
 
+bool GameWorld::needsPerElementUpscaling() const
+{
+  return mpSpriteFactory->hasHighResReplacements() ||
+    mpState->mMapRenderer.hasHighResReplacements();
+}
+
+
 void GameWorld::updateGameLogic(const PlayerInput& input)
 {
   mpState->mBackdropFlashColor = std::nullopt;

--- a/src/game_logic/game_world.hpp
+++ b/src/game_logic/game_world.hpp
@@ -99,6 +99,7 @@ public:
   void receive(const rigel::events::CloakPickedUp& event);
   void receive(const rigel::events::CloakExpired& event);
 
+  bool needsPerElementUpscaling() const;
   void updateGameLogic(const PlayerInput& input);
   void render();
   void processEndOfFrameActions();

--- a/src/game_logic/game_world.hpp
+++ b/src/game_logic/game_world.hpp
@@ -156,6 +156,7 @@ private:
   renderer::RenderTargetTexture mWaterEffectBuffer;
   renderer::RenderTargetTexture mLowResLayer;
   bool mWidescreenModeWasOn;
+  bool mPerElementUpscalingWasEnabled;
 
   std::unique_ptr<WorldState> mpState;
   std::unique_ptr<QuickSaveData> mpQuickSave;

--- a/src/loader/actor_image_package.cpp
+++ b/src/loader/actor_image_package.cpp
@@ -133,6 +133,7 @@ std::vector<ActorData::Frame> ActorImagePackage::loadFrameImages(
 
       return ActorData::Frame{
         frameHeader.mDrawOffset,
+        frameHeader.mSizeInTiles,
         maybeReplacement ? *maybeReplacement : loadImage(frameHeader, palette)};
     });
 }

--- a/src/loader/actor_image_package.hpp
+++ b/src/loader/actor_image_package.hpp
@@ -36,6 +36,7 @@ struct ActorData
   struct Frame
   {
     base::Vector mDrawOffset;
+    base::Extents mLogicalSize;
     data::Image mFrameImage;
   };
 

--- a/src/loader/resource_loader.cpp
+++ b/src/loader/resource_loader.cpp
@@ -71,7 +71,7 @@ const auto FULL_SCREEN_IMAGE_DATA_SIZE =
 //
 // For tilesets and backdrops, <num> should be the same number as in the
 // original asset filename. E.g. to replace CZONE1.MNI, provide a file named
-// tileset_1.png, etc.
+// tileset1.png, etc.
 //
 // The files can contain full 32-bit RGBA values, there are no limitations.
 const auto ASSET_REPLACEMENTS_PATH = "asset_replacements";

--- a/src/loader/resource_loader.cpp
+++ b/src/loader/resource_loader.cpp
@@ -29,7 +29,6 @@
 #include <chrono>
 #include <cstdint>
 #include <iostream>
-#include <map>
 #include <regex>
 
 namespace fs = std::filesystem;
@@ -280,20 +279,24 @@ data::Song ResourceLoader::loadMusic(const std::string& name) const
 
 data::AudioBuffer ResourceLoader::loadSound(const data::SoundId id) const
 {
-  static const std::map<data::SoundId, const char*> INTRO_SOUND_MAP{
-    {data::SoundId::IntroGunShot, "INTRO3.MNI"},
-    {data::SoundId::IntroGunShotLow, "INTRO4.MNI"},
-    {data::SoundId::IntroEmptyShellsFalling, "INTRO5.MNI"},
-    {data::SoundId::IntroTargetMovingCloser, "INTRO6.MNI"},
-    {data::SoundId::IntroTargetStopsMoving, "INTRO7.MNI"},
-    {data::SoundId::IntroDukeSpeaks1, "INTRO8.MNI"},
-    {data::SoundId::IntroDukeSpeaks2, "INTRO9.MNI"}};
+  auto introSoundFilenameFor = [](const data::SoundId soundId) -> const char* {
+    // clang-format off
+    switch (soundId) {
+      case data::SoundId::IntroGunShot: return "INTRO3.MNI";
+      case data::SoundId::IntroGunShotLow: return "INTRO4.MNI";
+      case data::SoundId::IntroEmptyShellsFalling: return "INTRO5.MNI";
+      case data::SoundId::IntroTargetMovingCloser: return "INTRO6.MNI";
+      case data::SoundId::IntroTargetStopsMoving: return "INTRO7.MNI";
+      case data::SoundId::IntroDukeSpeaks1: return "INTRO8.MNI";
+      case data::SoundId::IntroDukeSpeaks2: return "INTRO9.MNI";
+      default: return nullptr;
+    }
+    // clang-format on
+  };
 
-  const auto introSoundIter = INTRO_SOUND_MAP.find(id);
-
-  if (introSoundIter != INTRO_SOUND_MAP.end())
+  if (const auto introSoundFilename = introSoundFilenameFor(id))
   {
-    return loadSound(introSoundIter->second);
+    return loadSound(introSoundFilename);
   }
 
   const auto digitizedSoundFileName =

--- a/src/renderer/texture_atlas.hpp
+++ b/src/renderer/texture_atlas.hpp
@@ -37,10 +37,10 @@ class TextureAtlas
 public:
   /** Build a texture atlas
    *
-   * Create an atlas using the provided list of images. Currently, atlas
-   * size is hardcoded. This will throw an exception if not all images fit
-   * into the size.
-   * Also note that the order of images in the given list determines how
+   * Create an atlas using the provided list of images. Might use more than
+   * one texture internally if not all images fit into a single texture.
+   *
+   * Note that the order of images in the given list determines how
    * to address these images when drawing: The first image in the list is
    * referenced by index 0, the 2nd one by index 1, etc.
    */
@@ -54,8 +54,14 @@ public:
   void draw(int index, const base::Rect<int>& destRect) const;
 
 private:
-  std::vector<TexCoords> mCoordinatesMap;
-  Texture mAtlasTexture;
+  struct TextureInfo
+  {
+    TexCoords mCoordinates;
+    int mTextureIndex;
+  };
+
+  std::vector<TextureInfo> mAtlasMap;
+  std::vector<Texture> mAtlasTextures;
   Renderer* mpRenderer;
 };
 


### PR DESCRIPTION
This makes it possible for replacement sprites/tilesets/backdrops to be higher resolution than the original art. Replacements should be larger by integer multiples only.