### PR TITLE
Move `src/data/audio_buffer.hpp` to `src/base`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@ set(core_sources
     audio/sound_system.hpp
     base/array_view.cpp
     base/array_view.hpp
+    base/audio_buffer.hpp
     base/clock.hpp
     base/container_utils.hpp
     base/defer.hpp
@@ -52,7 +53,6 @@ set(core_sources
     base/string_utils.hpp
     base/warnings.hpp
     data/actor_ids.hpp
-    data/audio_buffer.hpp
     data/bonus.hpp
     data/duke_script.hpp
     data/game_options.cpp

--- a/src/assets/resource_loader.cpp
+++ b/src/assets/resource_loader.cpp
@@ -440,7 +440,7 @@ bool ResourceLoader::hasSoundBlasterSound(const data::SoundId id) const
 }
 
 
-data::AudioBuffer
+base::AudioBuffer
   ResourceLoader::loadSoundBlasterSound(const data::SoundId id) const
 {
   const auto digitizedSoundFileName = digitizedSoundFilenameForId(id);
@@ -493,7 +493,7 @@ std::vector<std::filesystem::path>
 }
 
 
-data::AudioBuffer ResourceLoader::loadSound(std::string_view name) const
+base::AudioBuffer ResourceLoader::loadSound(std::string_view name) const
 {
   return assets::decodeVoc(file(name));
 }

--- a/src/assets/resource_loader.hpp
+++ b/src/assets/resource_loader.hpp
@@ -21,8 +21,8 @@
 #include "assets/duke_script_loader.hpp"
 #include "assets/palette.hpp"
 #include "base/array_view.hpp"
+#include "base/audio_buffer.hpp"
 #include "base/image.hpp"
-#include "data/audio_buffer.hpp"
 #include "data/movie.hpp"
 #include "data/song.hpp"
 #include "data/sound_ids.hpp"
@@ -102,7 +102,7 @@ public:
 
   data::Song loadMusic(std::string_view name) const;
   bool hasSoundBlasterSound(data::SoundId id) const;
-  data::AudioBuffer loadSoundBlasterSound(data::SoundId id) const;
+  base::AudioBuffer loadSoundBlasterSound(data::SoundId id) const;
 
   std::vector<std::filesystem::path>
     replacementSoundPaths(data::SoundId id) const;
@@ -133,7 +133,7 @@ private:
   data::Image loadTiledFullscreenImage(
     std::string_view name,
     const data::Palette16& overridePalette) const;
-  data::AudioBuffer loadSound(std::string_view name) const;
+  base::AudioBuffer loadSound(std::string_view name) const;
 
   std::filesystem::path mGamePath;
   std::vector<std::filesystem::path> mModPaths;

--- a/src/assets/voc_decoder.cpp
+++ b/src/assets/voc_decoder.cpp
@@ -375,7 +375,7 @@ void decodeAudio(
 } // namespace
 
 
-data::AudioBuffer decodeVoc(const ByteBuffer& data)
+base::AudioBuffer decodeVoc(const ByteBuffer& data)
 {
   LeStreamReader reader(data);
   if (!readAndValidateVocHeader(reader))
@@ -383,7 +383,7 @@ data::AudioBuffer decodeVoc(const ByteBuffer& data)
     throw std::invalid_argument("Invalid VOC file header");
   }
 
-  std::vector<data::Sample> decodedSamples;
+  std::vector<base::Sample> decodedSamples;
   std::optional<int> sampleRate;
 
   while (reader.hasData())

--- a/src/assets/voc_decoder.hpp
+++ b/src/assets/voc_decoder.hpp
@@ -17,12 +17,12 @@
 #pragma once
 
 #include "assets/byte_buffer.hpp"
-#include "data/audio_buffer.hpp"
+#include "base/audio_buffer.hpp"
 
 
 namespace rigel::assets
 {
 
-data::AudioBuffer decodeVoc(const ByteBuffer& data);
+base::AudioBuffer decodeVoc(const ByteBuffer& data);
 
 }

--- a/src/audio/sound_system.hpp
+++ b/src/audio/sound_system.hpp
@@ -16,8 +16,8 @@
 
 #pragma once
 
+#include "base/audio_buffer.hpp"
 #include "base/defer.hpp"
-#include "data/audio_buffer.hpp"
 #include "data/game_options.hpp"
 #include "data/song.hpp"
 #include "data/sound_ids.hpp"

--- a/src/base/audio_buffer.hpp
+++ b/src/base/audio_buffer.hpp
@@ -20,7 +20,7 @@
 #include <vector>
 
 
-namespace rigel::data
+namespace rigel::base
 {
 
 using Sample = std::int16_t;
@@ -33,4 +33,4 @@ struct AudioBuffer
 };
 
 
-} // namespace rigel::data
+} // namespace rigel::base


### PR DESCRIPTION
## Summary
Hello, @lethal-guitar check this out!

close #816
- Move `src/data/audio_buffer.hpp` to `src/base`
- Adapt all `#include` preprocessors in client code
- Adapt header file code form `namespace data` to `namespace base`
- Adapt client code from  namespace`data::` to `base::`