### PR TITLE
Fix openSUSE Tumbleweed build

### DIFF
--- a/cmake/Modules/FindSDL2.cmake
+++ b/cmake/Modules/FindSDL2.cmake
@@ -227,7 +227,7 @@ endif()
 # But for non-OSX systems, I will use the CMake Threads package.
 if(NOT APPLE AND NOT MSVC)
   find_package(Threads QUIET)
-  if(NOT CMAKE_THREAD_LIBS_INIT)
+  if(NOT Threads_FOUND)
     set(SDL2_THREADS_NOT_FOUND "Could NOT find Threads (Threads is required by SDL2).")
     if(SDL2_FIND_REQUIRED)
       message(FATAL_ERROR ${SDL2_THREADS_NOT_FOUND})


### PR DESCRIPTION
According to the [CMake docs](https://cmake.org/cmake/help/latest/module/FindThreads.html), `CMAKE_THREAD_LIBS_INIT` may be empty
even if threads are available. Therefore, we should use `Threads_FOUND`
instead. This fixes the build on openSUSE Tumbleweed.