### PR TITLE
Implement `std::string_view`

### DIFF
--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -70,7 +70,7 @@ void showLoadingScreen(SDL_Window* pWindow)
 void setupForFirstLaunch(
   SDL_Window* pWindow,
   UserProfile& userProfile,
-  const std::string& commandLineGamePath)
+  std::string_view commandLineGamePath)
 {
   namespace fs = std::filesystem;
 

--- a/src/loader/cmp_file_package.cpp
+++ b/src/loader/cmp_file_package.cpp
@@ -32,7 +32,7 @@ using namespace std;
 namespace
 {
 
-std::string normalizedFileName(const std::string& fileName)
+std::string normalizedFileName(std::string_view fileName)
 {
   return strings::toUppercase(fileName);
 }
@@ -66,7 +66,7 @@ CMPFilePackage::CMPFilePackage(const string& filePath)
 }
 
 
-ByteBuffer CMPFilePackage::file(const std::string& name) const
+ByteBuffer CMPFilePackage::file(std::string_view name) const
 {
   const auto it = findFileEntry(name);
   if (it == mFileDict.end())
@@ -81,14 +81,14 @@ ByteBuffer CMPFilePackage::file(const std::string& name) const
 }
 
 
-bool CMPFilePackage::hasFile(const std::string& name) const
+bool CMPFilePackage::hasFile(std::string_view name) const
 {
   return findFileEntry(name) != mFileDict.end();
 }
 
 
 CMPFilePackage::FileDict::const_iterator
-  CMPFilePackage::findFileEntry(const std::string& name) const
+  CMPFilePackage::findFileEntry(std::string_view name) const
 {
   return mFileDict.find(normalizedFileName(name));
 }

--- a/src/loader/cmp_file_package.hpp
+++ b/src/loader/cmp_file_package.hpp
@@ -33,9 +33,9 @@ class CMPFilePackage
 public:
   explicit CMPFilePackage(const std::string& filePath);
 
-  ByteBuffer file(const std::string& name) const;
+  ByteBuffer file(std::string_view name) const;
 
-  bool hasFile(const std::string& name) const;
+  bool hasFile(std::string_view name) const;
 
 private:
   struct DictEntry
@@ -50,7 +50,7 @@ private:
 
   using FileDict = std::unordered_map<std::string, DictEntry>;
 
-  FileDict::const_iterator findFileEntry(const std::string& name) const;
+  FileDict::const_iterator findFileEntry(std::string_view name) const;
 
 private:
   std::vector<std::uint8_t> mFileData;

--- a/src/loader/duke_script_loader.cpp
+++ b/src/loader/duke_script_loader.cpp
@@ -63,7 +63,7 @@ void skipWhiteSpace(istream& sourceStream)
 }
 
 
-bool isCommand(const string& line)
+bool isCommand(string_view line)
 {
   return strings::startsWith(line, "//");
 }
@@ -327,7 +327,7 @@ vector<Action> parseTextCommandWithBigText(
 }
 
 
