### PR TITLE
Smooth dynamic geometry

### DIFF
--- a/src/engine/map_renderer.hpp
+++ b/src/engine/map_renderer.hpp
@@ -23,13 +23,69 @@
 #include "renderer/renderer.hpp"
 #include "renderer/texture.hpp"
 
+#include <array>
+#include <vector>
+
 
 namespace rigel::engine
 {
 
+using PackedTileData = std::uint32_t;
+
+
+constexpr auto BLOCK_SIZE = 32;
+
+
+struct AnimatedTile
+{
+  base::Vec2 mPosition;
+  data::map::TileIndex mIndex;
+};
+
+
+struct TileBlock
+{
+  renderer::VertexBufferId mTilesBuffer;
+  std::vector<AnimatedTile> mAnimatedTiles;
+};
+
+
+struct TileRenderData
+{
+  TileRenderData(base::Extents size, renderer::Renderer* pRenderer);
+  ~TileRenderData();
+
+  TileRenderData(TileRenderData&&) noexcept = default;
+  TileRenderData& operator=(TileRenderData&&) noexcept = default;
+  TileRenderData(const TileRenderData&) = delete;
+  TileRenderData& operator=(const TileRenderData&) = delete;
+
+  std::array<std::vector<TileBlock>, 2> mLayers;
+  base::Extents mSize;
+  renderer::Renderer* mpRenderer;
+};
+
+
+/** Grab a copy of map data for use with renderCachedSection
+ *
+ * It's the client's responsibility to separately keep track of the
+ * width of the section, since that's needed by renderCachedSection.
+ */
+std::vector<PackedTileData>
+  copyMapData(const base::Rect<int>& section, const data::map::Map& map);
+
+
 class MapRenderer
 {
 public:
+  // The enum values also serve as array indices into the layers in
+  // TileRenderData.
+  enum class DrawMode : std::uint8_t
+  {
+    Background = 0,
+    Foreground = 1
+  };
+
   struct MapRenderData
   {
     data::Image mTileSetImage;
@@ -40,7 +96,8 @@ public:
 
   MapRenderer(
     renderer::Renderer* renderer,
-    const data::map::Map* pMap,
+    const data::map::Map& map,
+    const data::map::TileAttributeDict* pTileAttributes,
     MapRenderData&& renderData);
 
   void synchronizeTo(const MapRenderer& other);
@@ -65,14 +122,18 @@ public:
   void renderSingleTile(
     data::map::TileIndex index,
     const base::Vec2& pixelPosition) const;
+  void renderDynamicSection(
+    const data::map::Map& map,
+    const base::Rect<int>& coordinates,
+    const base::Vec2& pixelPosition,
+    const DrawMode drawMode) const;
+  void renderCachedSection(
+    const base::Vec2& pixelPosition,
+    base::ArrayView<PackedTileData> data,
+    int width,
+    const DrawMode drawMode) const;
 
 private:
-  enum class DrawMode
-  {
-    Background,
-    Foreground
-  };
-
   renderer::TexCoords calculateBackdropTexCoords(
     const base::Vec2f& cameraPosition,
     const base::Extents& viewportSize) const;
@@ -81,16 +142,17 @@ private:
     const base::Vec2& sectionStart,
     const base::Extents& sectionSize,
     DrawMode drawMode) const;
-  void renderTile(data::map::TileIndex index, int x, int y) const;
   data::map::TileIndex animatedTileIndex(data::map::TileIndex) const;
 
 private:
-  mutable renderer::Renderer* mpRenderer;
-  const data::map::Map* mpMap;
+  renderer::Renderer* mpRenderer;
+  const data::map::TileAttributeDict* mpTileAttributes;
 
   TiledTexture mTileSetTexture;
   renderer::Texture mBackdropTexture;
   renderer::Texture mAlternativeBackdropTexture;
+
+  TileRenderData mRenderData;
 
   data::map::BackdropScrollMode mScrollMode;
 

--- a/src/frontend/game_runner.cpp
+++ b/src/frontend/game_runner.cpp
@@ -94,7 +94,7 @@ void GameRunner::updateAndRender(engine::TimeDelta dt)
   {
     // TODO: This is a workaround to make the fadeout on quitting work.
     // Would be good to find a better way to do this.
-    mWorld.render();
+    mWorld.render(interpolationFactor(dt));
     return;
   }
 
@@ -104,12 +104,7 @@ void GameRunner::updateAndRender(engine::TimeDelta dt)
   }
 
   updateWorld(dt);
-
-  const auto interpolationFactor =
-    mContext.mpUserProfile->mOptions.mMotionSmoothing
-    ? static_cast<float>(mAccumulatedTime / game_logic::GAME_LOGIC_UPDATE_DELAY)
-    : 1.0f;
-  mWorld.render(interpolationFactor);
+  mWorld.render(interpolationFactor(dt));
 
   renderDebugText();
   mWorld.processEndOfFrameActions();
@@ -119,6 +114,14 @@ void GameRunner::updateAndRender(engine::TimeDelta dt)
 bool GameRunner::needsPerElementUpscaling() const
 {
   return mWorld.needsPerElementUpscaling();
+}
+
+
+float GameRunner::interpolationFactor(const engine::TimeDelta dt) const
+{
+  return mContext.mpUserProfile->mOptions.mMotionSmoothing
+    ? static_cast<float>(mAccumulatedTime / game_logic::GAME_LOGIC_UPDATE_DELAY)
+    : 1.0f;
 }
 
 
@@ -159,7 +162,7 @@ bool GameRunner::updateMenu(const engine::TimeDelta dt)
 
     if (mMenu.isTransparent())
     {
-      mWorld.render();
+      mWorld.render(interpolationFactor(dt));
     }
 
     const auto result = mMenu.updateAndRender(dt);
@@ -167,7 +170,7 @@ bool GameRunner::updateMenu(const engine::TimeDelta dt)
     if (result == ui::IngameMenu::UpdateResult::FinishedNeedsFadeout)
     {
       mContext.mpServiceProvider->fadeOutScreen();
-      mWorld.render();
+      mWorld.render(interpolationFactor(dt));
       mContext.mpServiceProvider->fadeInScreen();
     }
 

--- a/src/frontend/game_runner.hpp
+++ b/src/frontend/game_runner.hpp
@@ -55,6 +55,7 @@ public:
   std::set<data::Bonus> achievedBonuses() const;
 
 private:
+  float interpolationFactor(engine::TimeDelta dt) const;
   void updateWorld(engine::TimeDelta dt);
   bool updateMenu(engine::TimeDelta dt);
   void handleDebugKeys(const SDL_Event& event);

--- a/src/game_logic/debugging_system.cpp
+++ b/src/game_logic/debugging_system.cpp
@@ -196,19 +196,19 @@ void DebuggingSystem::update(
         mpRenderer->drawRectangle(boxInPixels, colorForEntity(entity));
       });
 
