### PR TITLE
Add option to run tests with ASan #244

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -40,7 +40,7 @@ Each option can be either `ON` or `OFF`. The default is `OFF` for all options.
 
 * `USE_GL_ES`: Build against the OpenGL ES 2.0 API instead of OpenGL 3.0. See [OpenGL ES version](#linux-build-instructions-gles) for more info.
 * `WARNINGS_AS_ERRORS`: Make compiler warnings fail the build
-* `BUILD_TESTS`: Build the unit tests (`tests` target) 
+* `BUILD_TESTS`: Build the unit tests (`tests` target)
 * `BUILD_BENCHMARKS`: Build the benchmarks (`benchmarks` target)
 
 For developing RigelEngine, I recommend enabling warnings as errors and tests:
@@ -50,6 +50,15 @@ cmake . -DWARNINGS_AS_ERRORS=ON -DBUILD_TESTS=ON
 ```
 
 This is how the project is built on CI.
+
+#### Using Address Sanitizer (ASAN)
+
+If you wish to run tests with AddressSanitizer (available on clang and gcc), use `CMAKE_BUILD_TYPE=Asan`, like so:
+
+```shell
+cmake . -DCMAKE_BUILD_TYPE=Asan -DWARNINGS_AS_ERRORS=ON -DBUILD_TESTS=ON
+ctest -T MemCheck # add other ctest options here, -V is a good one
+```
 
 ### <a name="dependencies">Pre-requisites and dependencies</a>
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,14 @@ if (NOT CMAKE_BUILD_TYPE)
   message(STATUS "No build type was specified, will default to ${CMAKE_BUILD_TYPE}")
 endif()
 
+message(STATUS "${PROJECT_NAME}, build type: ${CMAKE_BUILD_TYPE}, version: ${PROJECT_VERSION}")
+
 option(USE_GL_ES "Use OpenGL ES instead of regular OpenGL" OFF)
 option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 option(BUILD_BENCHMARKS "Build benchmarks" OFF)
 option(BUILD_TESTS "Build tests" OFF)
+
+include("${CMAKE_SOURCE_DIR}/cmake/rigel_sanitizers.cmake")
 
 # Dependencies
 ###############################################################################

--- a/cmake/rigel_sanitizers.cmake
+++ b/cmake/rigel_sanitizers.cmake
@@ -1,0 +1,26 @@
+# allow CTest to work with address sanitizer (requires cmake > 3.18)
+# eg. ctest -V -T MemCheck
+# https://gitlab.kitware.com/cmake/cmake/-/issues/20584
+if(CMAKE_BUILD_TYPE STREQUAL "Asan")
+  # https://cmake.org/cmake/help/latest/variable/CTEST_MEMORYCHECK_TYPE.html
+  set(MEMORYCHECK_TYPE "AddressSanitizer" CACHE STRING "Use ASAN in MemCheck" FORCE)
+endif()
+
+# only enable sanitizers on clang and gcc via CMAKE_BUILD_TYPE
+# flags for C/CXX are setup using `CMAKE_C_FLAGS_<CMAKE_BUILD_TYPE-in-all-caps>
+# use CMAKE_BUILD_TYPE=Asan to enabled these flags
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+  # ASAN flags
+  set(CMAKE_C_FLAGS_ASAN
+    "${CMAKE_C_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer" CACHE STRING
+    "Flags used by the C compiler for Asan build type or configuration." FORCE)
+  set(CMAKE_CXX_FLAGS_ASAN
+    "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer" CACHE STRING
+    "Flags used by the C++ compiler for Asan build type or configuration." FORCE)
+  set(CMAKE_EXE_LINKER_FLAGS_ASAN
+    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=address" CACHE STRING
+    "Linker flags to be used to create executables for Asan build type." FORCE)
+  set(CMAKE_SHARED_LINKER_FLAGS_ASAN
+    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=address" CACHE STRING
+    "Linker flags to be used to create shared libraries for Asan build type." FORCE)
+endif()


### PR DESCRIPTION
* cmake build type == Asan will add the required flags (fsanitizer and
-fno-omit-frame-pointer alongside the debug flags
* helpful messages are printed to see the build type
* usage with ctest is described in the BUILDING.md file