### PR TITLE
Rename `PlayerModel` to `PersistentPlayerState`

### DIFF
--- a/src/data/bonus.hpp
+++ b/src/data/bonus.hpp
@@ -48,10 +48,10 @@ constexpr int asNumber(const Bonus bonus)
 
 
 inline void
-  addBonusScore(PlayerModel& playerModel, const std::set<Bonus>& bonuses)
+  addBonusScore(PersistentPlayerState& persistentPlayerState, const std::set<Bonus>& bonuses)
 {
   const auto numBonuses = static_cast<int>(bonuses.size());
-  playerModel.giveScore(numBonuses * SCORE_ADDED_PER_BONUS);
+  persistentPlayerState.giveScore(numBonuses * SCORE_ADDED_PER_BONUS);
 }
 
 } // namespace rigel::data

--- a/src/data/player_model.cpp
+++ b/src/data/player_model.cpp
@@ -24,8 +24,7 @@
 
 namespace rigel::data
 {
-
-PlayerModel::PlayerModel()
+PersistentPlayerState::PersistentPlayerState()
   : mWeapon(WeaponType::Normal)
   , mScore(0)
   , mAmmo(MAX_AMMO)
@@ -34,7 +33,7 @@ PlayerModel::PlayerModel()
 }
 
 
-PlayerModel::PlayerModel(const SavedGame& save)
+PersistentPlayerState::PersistentPlayerState(const SavedGame& save)
   : mTutorialMessages(save.mTutorialMessagesAlreadySeen)
   , mWeapon(save.mWeapon)
   , mScore(save.mScore)
@@ -44,13 +43,13 @@ PlayerModel::PlayerModel(const SavedGame& save)
 }
 
 
-PlayerModel::CheckpointState PlayerModel::makeCheckpoint() const
+PersistentPlayerState::CheckpointState PersistentPlayerState::makeCheckpoint() const
 {
   return CheckpointState{mWeapon, mAmmo, mHealth};
 }
 
 
-void PlayerModel::restoreFromCheckpoint(const CheckpointState& state)
+void PersistentPlayerState::restoreFromCheckpoint(const CheckpointState& state)
 {
   mHealth = std::max(2, state.mHealth);
   mWeapon = state.mWeapon;
@@ -58,51 +57,51 @@ void PlayerModel::restoreFromCheckpoint(const CheckpointState& state)
 }
 
 
-int PlayerModel::score() const
+int PersistentPlayerState::score() const
 {
   return mScore;
 }
 
 
-void PlayerModel::giveScore(const int amount)
+void PersistentPlayerState::giveScore(const int amount)
 {
   mScore = std::clamp(mScore + amount, 0, MAX_SCORE);
 }
 
 
-int PlayerModel::ammo() const
+int PersistentPlayerState::ammo() const
 {
   return mAmmo;
 }
 
 
-int PlayerModel::currentMaxAmmo() const
+int PersistentPlayerState::currentMaxAmmo() const
 {
   return mWeapon == WeaponType::FlameThrower ? MAX_AMMO_FLAME_THROWER
                                              : MAX_AMMO;
 }
 
 
-WeaponType PlayerModel::weapon() const
+WeaponType PersistentPlayerState::weapon() const
 {
   return mWeapon;
 }
 
 
-bool PlayerModel::currentWeaponConsumesAmmo() const
+bool PersistentPlayerState::currentWeaponConsumesAmmo() const
 {
   return mWeapon != WeaponType::Normal;
 }
 
 
-void PlayerModel::switchToWeapon(const WeaponType type)
+void PersistentPlayerState::switchToWeapon(const WeaponType type)
 {
   mWeapon = type;
   mAmmo = currentMaxAmmo();
 }
 
 
