### PR TITLE
Fix incorrect backdrop when quickloading after teleport in L1

### DIFF
--- a/src/game_logic/world_state.cpp
+++ b/src/game_logic/world_state.cpp
@@ -282,6 +282,11 @@ void WorldState::synchronizeTo(
   data::PlayerModel* pPlayerModel,
   const data::GameSessionId sessionId)
 {
+  if (mBackdropSwitched != other.mBackdropSwitched)
+  {
+    mMapRenderer.switchBackdrops();
+  }
+
   mBonusInfo = other.mBonusInfo;
   mLevelMusicFile = other.mLevelMusicFile;
   mActivatedCheckpoint = other.mActivatedCheckpoint;


### PR DESCRIPTION
Many thanks to LGR for the awesome video on RigelEngine, and for spotting this bug 😅 