### PR TITLE
Gamepath without boost

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,18 +4,18 @@
 
 Nikolai Wuttke ([@lethal-guitar](https://github.com/lethal-guitar))
 
-## Contributors (code/documentation)
+## Major contributors
 
 * Alain Martin ([@McMartin](https://github.com/McMartin)): Help with OS X port, clang-tidy, compiler upgrades and lots of other things
-* Andrei-Florin Bencsik ([@bencsikandrei](https://github.com/bencsikandrei)): Replacements for Boost string utilities, introducing clang-format, various code & CMake cleanups
-* Evo Stamatov ([@avioli](https://github.com/avioli)): README improvements
+* Andrei-Florin Bencsik ([@bencsikandrei](https://github.com/bencsikandrei)): Replacements for Boost string utilities, introducing clang-format, .deb package creation, various code & CMake cleanups
 * Pratik Anand ([@pratikone](https://github.com/pratikone)): Webassembly port, widescreen support, game path browser, initial gamepad support, README improvements
 * Ryan Brown ([@rbrown46](https://github.com/rbrown46)): Actor image modding (replace sprites using `png` files)
 * [@mnhauke](https://github.com/mnhauke): OpenSUSE package
 * [@s-martin](https://github.com/s-martin): Refactoring, code cleanups, README improvements
 
-## Contributors (issues/reports)
+## Contributors (issues/reports/suggestions)
 
+* Evo Stamatov ([@avioli](https://github.com/avioli))
 * Jomon John ([@jomonjohnn](https://github.com/jomonjohnn))
 * Julius Schwartzenberg ([@jschwartzenberg](https://github.com/jschwartzenberg))
 * Kyle Falconer ([@Kyle-Falconer](https://github.com/Kyle-Falconer))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -245,7 +245,19 @@ int main(int argc, char** argv)
 #else
   try
   {
-    gameMain({});
+    CommandLineOptions config;
+
+    if (argc > 1)
+    {
+      config.mGamePath = argv[1];
+
+      if (!config.mGamePath.empty() && config.mGamePath.back() != '/')
+      {
+        config.mGamePath += "/";
+      }
+    }
+
+    gameMain(config);
   }
   catch (const std::exception& ex)
   {


### PR DESCRIPTION
Implement setting a game path on the command line even if built without Boost (and thus without command line parsing)