-void PlayerModel::useAmmo()
+void PersistentPlayerState::useAmmo()
 {
   if (currentWeaponConsumesAmmo())
   {
@@ -115,56 +114,56 @@ void PlayerModel::useAmmo()
 }
 
 
-void PlayerModel::setAmmo(int amount)
+void PersistentPlayerState::setAmmo(int amount)
 {
   assert(amount >= 0 && amount <= currentMaxAmmo());
   mAmmo = amount;
 }
 
 
-int PlayerModel::health() const
+int PersistentPlayerState::health() const
 {
   return mHealth;
 }
 
 
-bool PlayerModel::isAtFullHealth() const
+bool PersistentPlayerState::isAtFullHealth() const
 {
   return mHealth == MAX_HEALTH;
 }
 
 
-bool PlayerModel::isDead() const
+bool PersistentPlayerState::isDead() const
 {
   return mHealth <= 0;
 }
 
 
-void PlayerModel::takeDamage(const int amount)
+void PersistentPlayerState::takeDamage(const int amount)
 {
   mHealth = std::clamp(mHealth - amount, 0, MAX_HEALTH);
 }
 
 
-void PlayerModel::takeFatalDamage()
+void PersistentPlayerState::takeFatalDamage()
 {
   mHealth = 0;
 }
 
 
-void PlayerModel::giveHealth(const int amount)
+void PersistentPlayerState::giveHealth(const int amount)
 {
   mHealth = std::clamp(mHealth + amount, 0, MAX_HEALTH);
 }
 
 
-const std::vector<InventoryItemType>& PlayerModel::inventory() const
+const std::vector<InventoryItemType>& PersistentPlayerState::inventory() const
 {
   return mInventory;
 }
 
 
-bool PlayerModel::hasItem(const InventoryItemType type) const
+bool PersistentPlayerState::hasItem(const InventoryItemType type) const
 {
   using namespace std;
 
@@ -172,7 +171,7 @@ bool PlayerModel::hasItem(const InventoryItemType type) const
 }
 
 
-void PlayerModel::giveItem(InventoryItemType type)
+void PersistentPlayerState::giveItem(InventoryItemType type)
 {
   using namespace std;
 
@@ -191,7 +190,7 @@ void PlayerModel::giveItem(InventoryItemType type)
 }
 
 
-void PlayerModel::removeItem(const InventoryItemType type)
+void PersistentPlayerState::removeItem(const InventoryItemType type)
 {
   using namespace std;
 
@@ -203,14 +202,14 @@ void PlayerModel::removeItem(const InventoryItemType type)
 }
 
 
-const std::vector<CollectableLetterType>& PlayerModel::collectedLetters() const
+const std::vector<CollectableLetterType>& PersistentPlayerState::collectedLetters() const
 {
   return mCollectedLetters;
 }
 
 
-PlayerModel::LetterCollectionState
-  PlayerModel::addLetter(const CollectableLetterType type)
+PersistentPlayerState::LetterCollectionState
+  PersistentPlayerState::addLetter(const CollectableLetterType type)
 {
   using L = CollectableLetterType;
   static std::vector<L> sExpectedOrder = {L::N, L::U, L::K, L::E, L::M};
@@ -231,7 +230,7 @@ PlayerModel::LetterCollectionState
 }
 
 
-void PlayerModel::resetForNewLevel()
+void PersistentPlayerState::resetForNewLevel()
 {
   mHealth = MAX_HEALTH;
   mCollectedLetters.clear();
@@ -239,20 +238,20 @@ void PlayerModel::resetForNewLevel()
 }
 
 
-void PlayerModel::resetHealthAndScore()
+void PersistentPlayerState::resetHealthAndScore()
 {
   mHealth = MAX_HEALTH;
   mScore = 0;
 }
 
 
-TutorialMessageState& PlayerModel::tutorialMessages()
+TutorialMessageState& PersistentPlayerState::tutorialMessages()
 {
   return mTutorialMessages;
 }
 
 
-const TutorialMessageState& PlayerModel::tutorialMessages() const
+const TutorialMessageState& PersistentPlayerState::tutorialMessages() const
 {
   return mTutorialMessages;
 }

--- a/src/data/player_model.hpp
+++ b/src/data/player_model.hpp
@@ -68,7 +68,7 @@ constexpr auto MAX_AMMO_FLAME_THROWER = 64;
 constexpr auto MAX_HEALTH = 9;
 
 
-class PlayerModel
+class PersistentPlayerState
 {
 public:
   struct CheckpointState
@@ -85,8 +85,8 @@ public:
     InOrder
   };
 
-  PlayerModel();
-  explicit PlayerModel(const SavedGame& save);
+  PersistentPlayerState();
+  explicit PersistentPlayerState(const SavedGame& save);
 
   CheckpointState makeCheckpoint() const;
   void restoreFromCheckpoint(const CheckpointState& state);

--- a/src/frontend/demo_player.cpp
+++ b/src/frontend/demo_player.cpp
@@ -112,7 +112,7 @@ void DemoPlayer::updateAndRender(const engine::TimeDelta dt)
   if (!mpWorld)
   {
     mpWorld = std::make_unique<GameWorld_Classic>(
-      &mPlayerModel,
+      &mPersistentPlayerState,
       demoSessionId(0),
       mContext,
       std::nullopt,
@@ -144,10 +144,10 @@ void DemoPlayer::updateAndRender(const engine::TimeDelta dt)
 
     ++mLevelIndex;
 
-    mPlayerModel.resetForNewLevel();
+    mPersistentPlayerState.resetForNewLevel();
 
     mpWorld = std::make_unique<GameWorld_Classic>(
-      &mPlayerModel,
+      &mPersistentPlayerState,
       demoSessionId(mLevelIndex),
       mContext,
       std::nullopt,

--- a/src/frontend/demo_player.hpp
+++ b/src/frontend/demo_player.hpp
@@ -53,7 +53,7 @@ public:
 
 private:
   GameMode::Context mContext;
-  data::PlayerModel mPlayerModel;
+  data::PersistentPlayerState mPersistentPlayerState;
 
   std::vector<DemoInput> mFrames;
   std::size_t mCurrentFrameIndex = 1;

--- a/src/frontend/game_runner.cpp
+++ b/src/frontend/game_runner.cpp
@@ -51,7 +51,7 @@ std::unique_ptr<game_logic::IGameWorld>
 
 
 GameRunner::GameRunner(
-  data::PlayerModel* pPlayerModel,
+  data::PersistentPlayerState* pPersistentPlayerState,
   const data::GameSessionId& sessionId,
   GameMode::Context context,
   const std::optional<base::Vec2> playerPositionOverride,
@@ -59,13 +59,13 @@ GameRunner::GameRunner(
   : mContext(context)
   , mpWorld(createGameWorld(
       context.mpUserProfile->mOptions.mGameplayStyle,
-      pPlayerModel,
+      pPersistentPlayerState,
       sessionId,
       context,
       playerPositionOverride,
       showWelcomeMessage))
   , mInputHandler(&context.mpUserProfile->mOptions)
-  , mMenu(context, pPlayerModel, mpWorld.get(), sessionId)
+  , mMenu(context, pPersistentPlayerState, mpWorld.get(), sessionId)
 {
 }
 

--- a/src/frontend/game_runner.hpp
+++ b/src/frontend/game_runner.hpp
@@ -40,7 +40,7 @@ class GameRunner
 {
 public:
   GameRunner(
-    data::PlayerModel* pPlayerModel,
+    data::PersistentPlayerState* pPersistentPlayerState,
     const data::GameSessionId& sessionId,
     GameMode::Context context,
     std::optional<base::Vec2> playerPositionOverride = std::nullopt,

--- a/src/frontend/game_session_mode.cpp
+++ b/src/frontend/game_session_mode.cpp
@@ -35,7 +35,7 @@ GameSessionMode::GameSessionMode(
   Context context,
   std::optional<base::Vec2> playerPositionOverride)
   : mCurrentStage(std::make_unique<GameRunner>(
-      &mPlayerModel,
+      &mPersistentPlayerState,
       sessionId,
       context,
       playerPositionOverride,
@@ -49,9 +49,9 @@ GameSessionMode::GameSessionMode(
 
 
 GameSessionMode::GameSessionMode(const data::SavedGame& save, Context context)
-  : mPlayerModel(save)
+  : mPersistentPlayerState(save)
   , mCurrentStage(std::make_unique<GameRunner>(
-      &mPlayerModel,
+      &mPersistentPlayerState,
       save.mSessionId,
       context,
       std::nullopt,
@@ -66,11 +66,11 @@ GameSessionMode::GameSessionMode(const data::SavedGame& save, Context context)
 
 GameSessionMode::GameSessionMode(
   const data::GameSessionId& sessionId,
-  data::PlayerModel playerModel,
+  data::PersistentPlayerState PersistentPlayerState,
   Context context)
-  : mPlayerModel(std::move(playerModel))
+  : mPersistentPlayerState(std::move(PersistentPlayerState))
   , mCurrentStage(std::make_unique<GameRunner>(
-      &mPlayerModel,
+      &mPersistentPlayerState,
       sessionId,
       context,
       std::nullopt,
@@ -153,9 +153,9 @@ std::unique_ptr<GameMode> GameSessionMode::updateAndRender(
       if (pIngameMode->levelFinished())
       {
         const auto achievedBonuses = pIngameMode->achievedBonuses();
-        const auto scoreWithoutBonuses = mPlayerModel.score();
+        const auto scoreWithoutBonuses = mPersistentPlayerState.score();
 
-        data::addBonusScore(mPlayerModel, achievedBonuses);
+        data::addBonusScore(mPersistentPlayerState, achievedBonuses);
 
         if (data::isBossLevel(mCurrentLevelNr))
         {
@@ -186,7 +186,7 @@ std::unique_ptr<GameMode> GameSessionMode::updateAndRender(
 
       if (bonusScreen.finished())
       {
-        mPlayerModel.resetForNewLevel();
+        mPersistentPlayerState.resetForNewLevel();
 
         // The new level we are about to enter might have different
         // requirements w.r.t. low-res vs. hi-res mode (per-element upscaling).
@@ -203,7 +203,7 @@ std::unique_ptr<GameMode> GameSessionMode::updateAndRender(
         // We can't use make_unique here, because the constructor is private.
         return std::unique_ptr<GameSessionMode>{new GameSessionMode{
           data::GameSessionId{mEpisode, ++mCurrentLevelNr, mDifficulty},
-          mPlayerModel,
+          mPersistentPlayerState,
           mContext}};
       }
 
@@ -269,7 +269,7 @@ void GameSessionMode::finishGameSession()
   mContext.mpServiceProvider->fadeOutScreen();
 
   const auto scoreQualifies = data::scoreQualifiesForHighScoreList(
-    mPlayerModel.score(), mContext.mpUserProfile->mHighScoreLists[mEpisode]);
+    mPersistentPlayerState.score(), mContext.mpUserProfile->mHighScoreLists[mEpisode]);
   if (scoreQualifies)
   {
     SDL_StartTextInput();
@@ -287,7 +287,7 @@ void GameSessionMode::enterHighScore(std::string_view name)
   SDL_StopTextInput();
 
   data::insertNewScore(
-    mPlayerModel.score(),
+    mPersistentPlayerState.score(),
     std::string{name},
     mContext.mpUserProfile->mHighScoreLists[mEpisode]);
   mContext.mpUserProfile->saveToDisk();

--- a/src/frontend/game_session_mode.hpp
+++ b/src/frontend/game_session_mode.hpp
@@ -53,7 +53,7 @@ public:
 private:
   GameSessionMode(
     const data::GameSessionId& sessionId,
-    data::PlayerModel playerModel,
+    data::PersistentPlayerState PersistentPlayerState,
     Context context);
 
   void handleEvent(const SDL_Event& event);
@@ -79,7 +79,7 @@ private:
     HighScoreNameEntry,
     HighScoreListDisplay>;
 
-  data::PlayerModel mPlayerModel;
+  data::PersistentPlayerState mPersistentPlayerState;
   SessionStage mCurrentStage;
   const int mEpisode;
   int mCurrentLevelNr;

--- a/src/game_logic/damage_infliction_system.cpp
+++ b/src/game_logic/damage_infliction_system.cpp
@@ -53,10 +53,10 @@ auto extractVelocity(entityx::Entity entity)
 
 
 DamageInflictionSystem::DamageInflictionSystem(
-  data::PlayerModel* pPlayerModel,
+  data::PersistentPlayerState* pPersistentPlayerState,
   IGameServiceProvider* pServiceProvider,
   entityx::EventManager* pEvents)
-  : mpPlayerModel(pPlayerModel)
+  : mpPersistentPlayerState(pPersistentPlayerState)
   , mpServiceProvider(pServiceProvider)
   , mpEvents(pEvents)
 {
@@ -139,7 +139,7 @@ void DamageInflictionSystem::inflictDamage(
     // Event listeners mustn't remove the shootable component
     assert(shootableEntity.has_component<Shootable>());
 
-    mpPlayerModel->giveScore(shootable.mGivenScore);
+    mpPersistentPlayerState->giveScore(shootable.mGivenScore);
 
     if (shootable.mDestroyWhenKilled)
     {

--- a/src/game_logic/damage_infliction_system.hpp
+++ b/src/game_logic/damage_infliction_system.hpp
@@ -31,7 +31,7 @@ struct IGameServiceProvider;
 
 namespace rigel::data
 {
-class PlayerModel;
+class PersistentPlayerState;
 }
 
 
@@ -42,7 +42,7 @@ class DamageInflictionSystem
 {
 public:
   DamageInflictionSystem(
-    data::PlayerModel* pPlayerModel,
+    data::PersistentPlayerState* pPersistentPlayerState,
     IGameServiceProvider* pServiceProvider,
     entityx::EventManager* pEvents);
 
@@ -55,7 +55,7 @@ private:
     entityx::Entity shootableEntity,
     components::Shootable& shootable);
 
-  data::PlayerModel* mpPlayerModel;
+  data::PersistentPlayerState* mpPersistentPlayerState;
   IGameServiceProvider* mpServiceProvider;
   entityx::EventManager* mpEvents;
 };

--- a/src/game_logic/game_world.hpp
+++ b/src/game_logic/game_world.hpp
@@ -66,7 +66,7 @@ class GameWorld : public IGameWorld, public entityx::Receiver<GameWorld>
 {
 public:
   GameWorld(
-    data::PlayerModel* pPlayerModel,
+    data::PersistentPlayerState* pPersistentPlayerState,
     const data::GameSessionId& sessionId,
     GameMode::Context context,
     std::optional<base::Vec2> playerPositionOverride = std::nullopt,
@@ -154,7 +154,7 @@ private:
 
   struct QuickSaveData
   {
-    data::PlayerModel mPlayerModel;
+    data::PersistentPlayerState mPersistentPlayerState;
     std::unique_ptr<WorldState> mpState;
   };
 
@@ -162,13 +162,13 @@ private:
   IGameServiceProvider* mpServiceProvider;
   engine::TiledTexture mUiSpriteSheet;
   ui::MenuElementRenderer mTextRenderer;
-  data::PlayerModel* mpPlayerModel;
+  data::PersistentPlayerState* mpPersistentPlayerState;
   const data::GameOptions* mpOptions;
   const assets::ResourceLoader* mpResources;
   engine::SpriteFactory* mpSpriteFactory;
   data::GameSessionId mSessionId;
 
-  data::PlayerModel mPlayerModelAtLevelStart;
+  data::PersistentPlayerState mPersistentPlayerStateAtLevelStart;
   ui::HudRenderer mHudRenderer;
   ui::IngameMessageDisplay mMessageDisplay;
   engine::SpecialEffectsRenderer mSpecialEffects;

--- a/src/game_logic/player.hpp
+++ b/src/game_logic/player.hpp
@@ -39,7 +39,7 @@ struct IGameServiceProvider;
 namespace data
 {
 struct GameOptions;
-class PlayerModel;
+class PersistentPlayerState;
 
 namespace map
 {
@@ -244,7 +244,7 @@ public:
   Player(
     entityx::Entity entity,
     data::Difficulty difficulty,
-    data::PlayerModel* pModel,
+    data::PersistentPlayerState* pModel,
     IGameServiceProvider* pServiceProvider,
     const data::GameOptions* pOptions,
     const engine::CollisionChecker* pCollisionChecker,
@@ -311,7 +311,7 @@ public:
 
   base::Vec2& position();
 
-  data::PlayerModel& model() { return *mpPlayerModel; }
+  data::PersistentPlayerState& model() { return *mpPersistentPlayerState; }
 
   const entityx::Entity& entity() const { return mEntity; }
 
@@ -389,7 +389,7 @@ private:
   PlayerState mState;
   entityx::Entity mEntity;
   entityx::Entity mAttachedElevator;
-  data::PlayerModel* mpPlayerModel;
+  data::PersistentPlayerState* mpPersistentPlayerState;
   IGameServiceProvider* mpServiceProvider;
   const engine::CollisionChecker* mpCollisionChecker;
   const data::map::Map* mpMap;

--- a/src/game_logic/player/interaction_system.hpp
+++ b/src/game_logic/player/interaction_system.hpp
@@ -37,7 +37,7 @@ struct IGameServiceProvider;
 
 namespace data
 {
-class PlayerModel;
+class PersistentPlayerState;
 }
 
 namespace events
@@ -68,7 +68,7 @@ public:
   PlayerInteractionSystem(
     const data::GameSessionId& sessionId,
     Player* pPlayer,
-    data::PlayerModel* pPlayerModel,
+    data::PersistentPlayerState* pPersistentPlayerState,
     IGameServiceProvider* pServices,
     IEntityFactory* pEntityFactory,
     entityx::EventManager* pEvents,
@@ -104,7 +104,7 @@ private:
 
 private:
   Player* mpPlayer;
-  data::PlayerModel* mpPlayerModel;
+  data::PersistentPlayerState* mpPersistentPlayerState;
   IGameServiceProvider* mpServiceProvider;
   IEntityFactory* mpEntityFactory;
   entityx::EventManager* mpEvents;

--- a/src/game_logic/world_state.cpp
+++ b/src/game_logic/world_state.cpp
@@ -129,7 +129,7 @@ WorldState::WorldState(
   IGameServiceProvider* pServiceProvider,
   renderer::Renderer* pRenderer,
   const assets::ResourceLoader* pResources,
-  data::PlayerModel* pPlayerModel,
+  data::PersistentPlayerState* pPersistentPlayerState,
   const data::GameOptions* pOptions,
   engine::SpriteFactory* pSpriteFactory,
   const data::GameSessionId sessionId)
@@ -137,7 +137,7 @@ WorldState::WorldState(
       pServiceProvider,
       pRenderer,
       pResources,
-      pPlayerModel,
+      pPersistentPlayerState,
       pOptions,
       pSpriteFactory,
       sessionId,
@@ -153,7 +153,7 @@ WorldState::WorldState(
   IGameServiceProvider* pServiceProvider,
   renderer::Renderer* pRenderer,
   const assets::ResourceLoader* pResources,
-  data::PlayerModel* pPlayerModel,
+  data::PersistentPlayerState* pPersistentPlayerState,
   const data::GameOptions* pOptions,
   engine::SpriteFactory* pSpriteFactory,
   const data::GameSessionId sessionId,
@@ -162,7 +162,7 @@ WorldState::WorldState(
       pServiceProvider,
       pRenderer,
       pResources,
-      pPlayerModel,
+      pPersistentPlayerState,
       pOptions,
       pSpriteFactory,
       sessionId,
@@ -176,7 +176,7 @@ WorldState::WorldState(
   IGameServiceProvider* pServiceProvider,
   renderer::Renderer* pRenderer,
   const assets::ResourceLoader* pResources,
-  data::PlayerModel* pPlayerModel,
+  data::PersistentPlayerState* pPersistentPlayerState,
   const data::GameOptions* pOptions,
   engine::SpriteFactory* pSpriteFactory,
   const data::GameSessionId sessionId,
@@ -208,7 +208,7 @@ WorldState::WorldState(
         return playerEntity;
       }(),
       sessionId.mDifficulty,
-      pPlayerModel,
+      pPersistentPlayerState,
       pServiceProvider,
       pOptions,
       &mCollisionChecker,
@@ -233,7 +233,7 @@ WorldState::WorldState(
   , mPlayerInteractionSystem(
       sessionId,
       &mPlayer,
-      pPlayerModel,
+      pPersistentPlayerState,
       pServiceProvider,
       &mEntityFactory,
       &mEventManager,
@@ -244,7 +244,7 @@ WorldState::WorldState(
       pServiceProvider,
       &mCollisionChecker,
       &mMap)
-  , mDamageInflictionSystem(pPlayerModel, pServiceProvider, &mEventManager)
+  , mDamageInflictionSystem(pPersistentPlayerState, pServiceProvider, &mEventManager)
   , mDynamicGeometrySystem(
       pRenderer,
       pServiceProvider,
@@ -299,7 +299,7 @@ WorldState::WorldState(
 void WorldState::synchronizeTo(
   const WorldState& other,
   IGameServiceProvider* pServiceProvider,
-  data::PlayerModel* pPlayerModel,
+  data::PersistentPlayerState* pPersistentPlayerState,
   const data::GameSessionId sessionId)
 {
   if (mBackdropSwitched != other.mBackdropSwitched)
@@ -370,7 +370,7 @@ void WorldState::synchronizeTo(
     mPlayer = Player{
       playerEntity,
       sessionId.mDifficulty,
-      pPlayerModel,
+      pPersistentPlayerState,
       pServiceProvider,
       mpOptions,
       &mCollisionChecker,

--- a/src/game_logic/world_state.hpp
+++ b/src/game_logic/world_state.hpp
@@ -104,7 +104,7 @@ struct LevelBonusInfo
 
 struct CheckpointData
 {
-  data::PlayerModel::CheckpointState mState;
+  data::PersistentPlayerState::CheckpointState mState;
   base::Vec2 mPosition;
 };
 
@@ -115,7 +115,7 @@ struct WorldState
     IGameServiceProvider* pServiceProvider,
     renderer::Renderer* pRenderer,
     const assets::ResourceLoader* pResources,
-    data::PlayerModel* pPlayerModel,
+    data::PersistentPlayerState* pPersistentPlayerState,
     const data::GameOptions* pOptions,
     engine::SpriteFactory* pSpriteFactory,
     data::GameSessionId sessionId);
@@ -123,7 +123,7 @@ struct WorldState
     IGameServiceProvider* pServiceProvider,
     renderer::Renderer* pRenderer,
     const assets::ResourceLoader* pResources,
-    data::PlayerModel* pPlayerModel,
+    data::PersistentPlayerState* pPersistentPlayerState,
     const data::GameOptions* pOptions,
     engine::SpriteFactory* pSpriteFactory,
     data::GameSessionId sessionId,
@@ -132,7 +132,7 @@ struct WorldState
     IGameServiceProvider* pServiceProvider,
     renderer::Renderer* pRenderer,
     const assets::ResourceLoader* pResources,
-    data::PlayerModel* pPlayerModel,
+    data::PersistentPlayerState* pPersistentPlayerState,
     const data::GameOptions* pOptions,
     engine::SpriteFactory* pSpriteFactory,
     data::GameSessionId sessionId,
@@ -142,7 +142,7 @@ struct WorldState
   void synchronizeTo(
     const WorldState& other,
     IGameServiceProvider* pServiceProvider,
-    data::PlayerModel* pPlayerModel,
+    data::PersistentPlayerState* pPersistentPlayerState,
     data::GameSessionId sessionId);
 
   data::map::Map mMap;

--- a/src/game_logic_classic/game_world_classic.hpp
+++ b/src/game_logic_classic/game_world_classic.hpp
@@ -92,7 +92,7 @@ struct Bridge
     data::map::Map* pMap,
     IGameServiceProvider* pServiceProvider,
     ui::IngameMessageDisplay* pMessageDisplay,
-    data::PlayerModel* pPlayerModel);
+    data::PersistentPlayerState* pPersistentPlayerState);
 
   void resetForNewFrame();
 
@@ -111,7 +111,7 @@ struct Bridge
   engine::MapRenderer* mpMapRenderer = nullptr;
   IGameServiceProvider* mpServiceProvider;
   ui::IngameMessageDisplay* mpMessageDisplay;
-  data::PlayerModel* mpPlayerModel;
+  data::PersistentPlayerState* mpPersistentPlayerState;
 };
 
 } // namespace detail
@@ -121,7 +121,7 @@ class GameWorld_Classic : public IGameWorld
 {
 public:
   GameWorld_Classic(
-    data::PlayerModel* pPlayerModel,
+    data::PersistentPlayerState* pPersistentPlayerState,
     const data::GameSessionId& sessionId,
     GameMode::Context context,
     std::optional<base::Vec2> playerPositionOverride = std::nullopt,
@@ -164,7 +164,7 @@ private:
   void updateVisibleWaterAreas();
   void loadLevel(const data::GameSessionId& sessionId);
   void syncBackdrop();
-  void syncPlayerModel();
+  void syncPersistentPlayerState();
 
   struct QuickSaveData;
 
@@ -172,7 +172,7 @@ private:
   IGameServiceProvider* mpServiceProvider;
   engine::TiledTexture mUiSpriteSheet;
   ui::MenuElementRenderer mTextRenderer;
-  data::PlayerModel* mpPlayerModel;
+  data::PersistentPlayerState* mpPersistentPlayerState;
   const data::GameOptions* mpOptions;
   const assets::ResourceLoader* mpResources;
   engine::SpriteFactory* mpSpriteFactory;
@@ -184,7 +184,7 @@ private:
 
   data::map::Map mMap;
   std::optional<engine::MapRenderer> mMapRenderer;
-  data::PlayerModel mPlayerModelAtLevelStart;
+  data::PersistentPlayerState mPersistentPlayerStateAtLevelStart;
   ui::HudRenderer mHudRenderer;
   ui::IngameMessageDisplay mMessageDisplay;
   engine::SpecialEffectsRenderer mSpecialEffects;
@@ -197,7 +197,7 @@ private:
   std::unique_ptr<detail::State> mpState;
   std::unique_ptr<QuickSaveData> mpQuickSave;
 
-  std::optional<data::PlayerModel::CheckpointState> mCheckpointState;
+  std::optional<data::PersistentPlayerState::CheckpointState> mCheckpointState;
 };
 
 } // namespace rigel::game_logic

--- a/src/ui/hud_renderer.cpp
+++ b/src/ui/hud_renderer.cpp
@@ -282,7 +282,7 @@ void HudRenderer::updateAnimation()
 
 
 void HudRenderer::renderClassicHud(
-  const data::PlayerModel& playerModel,
+  const data::PersistentPlayerState& PersistentPlayerState,
   const base::ArrayView<base::Vec2> radarPositions)
 {
   // We group drawing into what texture is used to minimize the amount of
@@ -300,25 +300,25 @@ void HudRenderer::renderClassicHud(
     2,
     data::tilesToPixels(HUD_START_BOTTOM_RIGHT));
   drawInventory(
-    playerModel.inventory(), data::tilesToPixels(INVENTORY_START_POS));
+    PersistentPlayerState.inventory(), data::tilesToPixels(INVENTORY_START_POS));
   drawCollectedLetters(
-    playerModel, data::tilesToPixels(LETTER_INDICATOR_POSITION));
+    PersistentPlayerState, data::tilesToPixels(LETTER_INDICATOR_POSITION));
 
   // These use the UI sprite sheet texture.
   drawScore(
-    playerModel.score(),
+    PersistentPlayerState.score(),
     *mpStatusSpriteSheetRenderer,
     {2, GameTraits::mapViewportSize.height + 1});
   drawWeaponIcon(
-    playerModel.weapon(),
+    PersistentPlayerState.weapon(),
     *mpStatusSpriteSheetRenderer,
     {17, GameTraits::mapViewportSize.height + 1});
   drawAmmoBar(
-    playerModel.ammo(),
-    playerModel.currentMaxAmmo(),
+    PersistentPlayerState.ammo(),
+    PersistentPlayerState.currentMaxAmmo(),
     *mpStatusSpriteSheetRenderer,
     {22, GameTraits::mapViewportSize.height + 1});
-  drawHealthBar(playerModel, {24, GameTraits::mapViewportSize.height + 1});
+  drawHealthBar(PersistentPlayerState, {24, GameTraits::mapViewportSize.height + 1});
 
   if (mLevelNumber)
   {
@@ -336,7 +336,7 @@ void HudRenderer::renderClassicHud(
 void HudRenderer::renderWidescreenHud(
   const int viewportWidth,
   const data::WidescreenHudStyle style,
-  const data::PlayerModel& playerModel,
+  const data::PersistentPlayerState& PersistentPlayerState,
   const base::ArrayView<base::Vec2> radarPositions)
 {
   auto drawClassicWidescreenHud = [&]() {
@@ -350,7 +350,7 @@ void HudRenderer::renderWidescreenHud(
     auto guard = renderer::saveState(mpRenderer);
     renderer::setLocalTranslation(mpRenderer, {hudOffset, 0});
 
-    renderClassicHud(playerModel, radarPositions);
+    renderClassicHud(PersistentPlayerState, radarPositions);
   };
 
 
@@ -361,11 +361,11 @@ void HudRenderer::renderWidescreenHud(
       break;
 
     case data::WidescreenHudStyle::Modern:
-      drawModernHud(viewportWidth, playerModel, radarPositions);
+      drawModernHud(viewportWidth, PersistentPlayerState, radarPositions);
       break;
 
     case data::WidescreenHudStyle::Ultrawide:
-      drawUltrawideHud(viewportWidth, playerModel, radarPositions);
+      drawUltrawideHud(viewportWidth, PersistentPlayerState, radarPositions);
       break;
   }
 }
@@ -373,7 +373,7 @@ void HudRenderer::renderWidescreenHud(
 
 void HudRenderer::drawModernHud(
   int viewportWidth,
-  const data::PlayerModel& playerModel,
+  const data::PersistentPlayerState& PersistentPlayerState,
   base::ArrayView<base::Vec2> radarPositions)
 {
   const auto screenWidth =
@@ -386,7 +386,7 @@ void HudRenderer::drawModernHud(
   const auto rightEdgeForFloatingParts =
     screenWidth - std::max(0, paddingForCentering);
   drawFloatingInventory(
-    playerModel.inventory(), {rightEdgeForFloatingParts - 2, 2});
+    PersistentPlayerState.inventory(), {rightEdgeForFloatingParts - 2, 2});
 
   if (mpOptions->mShowRadarInModernHud)
   {
@@ -414,22 +414,22 @@ void HudRenderer::drawModernHud(
   auto guard = renderer::saveState(mpRenderer);
   renderer::setLocalTranslation(mpRenderer, {paddingForCentering + 29, 0});
 
-  drawCollectedLetters(playerModel, {33, -23});
+  drawCollectedLetters(PersistentPlayerState, {33, -23});
 
   drawScore(
-    playerModel.score(),
+    PersistentPlayerState.score(),
     *mpStatusSpriteSheetRenderer,
     {2, GameTraits::mapViewportSize.height + 1});
   drawWeaponIcon(
-    playerModel.weapon(),
+    PersistentPlayerState.weapon(),
     *mpStatusSpriteSheetRenderer,
     {17, GameTraits::mapViewportSize.height + 1});
   drawAmmoBar(
-    playerModel.ammo(),
-    playerModel.currentMaxAmmo(),
+    PersistentPlayerState.ammo(),
+    PersistentPlayerState.currentMaxAmmo(),
     *mpStatusSpriteSheetRenderer,
     {22, GameTraits::mapViewportSize.height + 1});
-  drawHealthBar(playerModel, {24, GameTraits::mapViewportSize.height + 1});
+  drawHealthBar(PersistentPlayerState, {24, GameTraits::mapViewportSize.height + 1});
 
   if (mLevelNumber)
   {
@@ -445,7 +445,7 @@ void HudRenderer::drawModernHud(
 
 void HudRenderer::drawUltrawideHud(
   int viewportWidth,
-  const data::PlayerModel& playerModel,
+  const data::PersistentPlayerState& PersistentPlayerState,
   base::ArrayView<base::Vec2> radarPositions)
 {
   const auto screenWidth =
@@ -470,22 +470,22 @@ void HudRenderer::drawUltrawideHud(
     auto guard = renderer::saveState(mpRenderer);
     renderer::setLocalTranslation(mpRenderer, {paddingForCentering, yPos});
 
-    drawInventory(playerModel.inventory(), {6, 15});
-    drawCollectedLetters(playerModel, {64, -138});
+    drawInventory(PersistentPlayerState.inventory(), {6, 15});
+    drawCollectedLetters(PersistentPlayerState, {64, -138});
   }
 
   auto guard = renderer::saveState(mpRenderer);
   renderer::setLocalTranslation(mpRenderer, {paddingForCentering, yPos - 2});
 
   // These use the UI sprite sheet texture.
-  drawScore(playerModel.score(), *mpStatusSpriteSheetRenderer, {12, 6});
-  drawWeaponIcon(playerModel.weapon(), *mpStatusSpriteSheetRenderer, {27, 6});
+  drawScore(PersistentPlayerState.score(), *mpStatusSpriteSheetRenderer, {12, 6});
+  drawWeaponIcon(PersistentPlayerState.weapon(), *mpStatusSpriteSheetRenderer, {27, 6});
   drawAmmoBar(
-    playerModel.ammo(),
-    playerModel.currentMaxAmmo(),
+    PersistentPlayerState.ammo(),
+    PersistentPlayerState.currentMaxAmmo(),
     *mpStatusSpriteSheetRenderer,
     {32, 6});
-  drawHealthBar(playerModel, {34, 6});
+  drawHealthBar(PersistentPlayerState, {34, 6});
 
   if (mLevelNumber)
   {
@@ -603,7 +603,7 @@ void HudRenderer::drawFloatingInventory(
 
 
 void HudRenderer::drawHealthBar(
-  const data::PlayerModel& playerModel,
+  const data::PersistentPlayerState& PersistentPlayerState,
   const base::Vec2& position) const
 {
   // Health slices start at col 20, row 4. The first 9 are for the "0 health"
@@ -611,7 +611,7 @@ void HudRenderer::drawHealthBar(
 
   // The model has a range of 1-9 for health, but the HUD shows only 8
   // slices, with a special animation for having 1 point of health.
-  const auto numFullSlices = playerModel.health() - 1;
+  const auto numFullSlices = PersistentPlayerState.health() - 1;
   if (numFullSlices > 0)
   {
     for (int i = 0; i < NUM_HEALTH_SLICES; ++i)
@@ -636,7 +636,7 @@ void HudRenderer::drawHealthBar(
 
 
 void HudRenderer::drawCollectedLetters(
-  const data::PlayerModel& playerModel,
+  const data::PersistentPlayerState& PersistentPlayerState,
   const base::Vec2& position) const
 {
   auto guard = renderer::saveState(mpRenderer);
@@ -652,7 +652,7 @@ void HudRenderer::drawCollectedLetters(
     {position + data::tilesToPixels(base::Vec2{35, 24}) + base::Vec2{1, 5},
      {29, 6}});
 
-  for (const auto letter : playerModel.collectedLetters())
+  for (const auto letter : PersistentPlayerState.collectedLetters())
   {
     // The draw position is the same for all cases, because each actor
     // includes a draw offset in its actor info that positions it correctly.

--- a/src/ui/hud_renderer.hpp
+++ b/src/ui/hud_renderer.hpp
@@ -96,23 +96,23 @@ public:
   void updateAnimation();
 
   void renderClassicHud(
-    const data::PlayerModel& playerModel,
+    const data::PersistentPlayerState& PersistentPlayerState,
     base::ArrayView<base::Vec2> radarPositions);
 
   void renderWidescreenHud(
     int viewportWidth,
     data::WidescreenHudStyle style,
-    const data::PlayerModel& playerModel,
+    const data::PersistentPlayerState& PersistentPlayerState,
     base::ArrayView<base::Vec2> radarPositions);
 
 private:
   void drawModernHud(
     int viewportWidth,
-    const data::PlayerModel& playerModel,
+    const data::PersistentPlayerState& PersistentPlayerState,
     base::ArrayView<base::Vec2> radarPositions);
   void drawUltrawideHud(
     int viewportWidth,
-    const data::PlayerModel& playerModel,
+    const data::PersistentPlayerState& PersistentPlayerState,
     base::ArrayView<base::Vec2> radarPositions);
   void drawLeftSideExtension(int viewportWidth) const;
   void drawInventory(
@@ -122,10 +122,10 @@ private:
     const std::vector<data::InventoryItemType>& inventory,
     const base::Vec2& position) const;
   void drawHealthBar(
-    const data::PlayerModel& playerModel,
+    const data::PersistentPlayerState& PersistentPlayerState,
     const base::Vec2& position) const;
   void drawCollectedLetters(
-    const data::PlayerModel& playerModel,
+    const data::PersistentPlayerState& PersistentPlayerState,
     const base::Vec2& position) const;
   void drawRadar(
     base::ArrayView<base::Vec2> positions,

--- a/src/ui/ingame_menu.cpp
+++ b/src/ui/ingame_menu.cpp
@@ -79,15 +79,15 @@ constexpr int itemIndex(const std::string_view item)
 
 auto createSavedGame(
   const data::GameSessionId& sessionId,
-  const data::PlayerModel& playerModel)
+  const data::PersistentPlayerState& PersistentPlayerState)
 {
   return data::SavedGame{
     sessionId,
-    playerModel.tutorialMessages(),
+    PersistentPlayerState.tutorialMessages(),
     "", // will be filled in on saving
-    playerModel.weapon(),
-    playerModel.ammo(),
-    playerModel.score()};
+    PersistentPlayerState.weapon(),
+    PersistentPlayerState.ammo(),
+    PersistentPlayerState.score()};
 }
 
 
@@ -303,11 +303,11 @@ IngameMenu::SavedGameNameEntry::SavedGameNameEntry(
 
 IngameMenu::IngameMenu(
   GameMode::Context context,
-  const data::PlayerModel* pPlayerModel,
+  const data::PersistentPlayerState* pPersistentPlayerState,
   game_logic::IGameWorld* pGameWorld,
   const data::GameSessionId& sessionId)
   : mContext(context)
-  , mSavedGame(createSavedGame(sessionId, *pPlayerModel))
+  , mSavedGame(createSavedGame(sessionId, *pPersistentPlayerState))
   , mSessionId(sessionId)
   , mpGameWorld(pGameWorld)
 {

--- a/src/ui/ingame_menu.hpp
+++ b/src/ui/ingame_menu.hpp
@@ -59,7 +59,7 @@ public:
 
   IngameMenu(
     GameMode::Context context,
-    const data::PlayerModel* pPlayerModel,
+    const data::PersistentPlayerState* pPersistentPlayerState,
     game_logic::IGameWorld* pGameWorld,
     const data::GameSessionId& sessionId);
 

--- a/test/test_elevator.cpp
+++ b/test/test_elevator.cpp
@@ -100,7 +100,7 @@ TEST_CASE("Rocket elevator")
   }
 
   CollisionChecker collisionChecker{&map, entityx.entities, entityx.events};
-  data::PlayerModel playerModel;
+  data::PersistentPlayerState PersistentPlayerState;
   MockServiceProvider mockServiceProvider;
   engine::RandomNumberGenerator randomGenerator;
   MockSpriteFactory mockSpriteFactory;
@@ -121,7 +121,7 @@ TEST_CASE("Rocket elevator")
   Player player(
     playerEntity,
     data::Difficulty::Medium,
-    &playerModel,
+    &PersistentPlayerState,
     &mockServiceProvider,
     &options,
     &collisionChecker,

--- a/test/test_letter_collection.cpp
+++ b/test/test_letter_collection.cpp
@@ -31,7 +31,7 @@ using namespace data;
 using namespace std;
 
 using LT = CollectableLetterType;
-using S = PlayerModel::LetterCollectionState;
+using S = PersistentPlayerState::LetterCollectionState;
 using ExpectedState = pair<LT, S>;
 
 
@@ -54,7 +54,7 @@ vector<S> getStates(const vector<ExpectedState>& expectations)
 
 vector<S> collectLetters(const vector<LT>& letters)
 {
-  PlayerModel model;
+  PersistentPlayerState model;
 
   return utils::transformed(
     letters, [&model](const auto letter) { return model.addLetter(letter); });

--- a/test/test_player.cpp
+++ b/test/test_player.cpp
@@ -212,7 +212,7 @@ TEST_CASE("Player movement")
 
   CollisionChecker collisionChecker{&map, entityx.entities, entityx.events};
 
-  data::PlayerModel playerModel;
+  data::PersistentPlayerState PersistentPlayerState;
   MockEntityFactory mockEntityFactory{&entityx.entities};
   MockServiceProvider mockServiceProvider;
   engine::RandomNumberGenerator randomGenerator;
@@ -229,7 +229,7 @@ TEST_CASE("Player movement")
   Player player(
     playerEntity,
     data::Difficulty::Medium,
-    &playerModel,
+    &PersistentPlayerState,
     &mockServiceProvider,
     &options,
     &collisionChecker,
@@ -1837,7 +1837,7 @@ TEST_CASE("Player movement")
 
       SECTION("Laser shot")
       {
-        playerModel.switchToWeapon(data::WeaponType::Laser);
+        PersistentPlayerState.switchToWeapon(data::WeaponType::Laser);
 
         player.update(fireButtonTriggered);
         CHECK(lastFiredShot().type == ProjectileType::Laser);
@@ -1845,7 +1845,7 @@ TEST_CASE("Player movement")
 
       SECTION("Rocket shot")
       {
-        playerModel.switchToWeapon(data::WeaponType::Rocket);
+        PersistentPlayerState.switchToWeapon(data::WeaponType::Rocket);
 
         player.update(fireButtonTriggered);
         CHECK(lastFiredShot().type == ProjectileType::Rocket);
@@ -1853,7 +1853,7 @@ TEST_CASE("Player movement")
 
       SECTION("Flame shot")
       {
-        playerModel.switchToWeapon(data::WeaponType::FlameThrower);
+        PersistentPlayerState.switchToWeapon(data::WeaponType::FlameThrower);
 
         player.update(fireButtonTriggered);
         CHECK(lastFiredShot().type == ProjectileType::Flame);
@@ -1876,7 +1876,7 @@ TEST_CASE("Player movement")
 
       SECTION("Laser")
       {
-        playerModel.switchToWeapon(data::WeaponType::Laser);
+        PersistentPlayerState.switchToWeapon(data::WeaponType::Laser);
 
         player.update(fireButtonTriggered);
         REQUIRE(mockServiceProvider.mLastTriggeredSoundId != std::nullopt);
@@ -1887,7 +1887,7 @@ TEST_CASE("Player movement")
 
       SECTION("Rocket launcher")
       {
-        playerModel.switchToWeapon(data::WeaponType::Rocket);
+        PersistentPlayerState.switchToWeapon(data::WeaponType::Rocket);
 
         // The rocket launcher also uses the normal shot sound
         player.update(fireButtonTriggered);
@@ -1899,7 +1899,7 @@ TEST_CASE("Player movement")
 
       SECTION("Flame thrower")
       {
-        playerModel.switchToWeapon(data::WeaponType::FlameThrower);
+        PersistentPlayerState.switchToWeapon(data::WeaponType::FlameThrower);
 
         player.update(fireButtonTriggered);
         REQUIRE(mockServiceProvider.mLastTriggeredSoundId != std::nullopt);
@@ -1910,8 +1910,8 @@ TEST_CASE("Player movement")
 
       SECTION("Last shot before ammo depletion still uses appropriate sound")
       {
-        playerModel.switchToWeapon(data::WeaponType::Laser);
-        playerModel.setAmmo(1);
+        PersistentPlayerState.switchToWeapon(data::WeaponType::Laser);
+        PersistentPlayerState.setAmmo(1);
 
         player.update(fireButtonTriggered);
 
@@ -1930,42 +1930,42 @@ TEST_CASE("Player movement")
     {
       SECTION("Normal shot doesn't consume ammo")
       {
-        playerModel.setAmmo(24);
+        PersistentPlayerState.setAmmo(24);
         fireOneShot();
-        CHECK(playerModel.ammo() == 24);
+        CHECK(PersistentPlayerState.ammo() == 24);
       }
 
       SECTION("Laser consumes 1 unit of ammo per shot")
       {
-        playerModel.switchToWeapon(data::WeaponType::Laser);
-        playerModel.setAmmo(10);
+        PersistentPlayerState.switchToWeapon(data::WeaponType::Laser);
+        PersistentPlayerState.setAmmo(10);
 
         fireOneShot();
-        CHECK(playerModel.ammo() == 9);
+        CHECK(PersistentPlayerState.ammo() == 9);
       }
 
       SECTION("Rocket launcher consumes 1 unit of ammo per shot")
       {
-        playerModel.switchToWeapon(data::WeaponType::Rocket);
-        playerModel.setAmmo(10);
+        PersistentPlayerState.switchToWeapon(data::WeaponType::Rocket);
+        PersistentPlayerState.setAmmo(10);
 
         fireOneShot();
-        CHECK(playerModel.ammo() == 9);
+        CHECK(PersistentPlayerState.ammo() == 9);
       }
 
       SECTION("Flame thrower consumes 1 unit of ammo per shot")
       {
-        playerModel.switchToWeapon(data::WeaponType::FlameThrower);
-        playerModel.setAmmo(10);
+        PersistentPlayerState.switchToWeapon(data::WeaponType::FlameThrower);
+        PersistentPlayerState.setAmmo(10);
 
         fireOneShot();
-        CHECK(playerModel.ammo() == 9);
+        CHECK(PersistentPlayerState.ammo() == 9);
       }
 
       SECTION("Multiple shots consume several units of ammo")
       {
-        playerModel.switchToWeapon(data::WeaponType::Laser);
-        playerModel.setAmmo(20);
+        PersistentPlayerState.switchToWeapon(data::WeaponType::Laser);
+        PersistentPlayerState.setAmmo(20);
 
         const auto shotsToFire = 15;
         for (int i = 0; i < shotsToFire; ++i)
@@ -1973,25 +1973,25 @@ TEST_CASE("Player movement")
           fireOneShot();
         }
 
-        CHECK(playerModel.ammo() == 20 - shotsToFire);
+        CHECK(PersistentPlayerState.ammo() == 20 - shotsToFire);
       }
 
       SECTION("Depleting ammo switches back to normal weapon")
       {
-        playerModel.switchToWeapon(data::WeaponType::Rocket);
-        playerModel.setAmmo(1);
+        PersistentPlayerState.switchToWeapon(data::WeaponType::Rocket);
+        PersistentPlayerState.setAmmo(1);
 
         fireOneShot();
 
-        CHECK(playerModel.weapon() == data::WeaponType::Normal);
-        CHECK(playerModel.ammo() == playerModel.currentMaxAmmo());
+        CHECK(PersistentPlayerState.weapon() == data::WeaponType::Normal);
+        CHECK(PersistentPlayerState.ammo() == PersistentPlayerState.currentMaxAmmo());
       }
     }
 
     SECTION(
       "Player fires continuously every other frame when owning rapid fire buff")
     {
-      playerModel.giveItem(data::InventoryItemType::RapidFire);
+      PersistentPlayerState.giveItem(data::InventoryItemType::RapidFire);
 
       player.update(pressingFire & fireButtonTriggered);
       CHECK(fireShotSpy.size() == 1);
@@ -2009,7 +2009,7 @@ TEST_CASE("Player movement")
 
     SECTION("Firing stops when rapid fire is taken away")
     {
-      playerModel.giveItem(data::InventoryItemType::RapidFire);
+      PersistentPlayerState.giveItem(data::InventoryItemType::RapidFire);
 
       for (int i = 0; i < 700; ++i)
       {
@@ -2017,7 +2017,7 @@ TEST_CASE("Player movement")
       }
       CHECK(fireShotSpy.size() == 350);
 
-      playerModel.removeItem(data::InventoryItemType::RapidFire);
+      PersistentPlayerState.removeItem(data::InventoryItemType::RapidFire);
 
       for (int i = 0; i < 2; ++i)
       {

--- a/test/test_spike_ball.cpp
+++ b/test/test_spike_ball.cpp
@@ -105,11 +105,11 @@ TEST_CASE("Spike ball")
   playerEntity.assign<Sprite>();
   assignPlayerComponents(playerEntity, Orientation::Left);
 
-  data::PlayerModel playerModel;
+  data::PersistentPlayerState PersistentPlayerState;
   Player player(
     playerEntity,
     data::Difficulty::Medium,
-    &playerModel,
+    &PersistentPlayerState,
     &mockServiceProvider,
     &options,
     &collisionChecker,


### PR DESCRIPTION
## summary
1. Addresses and closes #878
2. Renames `PlayerModel` class and types of `PlayerModel*` to `PersistentPlayerState`
3. Rename`mpPlayerModel -> mpPersistentPlayerState`, `pPlayerModel -> pPersistentPlayerState`