-    es.each<game_logic::components::MapGeometryLink>(
+    es.each<game_logic::components::DynamicGeometrySection>(
       [&](
         ex::Entity entity,
-        const game_logic::components::MapGeometryLink& link) {
+        const game_logic::components::DynamicGeometrySection& dynamic) {
         const auto worldToScreenPx = tileVectorToPixelVector(cameraPosition);
         const auto boxInPixels = BoundingBox{
-          tileVectorToPixelVector(link.mLinkedGeometrySection.topLeft) -
+          tileVectorToPixelVector(dynamic.mLinkedGeometrySection.topLeft) -
             worldToScreenPx,
-          tileExtentsToPixelExtents(link.mLinkedGeometrySection.size)};
+          tileExtentsToPixelExtents(dynamic.mLinkedGeometrySection.size)};
 
         mpRenderer->drawRectangle(boxInPixels, base::Color{0, 255, 255, 190});
 
-        if (const auto extraSectionRect = link.extraSectionRect())
+        if (const auto extraSectionRect = dynamic.extraSectionRect())
         {
           const auto extraBoxInPixels = BoundingBox{
             tileVectorToPixelVector(extraSectionRect->topLeft) -

--- a/src/game_logic/debugging_system.cpp
+++ b/src/game_logic/debugging_system.cpp
@@ -207,6 +207,16 @@ void DebuggingSystem::update(
           tileExtentsToPixelExtents(link.mLinkedGeometrySection.size)};
 
         mpRenderer->drawRectangle(boxInPixels, base::Color{0, 255, 255, 190});
+
+        if (const auto extraSectionRect = link.extraSectionRect())
+        {
+          const auto extraBoxInPixels = BoundingBox{
+            tileVectorToPixelVector(extraSectionRect->topLeft) -
+              worldToScreenPx,
+            tileExtentsToPixelExtents(extraSectionRect->size)};
+          mpRenderer->drawRectangle(
+            extraBoxInPixels, base::Color{255, 255, 100, 190});
+        }
       });
   }
 

--- a/src/game_logic/dynamic_geometry_components.hpp
+++ b/src/game_logic/dynamic_geometry_components.hpp
@@ -50,21 +50,14 @@ struct DynamicGeometrySection
 
   std::optional<base::Rect<int>> extraSectionRect() const
   {
-    if (!mExtraSection)
+    if (mExtraSection)
     {
-      return std::nullopt;
+      return base::Rect<int>{
+        {mLinkedGeometrySection.left(), mExtraSection->mTop},
+        {mLinkedGeometrySection.size.width, mExtraSection->mHeight}};
     }
 
-    const auto actualTop =
-      std::max(mExtraSection->mTop, mLinkedGeometrySection.bottom() + 1);
-    const auto removedHeight =
-      std::min(mExtraSection->mHeight, actualTop - mExtraSection->mTop);
-    const auto actualHeight =
-      std::max(0, mExtraSection->mHeight - removedHeight);
-
-    return base::Rect<int>{
-      {mLinkedGeometrySection.left(), actualTop},
-      {mLinkedGeometrySection.size.width, actualHeight}};
+    return std::nullopt;
   }
 
   engine::components::BoundingBox mLinkedGeometrySection;

--- a/src/game_logic/dynamic_geometry_components.hpp
+++ b/src/game_logic/dynamic_geometry_components.hpp
@@ -18,9 +18,11 @@
 
 #include "data/tile_attributes.hpp"
 #include "engine/base_components.hpp"
+#include "engine/map_renderer.hpp"
 #include "game_logic/global_dependencies.hpp"
 
 #include <optional>
+#include <vector>
 
 
 namespace rigel::game_logic
@@ -42,6 +44,7 @@ struct DynamicGeometrySection
   explicit DynamicGeometrySection(
     engine::components::BoundingBox geometrySection)
     : mLinkedGeometrySection(geometrySection)
+    , mPreviousHeight(geometrySection.size.height)
   {
   }
 
@@ -66,6 +69,10 @@ struct DynamicGeometrySection
 
   engine::components::BoundingBox mLinkedGeometrySection;
   std::optional<ExtraSection> mExtraSection;
+
+  // These two are for interpolation while sinking
+  std::vector<engine::PackedTileData> mBottomRowCopy;
+  int mPreviousHeight;
 };
 
 