-Action parseDrawSpriteCommand(const int x, const int y, const string& source)
+Action parseDrawSpriteCommand(const int x, const int y, string_view source)
 {
   if (source.size() < 5)
   {

--- a/src/loader/level_loader.cpp
+++ b/src/loader/level_loader.cpp
@@ -512,7 +512,7 @@ void sortByDrawIndex(ActorList& actors, const ResourceLoader& resources)
 
 
 LevelData loadLevel(
-  const std::string& mapName,
+  std::string_view mapName,
   const ResourceLoader& resources,
   const Difficulty chosenDifficulty)
 {

--- a/src/loader/level_loader.hpp
+++ b/src/loader/level_loader.hpp
@@ -32,7 +32,7 @@ class ResourceLoader;
 
 
 data::map::LevelData loadLevel(
-  const std::string& mapName,
+  std::string_view mapName,
   const ResourceLoader& resources,
   data::Difficulty chosenDifficulty);
 

--- a/src/loader/resource_loader.cpp
+++ b/src/loader/resource_loader.cpp
@@ -78,14 +78,16 @@ const auto ASSET_REPLACEMENTS_PATH = "asset_replacements";
 
 std::optional<data::Image> loadReplacementTilesetIfPresent(
   const fs::path& gamePath,
-  const std::string& name)
+  std::string_view name)
 {
   using namespace std::literals;
 
   std::regex tilesetNameRegex{"^CZONE([0-9A-Z])\\.MNI$", std::regex::icase};
-  std::smatch matches;
+  std::match_results<std::string_view::const_iterator> matches;
 
-  if (!std::regex_match(name, matches, tilesetNameRegex) || matches.size() != 2)
+  if (
+    !std::regex_match(name.begin(), name.end(), matches, tilesetNameRegex) ||
+    matches.size() != 2)
   {
     return {};
   }
@@ -142,14 +144,14 @@ ResourceLoader::ResourceLoader(const std::string& gamePath)
 
 
 data::Image
-  ResourceLoader::loadTiledFullscreenImage(const std::string& name) const
+  ResourceLoader::loadTiledFullscreenImage(std::string_view name) const
 {
   return loadTiledFullscreenImage(name, INGAME_PALETTE);
 }
 
 
 data::Image ResourceLoader::loadTiledFullscreenImage(
-  const std::string& name,
+  std::string_view name,
   const Palette16& overridePalette) const
 {
   return loadTiledImage(
@@ -161,7 +163,7 @@ data::Image ResourceLoader::loadTiledFullscreenImage(
 
 
 data::Image
-  ResourceLoader::loadStandaloneFullscreenImage(const std::string& name) const
+  ResourceLoader::loadStandaloneFullscreenImage(std::string_view name) const
 {
   const auto& data = file(name);
   const auto paletteStart = data.begin() + FULL_SCREEN_IMAGE_DATA_SIZE;
@@ -202,7 +204,7 @@ data::Image ResourceLoader::loadAntiPiracyImage() const
 
 
 loader::Palette16 ResourceLoader::loadPaletteFromFullScreenImage(
-  const std::string& imageName) const
+  std::string_view imageName) const
 {
   const auto& data = file(imageName);
   const auto paletteStart = data.begin() + FULL_SCREEN_IMAGE_DATA_SIZE;
@@ -210,14 +212,16 @@ loader::Palette16 ResourceLoader::loadPaletteFromFullScreenImage(
 }
 
 
-data::Image ResourceLoader::loadBackdrop(const std::string& name) const
+data::Image ResourceLoader::loadBackdrop(std::string_view name) const
 {
   using namespace std::literals;
 
   std::regex backdropNameRegex{"^DROP([0-9]+)\\.MNI$", std::regex::icase};
-  std::smatch matches;
+  std::match_results<std::string_view::const_iterator> matches;
 
-  if (std::regex_match(name, matches, backdropNameRegex) && matches.size() == 2)
+  if (
+    std::regex_match(name.begin(), name.end(), matches, backdropNameRegex) &&
+    matches.size() == 2)
   {
     const auto number = matches[1].str();
     const auto replacementName = "backdrop"s + number + ".png";
@@ -233,7 +237,7 @@ data::Image ResourceLoader::loadBackdrop(const std::string& name) const
 }
 
 
-TileSet ResourceLoader::loadCZone(const std::string& name) const
+TileSet ResourceLoader::loadCZone(std::string_view name) const
 {
   using namespace data;
   using namespace map;
@@ -291,13 +295,13 @@ TileSet ResourceLoader::loadCZone(const std::string& name) const
 }
 
 
-data::Movie ResourceLoader::loadMovie(const std::string& name) const
+data::Movie ResourceLoader::loadMovie(std::string_view name) const
 {
   return loader::loadMovie(loadFile(mGamePath / fs::u8path(name)));
 }
 
 
-data::Song ResourceLoader::loadMusic(const std::string& name) const
+data::Song ResourceLoader::loadMusic(std::string_view name) const
 {
   return loader::loadSong(file(name));
 }
@@ -347,19 +351,19 @@ std::filesystem::path ResourceLoader::replacementMusicBasePath() const
 }
 
 
-data::AudioBuffer ResourceLoader::loadSound(const std::string& name) const
+data::AudioBuffer ResourceLoader::loadSound(std::string_view name) const
 {
   return loader::decodeVoc(file(name));
 }
 
 
-ScriptBundle ResourceLoader::loadScriptBundle(const std::string& fileName) const
+ScriptBundle ResourceLoader::loadScriptBundle(std::string_view fileName) const
 {
   return loader::loadScripts(fileAsText(fileName));
 }
 
 
-ByteBuffer ResourceLoader::file(const std::string& name) const
+ByteBuffer ResourceLoader::file(std::string_view name) const
 {
   const auto unpackedFilePath = mGamePath / fs::u8path(name);
   if (fs::exists(unpackedFilePath))
@@ -371,12 +375,12 @@ ByteBuffer ResourceLoader::file(const std::string& name) const
 }
 
 
-std::string ResourceLoader::fileAsText(const std::string& name) const
+std::string ResourceLoader::fileAsText(std::string_view name) const
 {
   return asText(file(name));
 }
 
-bool ResourceLoader::hasFile(const std::string& name) const
+bool ResourceLoader::hasFile(std::string_view name) const
 {
   const auto unpackedFilePath = mGamePath / fs::u8path(name);
   return fs::exists(unpackedFilePath) || mFilePackage.hasFile(name);

--- a/src/loader/resource_loader.hpp
+++ b/src/loader/resource_loader.hpp
@@ -47,36 +47,36 @@ class ResourceLoader
 public:
   explicit ResourceLoader(const std::string& gamePath);
 
-  data::Image loadTiledFullscreenImage(const std::string& name) const;
+  data::Image loadTiledFullscreenImage(std::string_view name) const;
   data::Image loadTiledFullscreenImage(
-    const std::string& name,
+    std::string_view name,
     const Palette16& overridePalette) const;
 
-  data::Image loadStandaloneFullscreenImage(const std::string& name) const;
+  data::Image loadStandaloneFullscreenImage(std::string_view name) const;
   loader::Palette16
-    loadPaletteFromFullScreenImage(const std::string& imageName) const;
+    loadPaletteFromFullScreenImage(std::string_view imageName) const;
 
   data::Image loadAntiPiracyImage() const;
 
-  data::Image loadBackdrop(const std::string& name) const;
-  TileSet loadCZone(const std::string& name) const;
-  data::Movie loadMovie(const std::string& name) const;
+  data::Image loadBackdrop(std::string_view name) const;
+  TileSet loadCZone(std::string_view name) const;
+  data::Movie loadMovie(std::string_view name) const;
 
-  data::Song loadMusic(const std::string& name) const;
+  data::Song loadMusic(std::string_view name) const;
   bool hasSoundBlasterSound(data::SoundId id) const;
   data::AudioBuffer loadAdlibSound(data::SoundId id) const;
   data::AudioBuffer loadPreferredSound(data::SoundId id) const;
   std::filesystem::path replacementSoundPath(data::SoundId id) const;
   std::filesystem::path replacementMusicBasePath() const;
 
-  ScriptBundle loadScriptBundle(const std::string& fileName) const;
+  ScriptBundle loadScriptBundle(std::string_view fileName) const;
 
-  ByteBuffer file(const std::string& name) const;
-  std::string fileAsText(const std::string& name) const;
-  bool hasFile(const std::string& name) const;
+  ByteBuffer file(std::string_view name) const;
+  std::string fileAsText(std::string_view name) const;
+  bool hasFile(std::string_view name) const;
 
 private:
-  data::AudioBuffer loadSound(const std::string& name) const;
+  data::AudioBuffer loadSound(std::string_view name) const;
 
   std::filesystem::path mGamePath;
   loader::CMPFilePackage mFilePackage;

--- a/src/loader/user_profile_import.cpp
+++ b/src/loader/user_profile_import.cpp
@@ -30,7 +30,7 @@ namespace
 {
 
 std::array<std::string, data::NUM_SAVE_SLOTS>
-  loadNameList(const std::string& filename)
+  loadNameList(std::string_view filename)
 {
   std::array<std::string, data::NUM_SAVE_SLOTS> result;
 
@@ -75,7 +75,7 @@ data::Difficulty readDifficulty(LeStreamReader& reader)
 
 
 data::SavedGame
-  loadSavedGame(const std::string& filename, std::string saveSlotName)
+  loadSavedGame(std::string_view filename, std::string saveSlotName)
 {
   static_assert(
     static_cast<int>(data::WeaponType::Normal) == 0 &&
@@ -111,7 +111,7 @@ data::SavedGame
 }
 
 
-data::HighScoreList loadHighScoreList(const std::string& filename)
+data::HighScoreList loadHighScoreList(std::string_view filename)
 {
   using std::begin;
   using std::end;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -185,7 +185,7 @@ auto parseDifficulty(const std::string& difficultySpec)
 }
 
 
-base::Vector parsePlayerPosition(const std::string& playerPosString)
+base::Vector parsePlayerPosition(std::string_view playerPosString)
 {
   const std::vector<std::string> positionParts =
     strings::split(playerPosString, ',');

--- a/src/ui/duke_script_runner.cpp
+++ b/src/ui/duke_script_runner.cpp
@@ -363,7 +363,7 @@ void DukeScriptRunner::drawBigText(
   const int x,
   const int y,
   const int colorIndex,
-  const std::string& text) const
+  std::string_view text) const
 {
   mMenuElementRenderer.drawBigText(x, y, text, mCurrentPalette.at(colorIndex));
 }

--- a/src/ui/duke_script_runner.hpp
+++ b/src/ui/duke_script_runner.hpp
@@ -191,7 +191,7 @@ private:
 
   void updateAndRenderDynamicElements(engine::TimeDelta dt);
 
-  void drawBigText(int x, int y, int colorIndex, const std::string& text) const;
+  void drawBigText(int x, int y, int colorIndex, std::string_view text) const;
 
   void bindCanvas();
   void unbindCanvas();

--- a/src/ui/menu_element_renderer.cpp
+++ b/src/ui/menu_element_renderer.cpp
@@ -181,7 +181,7 @@ MenuElementRenderer::MenuElementRenderer(
 }
 
 
-void MenuElementRenderer::drawText(int x, int y, const std::string& text) const
+void MenuElementRenderer::drawText(int x, int y, std::string_view text) const
 {
   for (auto i = 0u; i < text.size(); ++i)
   {
@@ -212,7 +212,7 @@ void MenuElementRenderer::drawText(int x, int y, const std::string& text) const
 void MenuElementRenderer::drawSmallWhiteText(
   int x,
   int y,
-  const std::string& text) const
+  std::string_view text) const
 {
   for (auto i = 0u; i < text.size(); ++i)
   {
@@ -247,7 +247,7 @@ void MenuElementRenderer::drawSmallWhiteText(
 void MenuElementRenderer::drawMultiLineText(
   const int x,
   const int y,
-  const std::string& text) const
+  std::string_view text) const
 {
   const std::vector<std::string> lines = strings::split(text, '\n');
   for (int i = 0; i < int(lines.size()); ++i)
@@ -260,7 +260,7 @@ void MenuElementRenderer::drawMultiLineText(
 void MenuElementRenderer::drawBigText(
   int x,
   int y,
-  const std::string& text,
+  std::string_view text,
   const base::Color& color) const
 {
   const auto saved = renderer::saveState(mpRenderer);
@@ -330,7 +330,7 @@ void MenuElementRenderer::drawCheckBox(
 void MenuElementRenderer::drawBonusScreenText(
   const int x,
   const int y,
-  const std::string& text) const
+  std::string_view text) const
 {
   //        col 0, row 0: ASCII chars 48-57, 65-74
   //        col 0, row 2: ASCII chars 75-90,37,61,46,33

--- a/src/ui/menu_element_renderer.hpp
+++ b/src/ui/menu_element_renderer.hpp
@@ -51,17 +51,17 @@ public:
 
   // Stateless API
   // --------------------------------------------------------------------------
-  void drawText(int x, int y, const std::string& text) const;
-  void drawSmallWhiteText(int x, int y, const std::string& text) const;
-  void drawMultiLineText(int x, int y, const std::string& text) const;
+  void drawText(int x, int y, std::string_view text) const;
+  void drawSmallWhiteText(int x, int y, std::string_view text) const;
+  void drawMultiLineText(int x, int y, std::string_view text) const;
   void
-    drawBigText(int x, int y, const std::string& text, const base::Color& color)
+    drawBigText(int x, int y, std::string_view text, const base::Color& color)
       const;
   void drawMessageBox(int x, int y, int width, int height) const;
 
   void drawCheckBox(int x, int y, bool isChecked) const;
 
-  void drawBonusScreenText(int x, int y, const std::string& text) const;
+  void drawBonusScreenText(int x, int y, std::string_view text) const;
 
   /** Draw text entry cursor icon at given position/state.
    *

--- a/src/ui/text_entry_widget.cpp
+++ b/src/ui/text_entry_widget.cpp
@@ -82,7 +82,7 @@ void TextEntryWidget::handleEvent(const SDL_Event& event)
 
 void TextEntryWidget::updateAndRender(const engine::TimeDelta dt)
 {
-  auto drawText = [this](const std::string& text) {
+  auto drawText = [this](std::string_view text) {
     if (mTextStyle == Style::BigText)
     {
       mpUiRenderer->drawBigText(mPosX, mPosY, text, TEXT_COLOR);

--- a/src/ui/utils.cpp
+++ b/src/ui/utils.cpp
@@ -33,7 +33,7 @@ ImU32 toImgui(const base::Color& color)
 renderer::Texture fullScreenImageAsTexture(
   renderer::Renderer* pRenderer,
   const loader::ResourceLoader& resources,
-  const std::string& imageName)
+  std::string_view imageName)
 {
   return renderer::Texture(
     pRenderer, resources.loadStandaloneFullscreenImage(imageName));

--- a/src/ui/utils.hpp
+++ b/src/ui/utils.hpp
@@ -42,7 +42,7 @@ ImU32 toImgui(const base::Color& color);
 renderer::Texture fullScreenImageAsTexture(
   renderer::Renderer* pRenderer,
   const loader::ResourceLoader& resources,
-  const std::string& imageName);
+  std::string_view imageName);
 
 engine::TiledTexture makeUiSpriteSheet(
   renderer::Renderer* pRenderer,

--- a/test/test_duke_script_loader.cpp
+++ b/test/test_duke_script_loader.cpp
@@ -33,7 +33,7 @@ using namespace std;
 namespace
 {
 
-Script loadSingleScript(const string& source)
+Script loadSingleScript(string_view source)
 {
   auto sourceWithName = string("TestTestTest\r\n\r\n");
   sourceWithName += source;


### PR DESCRIPTION
- Replaced `const std::string&` with `std::string_view` where possible
- Fixes #683

Did not implement `std::string_view` where library functions incompatible with it were called on a `std::string` (eg. `.c_str()`), or where string concatenation was needed