### PR TITLE
Make Windows includes lowercase for MinGW

### DIFF
--- a/3rd_party/imgui-filebrowser/imfilebrowser.cpp
+++ b/3rd_party/imgui-filebrowser/imfilebrowser.cpp
@@ -439,7 +439,7 @@ void ImGui::FileBrowser::SetPwdUncatched(const std::filesystem::path &pwd)
 
 #endif // #ifndef WIN32_LEAN_AND_MEAN
 
-#include <Windows.h>
+#include <windows.h>
 
 #ifdef IMGUI_FILEBROWSER_UNDEF_WIN32_LEAN_AND_MEAN
 #undef IMGUI_FILEBROWSER_UNDEF_WIN32_LEAN_AND_MEAN

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -32,7 +32,7 @@ RIGEL_DISABLE_WARNINGS
 RIGEL_RESTORE_WARNINGS
 
 #ifdef _WIN32
-  #include <Windows.h>
+  #include <windows.h>
 #endif
 
 #include <filesystem>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,8 +51,8 @@ namespace po = boost::program_options;
 
 #ifdef _WIN32
 
-  #include <Windows.h>
   #include <stdio.h>
+  #include <windows.h>
 
 static std::optional<rigel::base::ScopeGuard> win32ReenableStdIo()
 {


### PR DESCRIPTION
MinGW-w64 ships all Windows SDK headers as lowercase, which prevents
cross-compiling this code from Linux.

Windows filesystems are case insensitive so it should work fine with
lowercase includes.