--- a/src/game_logic/dynamic_geometry_components.hpp
+++ b/src/game_logic/dynamic_geometry_components.hpp
@@ -28,7 +28,7 @@ namespace rigel::game_logic
 namespace components
 {
 
-struct MapGeometryLink
+struct DynamicGeometrySection
 {
   // This represents the area below a piece of dynamic geometry, which
   // will be erased as the piece is falling down.
@@ -39,7 +39,8 @@ struct MapGeometryLink
     int mHeight;
   };
 
-  explicit MapGeometryLink(engine::components::BoundingBox geometrySection)
+  explicit DynamicGeometrySection(
+    engine::components::BoundingBox geometrySection)
     : mLinkedGeometrySection(geometrySection)
   {
   }

--- a/src/game_logic/dynamic_geometry_system.hpp
+++ b/src/game_logic/dynamic_geometry_system.hpp
@@ -78,6 +78,7 @@ class DynamicGeometrySystem : public entityx::Receiver<DynamicGeometrySystem>
 {
 public:
   DynamicGeometrySystem(
+    renderer::Renderer* pRenderer,
     IGameServiceProvider* pServiceProvider,
     entityx::EntityManager* pEntityManager,
     data::map::Map* pMap,
@@ -110,6 +111,7 @@ private:
     float interpolationFactor,
     engine::MapRenderer::DrawMode drawMode);
 
+  renderer::Renderer* mpRenderer;
   IGameServiceProvider* mpServiceProvider;
   entityx::EntityManager* mpEntityManager;
   data::map::Map* mpMap;

--- a/src/game_logic/dynamic_geometry_system.hpp
+++ b/src/game_logic/dynamic_geometry_system.hpp
@@ -18,22 +18,25 @@
 
 #include "base/spatial_types.hpp"
 #include "base/warnings.hpp"
+#include "data/map.hpp"
+#include "engine/map_renderer.hpp"
 
 RIGEL_DISABLE_WARNINGS
 #include <entityx/entityx.h>
 RIGEL_RESTORE_WARNINGS
 
+#include <vector>
+
+
 namespace rigel
 {
 struct IGameServiceProvider;
-namespace data::map
-{
-class Map;
-}
+
 namespace engine
 {
+class CollisionChecker;
 class RandomNumberGenerator;
-}
+} // namespace engine
 namespace events
 {
 struct DoorOpened;
@@ -50,6 +53,27 @@ struct ShootableKilled;
 namespace rigel::game_logic
 {
 
+struct FallingSectionInfo
+{
+  base::Rect<int> mSectionBelow;
+  int mIndex;
+};
+
+
+struct DynamicMapSectionData
+{
+  data::map::Map mMapStaticParts;
+
+  std::vector<base::Rect<int>> mSimpleSections;
+  std::vector<FallingSectionInfo> mFallingSections;
+};
+
+
+DynamicMapSectionData determineDynamicMapSections(
+  const data::map::Map& originalMap,
+  const std::vector<data::map::LevelData::Actor>& actorDescriptions);
+
+
 class DynamicGeometrySystem : public entityx::Receiver<DynamicGeometrySystem>
 {
 public:
@@ -58,19 +82,41 @@ public:
     entityx::EntityManager* pEntityManager,
     data::map::Map* pMap,
     engine::RandomNumberGenerator* pRandomGenerator,
-    entityx::EventManager* pEvents);
+    entityx::EventManager* pEvents,
+    engine::MapRenderer* pMapRenderer,
+    std::vector<base::Rect<int>> simpleDynamicSections);
+
+  void initializeDynamicGeometryEntities(
+    const std::vector<FallingSectionInfo>& fallingSections);
 
   void receive(const events::ShootableKilled& event);
   void receive(const rigel::events::DoorOpened& event);
   void receive(const rigel::events::MissileDetonated& event);
   void receive(const rigel::events::TileBurnedAway& event);
 
+  void renderDynamicBackgroundSections(
+    const base::Vec2& sectionStart,
+    const base::Extents& sectionSize,
+    float interpolationFactor);
+  void renderDynamicForegroundSections(
+    const base::Vec2& sectionStart,
+    const base::Extents& sectionSize,
+    float interpolationFactor);
+
 private:
+  void renderDynamicSections(
+    const base::Vec2& sectionStart,
+    const base::Extents& sectionSize,
+    float interpolationFactor,
+    engine::MapRenderer::DrawMode drawMode);
+
   IGameServiceProvider* mpServiceProvider;
   entityx::EntityManager* mpEntityManager;
   data::map::Map* mpMap;
   engine::RandomNumberGenerator* mpRandomGenerator;
   entityx::EventManager* mpEvents;
+  engine::MapRenderer* mpMapRenderer;
+  std::vector<base::Rect<int>> mSimpleDynamicSections;
 };
 
 } // namespace rigel::game_logic

--- a/src/game_logic/entity_factory.cpp
+++ b/src/game_logic/entity_factory.cpp
@@ -436,6 +436,7 @@ void EntityFactory::createEntitiesForLevel(
     {
       const auto mapSectionRect = *actor.mAssignedArea;
       entity.assign<MapGeometryLink>(mapSectionRect);
+      engine::enableInterpolation(entity);
 
       boundingBox = mapSectionRect;
       boundingBox.topLeft = {0, 0};

--- a/src/game_logic/entity_factory.cpp
+++ b/src/game_logic/entity_factory.cpp
@@ -435,7 +435,7 @@ void EntityFactory::createEntitiesForLevel(
     if (actor.mAssignedArea)
     {
       const auto mapSectionRect = *actor.mAssignedArea;
-      entity.assign<MapGeometryLink>(mapSectionRect);
+      entity.assign<DynamicGeometrySection>(mapSectionRect);
       engine::enableInterpolation(entity);
 
       boundingBox = mapSectionRect;

--- a/src/game_logic/game_world.cpp
+++ b/src/game_logic/game_world.cpp
@@ -1020,12 +1020,16 @@ void GameWorld::drawMapAndSprites(
   auto renderBackgroundLayers = [&]() {
     state.mMapRenderer.renderBackground(
       params.mRenderStartPosition, params.mViewportSize);
+    state.mDynamicGeometrySystem.renderDynamicBackgroundSections(
+      params.mRenderStartPosition, params.mViewportSize, interpolationFactor);
     state.mSpriteRenderingSystem.renderRegularSprites();
   };
 
   auto renderForegroundLayers = [&]() {
     state.mMapRenderer.renderForeground(
       params.mRenderStartPosition, params.mViewportSize);
+    state.mDynamicGeometrySystem.renderDynamicForegroundSections(
+      params.mRenderStartPosition, params.mViewportSize, interpolationFactor);
     state.mSpriteRenderingSystem.renderForegroundSprites();
     renderTileDebris();
   };

--- a/src/game_logic/game_world.cpp
+++ b/src/game_logic/game_world.cpp
@@ -755,18 +755,18 @@ void GameWorld::render(const float interpolationFactor)
     };
 
   auto drawWorld = [&](const base::Extents& viewportSize) {
-    if (mpState->mScreenFlashColor)
-    {
-      mpRenderer->clear(*mpState->mScreenFlashColor);
-      return;
-    }
-
     const auto viewportParams =
       determineSmoothScrollViewport(viewportSize, interpolationFactor);
 
     // prevent out of bounds areas from showing the backdrop/sprites
     auto clipRectGuard =
       setupWorldClipRect(viewportParams.mRenderStartPosition, viewportSize);
+
+    if (mpState->mScreenFlashColor)
+    {
+      mpRenderer->clear(*mpState->mScreenFlashColor);
+      return;
+    }
 
     if (mpOptions->mPerElementUpscalingEnabled)
     {

--- a/src/game_logic/world_state.cpp
+++ b/src/game_logic/world_state.cpp
@@ -86,12 +86,12 @@ void copyAllComponents(entityx::Entity from, entityx::Entity to)
   copyComponentIfPresent<DamageInflicting>(from, to);
   copyComponentIfPresent<DestructionEffects>(from, to);
   copyComponentIfPresent<DrawTopMost>(from, to);
+  copyComponentIfPresent<DynamicGeometrySection>(from, to);
   copyComponentIfPresent<ExtendedFrameList>(from, to);
   copyComponentIfPresent<Interactable>(from, to);
   copyComponentIfPresent<InterpolateMotion>(from, to);
   copyComponentIfPresent<ItemBounceEffect>(from, to);
   copyComponentIfPresent<ItemContainer>(from, to);
-  copyComponentIfPresent<MapGeometryLink>(from, to);
   copyComponentIfPresent<MovementSequence>(from, to);
   copyComponentIfPresent<MovingBody>(from, to);
   copyComponentIfPresent<Orientation>(from, to);

--- a/src/game_logic/world_state.cpp
+++ b/src/game_logic/world_state.cpp
@@ -258,6 +258,7 @@ WorldState::WorldState(
       &mMap)
   , mDamageInflictionSystem(pPlayerModel, pServiceProvider, &mEventManager)
   , mDynamicGeometrySystem(
+      pRenderer,
       pServiceProvider,
       &mEntities,
       &mMap,

--- a/src/game_logic/world_state.hpp
+++ b/src/game_logic/world_state.hpp
@@ -108,6 +108,7 @@ struct CheckpointData
   base::Vec2 mPosition;
 };
 
+
 struct WorldState
 {
   WorldState(
@@ -126,6 +127,16 @@ struct WorldState
     const data::GameOptions* pOptions,
     engine::SpriteFactory* pSpriteFactory,
     data::GameSessionId sessionId,
+    data::map::LevelData&& loadedLevel);
+  WorldState(
+    IGameServiceProvider* pServiceProvider,
+    renderer::Renderer* pRenderer,
+    const assets::ResourceLoader* pResources,
+    data::PlayerModel* pPlayerModel,
+    const data::GameOptions* pOptions,
+    engine::SpriteFactory* pSpriteFactory,
+    data::GameSessionId sessionId,
+    DynamicMapSectionData&& dynamicMapSections,
     data::map::LevelData&& loadedLevel);
 
   void synchronizeTo(


### PR DESCRIPTION
TODO

* [x] Handle map changing
* [x] Fix out of bounds blanking
* [x] Consider `VertexBufferId` approach, where VBO handle and size are stored in a single 64-bit integer, instead of using pointers
* [x] Remove unused `list` and `spatial_types_printing` includes
* [x] Move VBO destruction into dtor of `RenderData`
* [x] Handle areas below falling geometry correctly
* [x] Cull dynamic areas when rendering

Fixes #830 