### PR TITLE
[WIP] Target Mac OS 10.14

### DIFF
--- a/.github/workflows/bundling.yml
+++ b/.github/workflows/bundling.yml
@@ -37,7 +37,18 @@ jobs:
       with:
         submodules: recursive
     - name: Install dependencies
-      run: brew install sdl2 sdl2_mixer boost llvm@8
+      run: brew install boost llvm@8
+    - name: Fetch SDL libraries
+      run: |
+        wget https://libsdl.org/release/SDL2-2.0.14.dmg
+        wget https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.4.dmg
+    - name: Install SDL libraries
+      run: |
+        hdiutil attach SDL2-2.0.14.dmg -quiet -mountpoint /Volumes/SDL2
+        hdiutil attach SDL2_mixer-2.0.4.dmg -quiet -mountpoint /Volumes/SDL2_mixer
+        mkdir -p ~/Library/Frameworks
+        cp -r /Volumes/SDL2/SDL2.framework ~/Library/Frameworks
+        cp -r /Volumes/SDL2_mixer/SDL2_mixer.framework ~/Library/Frameworks
     - name: Run CMake
       run: |
         export rigel_llvm_path=`brew --prefix llvm@8`;


### PR DESCRIPTION
This currently fails at the CPack step:

```
CPack: Create package using DragNDrop
CPack: Install projects
CPack: - Run preinstall target for: RigelEngine
CPack: - Install project: RigelEngine []
CPack: -   Install component: bin
CMake Error at /usr/local/Cellar/cmake/3.21.0/share/cmake/Modules/BundleUtilities.cmake:458 (message):
  otool -l failed: 1

  error:
  /Applications/Xcode_12.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/otool-classic:
  can't open file: @rpath/SDL2.framework/Versions/A/SDL2 (No such file or
  directory)

Call Stack (most recent call first):
  /usr/local/Cellar/cmake/3.21.0/share/cmake/Modules/BundleUtilities.cmake:527 (get_item_rpaths)
  /usr/local/Cellar/cmake/3.21.0/share/cmake/Modules/BundleUtilities.cmake:649 (set_bundle_key_values)
  /usr/local/Cellar/cmake/3.21.0/share/cmake/Modules/BundleUtilities.cmake:934 (get_bundle_keys)
  /Users/runner/work/RigelEngine/RigelEngine/build/src/cmake_install.cmake:53 (fixup_bundle)
  /Users/runner/work/RigelEngine/RigelEngine/build/cmake_install.cmake:43 (include)


CPack Error: Error when generating package: RigelEngine
```