### PR TITLE
cmake: Add BUILD_MODDING_TOOLS and BUILD_TESTS

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,7 +31,7 @@ before_build:
 
     - mkdir build
     - cd build
-    - cmake .. -G "Visual Studio 16 2019" -DBUILD_BENCHMARKS=ON
+    - cmake .. -G "Visual Studio 16 2019" -DBUILD_BENCHMARKS=ON -DBUILD_TESTS=ON -DBUILD_MODDING_TOOLS=ON
     - cd ..
 
 build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,9 @@ jobs:
     - name: Install dependencies
       run: sudo ./docker/ubuntu-deps.sh
     - name: Run CMake (debug)
-      run: CC=gcc-8 CXX=g++-8 cmake -H. -Bbuild_dbg -DCMAKE_BUILD_TYPE=Debug
+      run: CC=gcc-8 CXX=g++-8 cmake -H. -Bbuild_dbg -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DBUILD_MODDING_TOOLS=ON
     - name: Run CMake (release)
-      run: CC=gcc-8 CXX=g++-8 cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DBUILD_BENCHMARKS=ON
+      run: CC=gcc-8 CXX=g++-8 cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DBUILD_MODDING_TOOLS=ON -DBUILD_BENCHMARKS=ON
     - name: Build (debug)
       run: cd build_dbg && make -j2
     - name: Build (release)
@@ -81,9 +81,9 @@ jobs:
     - name: Install dependencies
       run: brew install sdl2 sdl2_mixer boost
     - name: Run CMake (debug)
-      run: cmake -H. -Bbuild_dbg -DCMAKE_BUILD_TYPE=Debug
+      run: cmake -H. -Bbuild_dbg -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DBUILD_MODDING_TOOLS=ON
     - name: Run CMake (release)
-      run: cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DBUILD_BENCHMARKS=ON
+      run: cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DBUILD_MODDING_TOOLS=ON -DBUILD_BENCHMARKS=ON
     - name: Build (debug)
       run: cd build_dbg && make -j2
     - name: Build (release)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ endif()
 option(USE_GL_ES "Use OpenGL ES instead of regular OpenGL" OFF)
 option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" ON)
 option(BUILD_BENCHMARKS "Build benchmarks" OFF)
+option(BUILD_MODDING_TOOLS "Build modding tools" OFF)
+option(BUILD_TESTS "Build tests" OFF)
 
 # Dependencies
 ###############################################################################
@@ -88,10 +90,14 @@ add_subdirectory(3rd_party)
 add_subdirectory(src)
 
 if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
-    enable_testing()
+    if(BUILD_MODDING_TOOLS)
+        add_subdirectory(modding_tools)
+    endif()
 
-    add_subdirectory(modding_tools)
-    add_subdirectory(test)
+    if(BUILD_TESTS)
+        enable_testing()
+        add_subdirectory(test)
+    endif()
 endif()
 
 if(BUILD_BENCHMARKS)


### PR DESCRIPTION
Introduce cmake build options
* BUILD_BENCHMARKS - build benchmarks (OFF by default)
* BUILD_MODDING_TOOLS - Build modding tools (OFF by default)