### PR TITLE
Rename `PlayerModel` class to `PersistentPlayerState`

### DIFF
--- a/src/data/bonus.hpp
+++ b/src/data/bonus.hpp
@@ -47,11 +47,12 @@ constexpr int asNumber(const Bonus bonus)
 }
 
 
-inline void
-  addBonusScore(PlayerModel& playerModel, const std::set<Bonus>& bonuses)
+inline void addBonusScore(
+  PersistentPlayerState& persistentPlayerState,
+  const std::set<Bonus>& bonuses)
 {
   const auto numBonuses = static_cast<int>(bonuses.size());
-  playerModel.giveScore(numBonuses * SCORE_ADDED_PER_BONUS);
+  persistentPlayerState.giveScore(numBonuses * SCORE_ADDED_PER_BONUS);
 }
 
 } // namespace rigel::data

--- a/src/data/player_model.cpp
+++ b/src/data/player_model.cpp
@@ -25,7 +25,7 @@
 namespace rigel::data
 {
 
-PlayerModel::PlayerModel()
+PersistentPlayerState::PersistentPlayerState()
   : mWeapon(WeaponType::Normal)
   , mScore(0)
   , mAmmo(MAX_AMMO)
@@ -34,7 +34,7 @@ PlayerModel::PlayerModel()
 }
 
 
-PlayerModel::PlayerModel(const SavedGame& save)
+PersistentPlayerState::PersistentPlayerState(const SavedGame& save)
   : mTutorialMessages(save.mTutorialMessagesAlreadySeen)
   , mWeapon(save.mWeapon)
   , mScore(save.mScore)
@@ -44,13 +44,14 @@ PlayerModel::PlayerModel(const SavedGame& save)
 }
 
 
-PlayerModel::CheckpointState PlayerModel::makeCheckpoint() const
+PersistentPlayerState::CheckpointState
+  PersistentPlayerState::makeCheckpoint() const
 {
   return CheckpointState{mWeapon, mAmmo, mHealth};
 }
 
 
-void PlayerModel::restoreFromCheckpoint(const CheckpointState& state)
+void PersistentPlayerState::restoreFromCheckpoint(const CheckpointState& state)
 {
   mHealth = std::max(2, state.mHealth);
   mWeapon = state.mWeapon;
@@ -58,51 +59,51 @@ void PlayerModel::restoreFromCheckpoint(const CheckpointState& state)
 }
 
 
-int PlayerModel::score() const
+int PersistentPlayerState::score() const
 {
   return mScore;
 }
 
 
-void PlayerModel::giveScore(const int amount)
+void PersistentPlayerState::giveScore(const int amount)
 {
   mScore = std::clamp(mScore + amount, 0, MAX_SCORE);
 }
 
 
-int PlayerModel::ammo() const
+int PersistentPlayerState::ammo() const
 {
   return mAmmo;
 }
 
 
-int PlayerModel::currentMaxAmmo() const
+int PersistentPlayerState::currentMaxAmmo() const
 {
   return mWeapon == WeaponType::FlameThrower ? MAX_AMMO_FLAME_THROWER
                                              : MAX_AMMO;
 }
 
 
-WeaponType PlayerModel::weapon() const
+WeaponType PersistentPlayerState::weapon() const
 {
   return mWeapon;
 }
 
 
-bool PlayerModel::currentWeaponConsumesAmmo() const
+bool PersistentPlayerState::currentWeaponConsumesAmmo() const
 {
   return mWeapon != WeaponType::Normal;
 }
 
 
-void PlayerModel::switchToWeapon(const WeaponType type)
+void PersistentPlayerState::switchToWeapon(const WeaponType type)
 {
   mWeapon = type;
   mAmmo = currentMaxAmmo();
 }
 
 
-void PlayerModel::useAmmo()
+void PersistentPlayerState::useAmmo()
 {
   if (currentWeaponConsumesAmmo())
   {
@@ -115,56 +116,56 @@ void PlayerModel::useAmmo()
 }
 
 
-void PlayerModel::setAmmo(int amount)
+void PersistentPlayerState::setAmmo(int amount)
 {
   assert(amount >= 0 && amount <= currentMaxAmmo());
   mAmmo = amount;
 }
 
 
-int PlayerModel::health() const
+int PersistentPlayerState::health() const
 {
   return mHealth;
 }
 
 
-bool PlayerModel::isAtFullHealth() const
+bool PersistentPlayerState::isAtFullHealth() const
 {
   return mHealth == MAX_HEALTH;
 }
 
 
-bool PlayerModel::isDead() const
+bool PersistentPlayerState::isDead() const
 {
   return mHealth <= 0;
 }
 
 
-void PlayerModel::takeDamage(const int amount)
+void PersistentPlayerState::takeDamage(const int amount)
 {
   mHealth = std::clamp(mHealth - amount, 0, MAX_HEALTH);
 }
 
 
-void PlayerModel::takeFatalDamage()
+void PersistentPlayerState::takeFatalDamage()
 {
   mHealth = 0;
 }
 
 
-void PlayerModel::giveHealth(const int amount)
+void PersistentPlayerState::giveHealth(const int amount)
 {
   mHealth = std::clamp(mHealth + amount, 0, MAX_HEALTH);
 }
 
 
-const std::vector<InventoryItemType>& PlayerModel::inventory() const
+const std::vector<InventoryItemType>& PersistentPlayerState::inventory() const
 {
   return mInventory;
 }
 
 
-bool PlayerModel::hasItem(const InventoryItemType type) const
+bool PersistentPlayerState::hasItem(const InventoryItemType type) const
 {
   using namespace std;
 
@@ -172,7 +173,7 @@ bool PlayerModel::hasItem(const InventoryItemType type) const
 }
 
 
-void PlayerModel::giveItem(InventoryItemType type)
+void PersistentPlayerState::giveItem(InventoryItemType type)
 {
   using namespace std;
 
@@ -191,7 +192,7 @@ void PlayerModel::giveItem(InventoryItemType type)
 }
 
 
-void PlayerModel::removeItem(const InventoryItemType type)
+void PersistentPlayerState::removeItem(const InventoryItemType type)
 {
   using namespace std;
 
@@ -203,14 +204,15 @@ void PlayerModel::removeItem(const InventoryItemType type)
 }
 
 
-const std::vector<CollectableLetterType>& PlayerModel::collectedLetters() const
+const std::vector<CollectableLetterType>&
+  PersistentPlayerState::collectedLetters() const
 {
   return mCollectedLetters;
 }
 
 
-PlayerModel::LetterCollectionState
-  PlayerModel::addLetter(const CollectableLetterType type)
+PersistentPlayerState::LetterCollectionState
+  PersistentPlayerState::addLetter(const CollectableLetterType type)
 {
   using L = CollectableLetterType;
   static std::vector<L> sExpectedOrder = {L::N, L::U, L::K, L::E, L::M};
@@ -231,7 +233,7 @@ PlayerModel::LetterCollectionState
 }
 
 
-void PlayerModel::resetForNewLevel()
+void PersistentPlayerState::resetForNewLevel()
 {
   mHealth = MAX_HEALTH;
   mCollectedLetters.clear();
@@ -239,20 +241,20 @@ void PlayerModel::resetForNewLevel()
 }
 
 
-void PlayerModel::resetHealthAndScore()
+void PersistentPlayerState::resetHealthAndScore()
 {
   mHealth = MAX_HEALTH;
   mScore = 0;
 }
 
 
-TutorialMessageState& PlayerModel::tutorialMessages()
+TutorialMessageState& PersistentPlayerState::tutorialMessages()
 {
   return mTutorialMessages;
 }
 
 
-const TutorialMessageState& PlayerModel::tutorialMessages() const
+const TutorialMessageState& PersistentPlayerState::tutorialMessages() const
 {
   return mTutorialMessages;
 }

--- a/src/data/player_model.hpp
+++ b/src/data/player_model.hpp
@@ -68,7 +68,7 @@ constexpr auto MAX_AMMO_FLAME_THROWER = 64;
 constexpr auto MAX_HEALTH = 9;
 
 
-class PlayerModel
+class PersistentPlayerState
 {
 public:
   struct CheckpointState
@@ -85,8 +85,8 @@ public:
     InOrder
   };
 
-  PlayerModel();
-  explicit PlayerModel(const SavedGame& save);
+  PersistentPlayerState();
+  explicit PersistentPlayerState(const SavedGame& save);
 
   CheckpointState makeCheckpoint() const;
   void restoreFromCheckpoint(const CheckpointState& state);

--- a/src/frontend/demo_player.cpp
+++ b/src/frontend/demo_player.cpp
@@ -112,7 +112,7 @@ void DemoPlayer::updateAndRender(const engine::TimeDelta dt)
   if (!mpWorld)
   {
     mpWorld = std::make_unique<GameWorld_Classic>(
-      &mPlayerModel,
+      &mPersistentPlayerState,
       demoSessionId(0),
       mContext,
       std::nullopt,
@@ -144,10 +144,10 @@ void DemoPlayer::updateAndRender(const engine::TimeDelta dt)
 
     ++mLevelIndex;
 
-    mPlayerModel.resetForNewLevel();
+    mPersistentPlayerState.resetForNewLevel();
 
     mpWorld = std::make_unique<GameWorld_Classic>(
-      &mPlayerModel,
+      &mPersistentPlayerState,
       demoSessionId(mLevelIndex),
       mContext,
       std::nullopt,

--- a/src/frontend/demo_player.hpp
+++ b/src/frontend/demo_player.hpp
@@ -53,7 +53,7 @@ public:
 
 private:
   GameMode::Context mContext;
-  data::PlayerModel mPlayerModel;
+  data::PersistentPlayerState mPersistentPlayerState;
 
   std::vector<DemoInput> mFrames;
   std::size_t mCurrentFrameIndex = 1;

--- a/src/frontend/game_runner.cpp
+++ b/src/frontend/game_runner.cpp
@@ -51,7 +51,7 @@ std::unique_ptr<game_logic::IGameWorld>
 
 
 GameRunner::GameRunner(
-  data::PlayerModel* pPlayerModel,
+  data::PersistentPlayerState* pPersistentPlayerState,
   const data::GameSessionId& sessionId,
   GameMode::Context context,
   const std::optional<base::Vec2> playerPositionOverride,
@@ -59,13 +59,13 @@ GameRunner::GameRunner(
   : mContext(context)
   , mpWorld(createGameWorld(
       context.mpUserProfile->mOptions.mGameplayStyle,
-      pPlayerModel,
+      pPersistentPlayerState,
       sessionId,
       context,
       playerPositionOverride,
       showWelcomeMessage))
   , mInputHandler(&context.mpUserProfile->mOptions)
-  , mMenu(context, pPlayerModel, mpWorld.get(), sessionId)
+  , mMenu(context, pPersistentPlayerState, mpWorld.get(), sessionId)
 {
 }
 

--- a/src/frontend/game_runner.hpp
+++ b/src/frontend/game_runner.hpp
@@ -40,7 +40,7 @@ class GameRunner
 {
 public:
   GameRunner(
-    data::PlayerModel* pPlayerModel,
+    data::PersistentPlayerState* pPersistentPlayerState,
     const data::GameSessionId& sessionId,
     GameMode::Context context,
     std::optional<base::Vec2> playerPositionOverride = std::nullopt,

--- a/src/frontend/game_session_mode.hpp
+++ b/src/frontend/game_session_mode.hpp
@@ -53,7 +53,7 @@ public:
 private:
   GameSessionMode(
     const data::GameSessionId& sessionId,
-    data::PlayerModel playerModel,
+    data::PersistentPlayerState persistentPlayerState,
     Context context);
 
   void handleEvent(const SDL_Event& event);
@@ -79,7 +79,7 @@ private:
     HighScoreNameEntry,
     HighScoreListDisplay>;
 
-  data::PlayerModel mPlayerModel;
+  data::PersistentPlayerState mPersistentPlayerState;
   SessionStage mCurrentStage;
   const int mEpisode;
   int mCurrentLevelNr;

--- a/src/game_logic/damage_infliction_system.cpp
+++ b/src/game_logic/damage_infliction_system.cpp
@@ -53,10 +53,10 @@ auto extractVelocity(entityx::Entity entity)
 
 
 DamageInflictionSystem::DamageInflictionSystem(
-  data::PlayerModel* pPlayerModel,
+  data::PersistentPlayerState* pPersistentPlayerState,
   IGameServiceProvider* pServiceProvider,
   entityx::EventManager* pEvents)
-  : mpPlayerModel(pPlayerModel)
+  : mpPersistentPlayerState(pPersistentPlayerState)
   , mpServiceProvider(pServiceProvider)
   , mpEvents(pEvents)
 {
@@ -139,7 +139,7 @@ void DamageInflictionSystem::inflictDamage(
     // Event listeners mustn't remove the shootable component
     assert(shootableEntity.has_component<Shootable>());
 
-    mpPlayerModel->giveScore(shootable.mGivenScore);
+    mpPersistentPlayerState->giveScore(shootable.mGivenScore);
 
     if (shootable.mDestroyWhenKilled)
     {

--- a/src/game_logic/damage_infliction_system.hpp
+++ b/src/game_logic/damage_infliction_system.hpp
@@ -31,7 +31,7 @@ struct IGameServiceProvider;
 
 namespace rigel::data
 {
-class PlayerModel;
+class PersistentPlayerState;
 }
 
 
@@ -42,7 +42,7 @@ class DamageInflictionSystem
 {
 public:
   DamageInflictionSystem(
-    data::PlayerModel* pPlayerModel,
+    data::PersistentPlayerState* pPersistentPlayerState,
     IGameServiceProvider* pServiceProvider,
     entityx::EventManager* pEvents);
 
@@ -55,7 +55,7 @@ private:
     entityx::Entity shootableEntity,
     components::Shootable& shootable);
 
-  data::PlayerModel* mpPlayerModel;
+  data::PersistentPlayerState* mpPersistentPlayerState;
   IGameServiceProvider* mpServiceProvider;
   entityx::EventManager* mpEvents;
 };

--- a/src/game_logic/game_world.cpp
+++ b/src/game_logic/game_world.cpp
@@ -57,7 +57,7 @@ namespace rigel::game_logic
 using namespace engine;
 using namespace std;
 
-using data::PlayerModel;
+using data::PersistentPlayerState;
 using engine::components::InterpolateMotion;
 using engine::components::WorldPosition;
 
@@ -207,7 +207,7 @@ base::Size clampedSectionSize(
 
 
 GameWorld::GameWorld(
-  data::PlayerModel* pPlayerModel,
+  data::PersistentPlayerState* pPersistentPlayerState,
   const data::GameSessionId& sessionId,
   GameMode::Context context,
   std::optional<base::Vec2> playerPositionOverride,
@@ -220,12 +220,12 @@ GameWorld::GameWorld(
       data::GameTraits::viewportSize,
       mpRenderer)
   , mTextRenderer(&mUiSpriteSheet, mpRenderer, *context.mpResources)
-  , mpPlayerModel(pPlayerModel)
+  , mpPersistentPlayerState(pPersistentPlayerState)
   , mpOptions(&context.mpUserProfile->mOptions)
   , mpResources(context.mpResources)
   , mpSpriteFactory(context.mpSpriteFactory)
   , mSessionId(sessionId)
-  , mPlayerModelAtLevelStart(*mpPlayerModel)
+  , mPlayerModelAtLevelStart(*mpPersistentPlayerState)
   , mHudRenderer(
       sessionId.mLevel + 1,
       mpOptions,
@@ -354,7 +354,7 @@ std::set<data::Bonus> GameWorld::achievedBonuses() const
 void GameWorld::receive(const rigel::events::CheckPointActivated& event)
 {
   mpState->mActivatedCheckpoint =
-    CheckpointData{mpPlayerModel->makeCheckpoint(), event.mPosition};
+    CheckpointData{mpPersistentPlayerState->makeCheckpoint(), event.mPosition};
   mMessageDisplay.setMessage(data::Messages::FoundRespawnBeacon);
 }
 
@@ -511,7 +511,7 @@ void GameWorld::createNewState()
     mpServiceProvider,
     mpRenderer,
     mpResources,
-    mpPlayerModel,
+    mpPersistentPlayerState,
     mpOptions,
     mpSpriteFactory,
     mSessionId);
@@ -763,14 +763,17 @@ void GameWorld::render(const float interpolationFactor)
   auto drawHud = [&, this]() {
     const auto radarDots =
       collectRadarDots(mpState->mEntities, mpState->mPlayer.orientedPosition());
-    mHudRenderer.renderClassicHud(*mpPlayerModel, radarDots);
+    mHudRenderer.renderClassicHud(*mpPersistentPlayerState, radarDots);
   };
 
   auto drawWidescreenHud = [&](const int viewportWidth) {
     const auto radarDots =
       collectRadarDots(mpState->mEntities, mpState->mPlayer.orientedPosition());
     mHudRenderer.renderWidescreenHud(
-      viewportWidth, mpOptions->mWidescreenHudStyle, *mpPlayerModel, radarDots);
+      viewportWidth,
+      mpOptions->mWidescreenHudStyle,
+      *mpPersistentPlayerState,
+      radarDots);
   };
 
 
@@ -1073,7 +1076,7 @@ void GameWorld::debugToggleGridDisplay()
 
 void GameWorld::activateFullHealthCheat()
 {
-  mpPlayerModel->resetHealthAndScore();
+  mpPersistentPlayerState->resetHealthAndScore();
 }
 
 
@@ -1105,14 +1108,14 @@ void GameWorld::activateGiveItemsCheat()
             inventoryItem == data::InventoryItemType::BlueKey ||
             inventoryItem == data::InventoryItemType::CircuitBoard)
           {
-            mpPlayerModel->giveItem(inventoryItem);
+            mpPersistentPlayerState->giveItem(inventoryItem);
             entity.destroy();
           }
           else if (
             inventoryItem == data::InventoryItemType::CloakingDevice &&
             !mpState->mPlayer.isCloaked())
           {
-            mpPlayerModel->giveItem(inventoryItem);
+            mpPersistentPlayerState->giveItem(inventoryItem);
           }
         },
 
@@ -1127,7 +1130,7 @@ void GameWorld::activateGiveItemsCheat()
 
   if (weaponToGive)
   {
-    mpPlayerModel->switchToWeapon(*weaponToGive);
+    mpPersistentPlayerState->switchToWeapon(*weaponToGive);
   }
 }
 
@@ -1145,15 +1148,15 @@ void GameWorld::quickSave()
     mpServiceProvider,
     mpRenderer,
     mpResources,
-    mpPlayerModel,
+    mpPersistentPlayerState,
     mpOptions,
     mpSpriteFactory,
     mSessionId);
   pStateCopy->synchronizeTo(
-    *mpState, mpServiceProvider, mpPlayerModel, mSessionId);
+    *mpState, mpServiceProvider, mpPersistentPlayerState, mSessionId);
 
   mpQuickSave = std::make_unique<QuickSaveData>(
-    QuickSaveData{*mpPlayerModel, std::move(pStateCopy)});
+    QuickSaveData{*mpPersistentPlayerState, std::move(pStateCopy)});
 
   mMessageDisplay.setMessage(
     data::Messages::QuickSaved, ui::MessagePriority::Menu);
@@ -1171,9 +1174,12 @@ void GameWorld::quickLoad()
 
   LOG_F(INFO, "Loading quick save");
 
-  *mpPlayerModel = mpQuickSave->mPlayerModel;
+  *mpPersistentPlayerState = mpQuickSave->mPersistentPlayerState;
   mpState->synchronizeTo(
-    *mpQuickSave->mpState, mpServiceProvider, mpPlayerModel, mSessionId);
+    *mpQuickSave->mpState,
+    mpServiceProvider,
+    mpPersistentPlayerState,
+    mSessionId);
   mpState->mPreviousCameraPosition = mpState->mCamera.position();
   mMessageDisplay.setMessage(
     data::Messages::QuickLoaded, ui::MessagePriority::Menu);
@@ -1270,7 +1276,7 @@ void GameWorld::restartLevel()
 {
   mpServiceProvider->fadeOutScreen();
 
-  *mpPlayerModel = mPlayerModelAtLevelStart;
+  *mpPersistentPlayerState = mPlayerModelAtLevelStart;
   loadLevel({});
 
   if (mpState->mRadarDishCounter.radarDishesPresent())
@@ -1296,7 +1302,8 @@ void GameWorld::restartFromCheckpoint()
     mpState->mBackdropSwitched = false;
   }
 
-  mpPlayerModel->restoreFromCheckpoint(mpState->mActivatedCheckpoint->mState);
+  mpPersistentPlayerState->restoreFromCheckpoint(
+    mpState->mActivatedCheckpoint->mState);
   mpState->mPlayer.reSpawnAt(mpState->mActivatedCheckpoint->mPosition);
 
   mpState->mCamera.centerViewOnPlayer();
@@ -1338,10 +1345,10 @@ void GameWorld::handleTeleporter()
 
 void GameWorld::showTutorialMessage(const data::TutorialMessageId id)
 {
-  if (!mpPlayerModel->tutorialMessages().hasBeenShown(id))
+  if (!mpPersistentPlayerState->tutorialMessages().hasBeenShown(id))
   {
     mMessageDisplay.setMessage(data::messageText(id));
-    mpPlayerModel->tutorialMessages().markAsShown(id);
+    mpPersistentPlayerState->tutorialMessages().markAsShown(id);
   }
 }
 

--- a/src/game_logic/game_world.hpp
+++ b/src/game_logic/game_world.hpp
@@ -66,7 +66,7 @@ class GameWorld : public IGameWorld, public entityx::Receiver<GameWorld>
 {
 public:
   GameWorld(
-    data::PlayerModel* pPlayerModel,
+    data::PersistentPlayerState* pPersistentPlayerState,
     const data::GameSessionId& sessionId,
     GameMode::Context context,
     std::optional<base::Vec2> playerPositionOverride = std::nullopt,
@@ -154,7 +154,7 @@ private:
 
   struct QuickSaveData
   {
-    data::PlayerModel mPlayerModel;
+    data::PersistentPlayerState mPersistentPlayerState;
     std::unique_ptr<WorldState> mpState;
   };
 
@@ -162,13 +162,13 @@ private:
   IGameServiceProvider* mpServiceProvider;
   engine::TiledTexture mUiSpriteSheet;
   ui::MenuElementRenderer mTextRenderer;
-  data::PlayerModel* mpPlayerModel;
+  data::PersistentPlayerState* mpPersistentPlayerState;
   const data::GameOptions* mpOptions;
   const assets::ResourceLoader* mpResources;
   engine::SpriteFactory* mpSpriteFactory;
   data::GameSessionId mSessionId;
 
-  data::PlayerModel mPlayerModelAtLevelStart;
+  data::PersistentPlayerState mPlayerModelAtLevelStart;
   ui::HudRenderer mHudRenderer;
   ui::IngameMessageDisplay mMessageDisplay;
   engine::SpecialEffectsRenderer mSpecialEffects;

--- a/src/game_logic/player.cpp
+++ b/src/game_logic/player.cpp
@@ -316,7 +316,7 @@ std::optional<int> recoilAnimationFrame(const VisualState state)
 Player::Player(
   ex::Entity entity,
   const data::Difficulty difficulty,
-  data::PlayerModel* pPlayerModel,
+  data::PersistentPlayerState* pPersistentPlayerState,
   IGameServiceProvider* pServiceProvider,
   const data::GameOptions* pOptions,
   const engine::CollisionChecker* pCollisionChecker,
@@ -325,7 +325,7 @@ Player::Player(
   ex::EventManager* pEvents,
   engine::RandomNumberGenerator* pRandomGenerator)
   : mEntity(entity)
-  , mpPlayerModel(pPlayerModel)
+  , mpPersistentPlayerState(pPersistentPlayerState)
   , mpServiceProvider(pServiceProvider)
   , mpCollisionChecker(pCollisionChecker)
   , mpMap(pMap)
@@ -403,7 +403,8 @@ bool Player::isInMercyFrames() const
 
 bool Player::isCloaked() const
 {
-  return mpPlayerModel->hasItem(data::InventoryItemType::CloakingDevice);
+  return mpPersistentPlayerState->hasItem(
+    data::InventoryItemType::CloakingDevice);
 }
 
 
@@ -650,8 +651,8 @@ void Player::takeDamage(const int amount)
   }
 
   mpEvents->emit(rigel::events::PlayerTookDamage{});
-  mpPlayerModel->takeDamage(amount);
-  if (!mpPlayerModel->isDead())
+  mpPersistentPlayerState->takeDamage(amount);
+  if (!mpPersistentPlayerState->isDead())
   {
     mMercyFramesRemaining = mMercyFramesPerHit;
     mpServiceProvider->playSound(data::SoundId::DukePain);
@@ -685,8 +686,8 @@ void Player::die()
     exitShip();
   }
 
-  mpPlayerModel->takeFatalDamage();
-  mpPlayerModel->removeItem(data::InventoryItemType::CloakingDevice);
+  mpPersistentPlayerState->takeFatalDamage();
+  mpPersistentPlayerState->removeItem(data::InventoryItemType::CloakingDevice);
   mpEvents->emit(rigel::events::CloakExpired{});
 
   auto& sprite = *mEntity.component<c::Sprite>();
@@ -827,7 +828,7 @@ void Player::updateTemporaryItemExpiration()
                             const InventoryItemType itemType,
                             const char* message,
                             int& framesElapsedHavingItem) {
-    if (mpPlayerModel->hasItem(itemType))
+    if (mpPersistentPlayerState->hasItem(itemType))
     {
       ++framesElapsedHavingItem;
       if (framesElapsedHavingItem == ITEM_ABOUT_TO_EXPIRE_TIME)
@@ -837,7 +838,7 @@ void Player::updateTemporaryItemExpiration()
 
       if (framesElapsedHavingItem >= TEMPORARY_ITEM_EXPIRATION_TIME)
       {
-        mpPlayerModel->removeItem(itemType);
+        mpPersistentPlayerState->removeItem(itemType);
         framesElapsedHavingItem = 0;
 
         if (itemType == InventoryItemType::CloakingDevice)
@@ -901,7 +902,7 @@ void Player::updateMovement(
   // clang-format off
   const auto shouldActivateJetpack =
     canFire() &&
-    mpPlayerModel->weapon() == data::WeaponType::FlameThrower &&
+    mpPersistentPlayerState->weapon() == data::WeaponType::FlameThrower &&
     movementVector.y > 0 &&
     fireButton.mIsPressed;
   // clang-format on
@@ -1285,8 +1286,8 @@ void Player::updateJumpButtonStateTracking(const Button& jumpButton)
 void Player::updateShooting(const Button& fireButton)
 {
   const auto hasRapidFire = stateIs<InShip>() ||
-    mpPlayerModel->hasItem(data::InventoryItemType::RapidFire) ||
-    mpPlayerModel->weapon() == data::WeaponType::FlameThrower;
+    mpPersistentPlayerState->hasItem(data::InventoryItemType::RapidFire) ||
+    mpPersistentPlayerState->weapon() == data::WeaponType::FlameThrower;
 
   if (!canFire())
   {
@@ -1823,13 +1824,13 @@ void Player::fireShot()
   }
   else
   {
-    const auto weaponType = mpPlayerModel->weapon();
+    const auto weaponType = mpPersistentPlayerState->weapon();
 
     mpEntityFactory->spawnProjectile(
       projectileTypeForWeapon(weaponType),
       position + shotOffset(orientation(), mStance),
       direction);
-    mpPlayerModel->useAmmo();
+    mpPersistentPlayerState->useAmmo();
 
     mpServiceProvider->playSound(soundIdForWeapon(weaponType));
     spawnOneShotSprite(

--- a/src/game_logic/player.hpp
+++ b/src/game_logic/player.hpp
@@ -39,7 +39,7 @@ struct IGameServiceProvider;
 namespace data
 {
 struct GameOptions;
-class PlayerModel;
+class PersistentPlayerState;
 
 namespace map
 {
@@ -244,7 +244,7 @@ public:
   Player(
     entityx::Entity entity,
     data::Difficulty difficulty,
-    data::PlayerModel* pModel,
+    data::PersistentPlayerState* pPersistentPlayerState,
     IGameServiceProvider* pServiceProvider,
     const data::GameOptions* pOptions,
     const engine::CollisionChecker* pCollisionChecker,
@@ -311,7 +311,7 @@ public:
 
   base::Vec2& position();
 
-  data::PlayerModel& model() { return *mpPlayerModel; }
+  data::PersistentPlayerState& model() { return *mpPersistentPlayerState; }
 
   const entityx::Entity& entity() const { return mEntity; }
 
@@ -389,7 +389,7 @@ private:
   PlayerState mState;
   entityx::Entity mEntity;
   entityx::Entity mAttachedElevator;
-  data::PlayerModel* mpPlayerModel;
+  data::PersistentPlayerState* mpPersistentPlayerState;
   IGameServiceProvider* mpServiceProvider;
   const engine::CollisionChecker* mpCollisionChecker;
   const data::map::Map* mpMap;

--- a/src/game_logic/player/interaction_system.cpp
+++ b/src/game_logic/player/interaction_system.cpp
@@ -34,7 +34,7 @@
 namespace rigel::game_logic
 {
 
-using data::PlayerModel;
+using data::PersistentPlayerState;
 using engine::components::AnimationLoop;
 using engine::components::BoundingBox;
 using engine::components::Sprite;
@@ -210,13 +210,13 @@ ex::Entity currentlyTouchedInteractable(
 PlayerInteractionSystem::PlayerInteractionSystem(
   const data::GameSessionId& sessionId,
   Player* pPlayer,
-  PlayerModel* pPlayerModel,
+  PersistentPlayerState* pPersistentPlayerState,
   IGameServiceProvider* pServices,
   IEntityFactory* pEntityFactory,
   entityx::EventManager* pEvents,
   const assets::ResourceLoader& resources)
   : mpPlayer(pPlayer)
-  , mpPlayerModel(pPlayerModel)
+  , mpPersistentPlayerState(pPersistentPlayerState)
   , mpServiceProvider(pServices)
   , mpEntityFactory(pEntityFactory)
   , mpEvents(pEvents)
@@ -283,12 +283,13 @@ void PlayerInteractionSystem::updateItemCollection(entityx::EntityManager& es)
       {
         std::optional<data::SoundId> soundToPlay;
 
-        const auto playerAtFullHealth = mpPlayerModel->isAtFullHealth();
+        const auto playerAtFullHealth =
+          mpPersistentPlayerState->isAtFullHealth();
         if (auto maybeScore = givenScore(collectable, playerAtFullHealth))
         {
           const auto score = *maybeScore;
           assert(score > 0);
-          mpPlayerModel->giveScore(score);
+          mpPersistentPlayerState->giveScore(score);
 
           soundToPlay = SoundId::ItemPickup;
 
@@ -301,20 +302,20 @@ void PlayerInteractionSystem::updateItemCollection(entityx::EntityManager& es)
         if (collectable.mGivenHealth)
         {
           assert(*collectable.mGivenHealth > 0);
-          mpPlayerModel->giveHealth(*collectable.mGivenHealth);
+          mpPersistentPlayerState->giveHealth(*collectable.mGivenHealth);
           soundToPlay = SoundId::HealthPickup;
         }
 
         if (collectable.mGivenWeapon)
         {
-          mpPlayerModel->switchToWeapon(*collectable.mGivenWeapon);
+          mpPersistentPlayerState->switchToWeapon(*collectable.mGivenWeapon);
           soundToPlay = SoundId::WeaponPickup;
         }
 
         if (collectable.mGivenItem)
         {
           const auto itemType = *collectable.mGivenItem;
-          mpPlayerModel->giveItem(itemType);
+          mpPersistentPlayerState->giveItem(itemType);
 
           soundToPlay = itemType == InventoryItemType::RapidFire
             ? SoundId::WeaponPickup
@@ -425,11 +426,11 @@ void PlayerInteractionSystem::activateCardReader(
   entityx::Entity interactable)
 {
   const auto hasKey =
-    mpPlayerModel->hasItem(data::InventoryItemType::CircuitBoard);
+    mpPersistentPlayerState->hasItem(data::InventoryItemType::CircuitBoard);
 
   if (hasKey)
   {
-    mpPlayerModel->removeItem(data::InventoryItemType::CircuitBoard);
+    mpPersistentPlayerState->removeItem(data::InventoryItemType::CircuitBoard);
     interaction::disableKeyCardSlot(interactable);
     interaction::disableNextForceField(es);
 
@@ -447,9 +448,9 @@ void PlayerInteractionSystem::activateKeyHole(
   entityx::EntityManager& es,
   entityx::Entity interactable)
 {
-  if (mpPlayerModel->hasItem(data::InventoryItemType::BlueKey))
+  if (mpPersistentPlayerState->hasItem(data::InventoryItemType::BlueKey))
   {
-    mpPlayerModel->removeItem(data::InventoryItemType::BlueKey);
+    mpPersistentPlayerState->removeItem(data::InventoryItemType::BlueKey);
     interaction::disableKeyHole(interactable);
 
     auto door = findFirstMatchInSpawnOrder(es, ActorTag::Type::Door);
@@ -470,14 +471,16 @@ void PlayerInteractionSystem::activateKeyHole(
 
 void PlayerInteractionSystem::activateHintMachine(entityx::Entity entity)
 {
-  if (!mpPlayerModel->hasItem(data::InventoryItemType::SpecialHintGlobe))
+  if (!mpPersistentPlayerState->hasItem(
+        data::InventoryItemType::SpecialHintGlobe))
   {
     return;
   }
 
   const auto machinePosition = *entity.component<WorldPosition>();
-  mpPlayerModel->removeItem(data::InventoryItemType::SpecialHintGlobe);
-  mpPlayerModel->giveScore(HINT_MACHINE_ACTIVATION_SCORE);
+  mpPersistentPlayerState->removeItem(
+    data::InventoryItemType::SpecialHintGlobe);
+  mpPersistentPlayerState->giveScore(HINT_MACHINE_ACTIVATION_SCORE);
 
   mpServiceProvider->playSound(data::SoundId::ItemPickup);
   spawnScoreNumbers(
@@ -502,20 +505,20 @@ void PlayerInteractionSystem::collectLetter(
   const data::CollectableLetterType type,
   const base::Vec2& position)
 {
-  using S = data::PlayerModel::LetterCollectionState;
+  using S = data::PersistentPlayerState::LetterCollectionState;
 
-  const auto collectionState = mpPlayerModel->addLetter(type);
+  const auto collectionState = mpPersistentPlayerState->addLetter(type);
   if (collectionState == S::InOrder)
   {
     mpServiceProvider->playSound(data::SoundId::LettersCollectedCorrectly);
-    mpPlayerModel->giveScore(CORRECT_LETTER_COLLECTION_SCORE);
+    mpPersistentPlayerState->giveScore(CORRECT_LETTER_COLLECTION_SCORE);
     spawnScoreNumbersForLetterCollectionBonus(*mpEntityFactory, position);
     showTutorialMessage(data::TutorialMessageId::LettersCollectedRightOrder);
   }
   else
   {
     mpServiceProvider->playSound(data::SoundId::ItemPickup);
-    mpPlayerModel->giveScore(BASIC_LETTER_COLLECTION_SCORE);
+    mpPersistentPlayerState->giveScore(BASIC_LETTER_COLLECTION_SCORE);
 
     // In the original game, bonus letters spawn a floating 100 on pickup, but
     // the player is given 10100 points. This seems like a bug. My guess is

--- a/src/game_logic/player/interaction_system.hpp
+++ b/src/game_logic/player/interaction_system.hpp
@@ -37,7 +37,7 @@ struct IGameServiceProvider;
 
 namespace data
 {
-class PlayerModel;
+class PersistentPlayerState;
 }
 
 namespace events
@@ -68,7 +68,7 @@ public:
   PlayerInteractionSystem(
     const data::GameSessionId& sessionId,
     Player* pPlayer,
-    data::PlayerModel* pPlayerModel,
+    data::PersistentPlayerState* pPersistentPlayerState,
     IGameServiceProvider* pServices,
     IEntityFactory* pEntityFactory,
     entityx::EventManager* pEvents,
@@ -104,7 +104,7 @@ private:
 
 private:
   Player* mpPlayer;
-  data::PlayerModel* mpPlayerModel;
+  data::PersistentPlayerState* mpPersistentPlayerState;
   IGameServiceProvider* mpServiceProvider;
   IEntityFactory* mpEntityFactory;
   entityx::EventManager* mpEvents;

--- a/src/game_logic/world_state.cpp
+++ b/src/game_logic/world_state.cpp
@@ -129,7 +129,7 @@ WorldState::WorldState(
   IGameServiceProvider* pServiceProvider,
   renderer::Renderer* pRenderer,
   const assets::ResourceLoader* pResources,
-  data::PlayerModel* pPlayerModel,
+  data::PersistentPlayerState* pPersistentPlayerState,
   const data::GameOptions* pOptions,
   engine::SpriteFactory* pSpriteFactory,
   const data::GameSessionId sessionId)
@@ -137,7 +137,7 @@ WorldState::WorldState(
       pServiceProvider,
       pRenderer,
       pResources,
-      pPlayerModel,
+      pPersistentPlayerState,
       pOptions,
       pSpriteFactory,
       sessionId,
@@ -153,7 +153,7 @@ WorldState::WorldState(
   IGameServiceProvider* pServiceProvider,
   renderer::Renderer* pRenderer,
   const assets::ResourceLoader* pResources,
-  data::PlayerModel* pPlayerModel,
+  data::PersistentPlayerState* pPersistentPlayerState,
   const data::GameOptions* pOptions,
   engine::SpriteFactory* pSpriteFactory,
   const data::GameSessionId sessionId,
@@ -162,7 +162,7 @@ WorldState::WorldState(
       pServiceProvider,
       pRenderer,
       pResources,
-      pPlayerModel,
+      pPersistentPlayerState,
       pOptions,
       pSpriteFactory,
       sessionId,
@@ -176,7 +176,7 @@ WorldState::WorldState(
   IGameServiceProvider* pServiceProvider,
   renderer::Renderer* pRenderer,
   const assets::ResourceLoader* pResources,
-  data::PlayerModel* pPlayerModel,
+  data::PersistentPlayerState* pPersistentPlayerState,
   const data::GameOptions* pOptions,
   engine::SpriteFactory* pSpriteFactory,
   const data::GameSessionId sessionId,
@@ -208,7 +208,7 @@ WorldState::WorldState(
         return playerEntity;
       }(),
       sessionId.mDifficulty,
-      pPlayerModel,
+      pPersistentPlayerState,
       pServiceProvider,
       pOptions,
       &mCollisionChecker,
@@ -233,7 +233,7 @@ WorldState::WorldState(
   , mPlayerInteractionSystem(
       sessionId,
       &mPlayer,
-      pPlayerModel,
+      pPersistentPlayerState,
       pServiceProvider,
       &mEntityFactory,
       &mEventManager,
@@ -244,7 +244,10 @@ WorldState::WorldState(
       pServiceProvider,
       &mCollisionChecker,
       &mMap)
-  , mDamageInflictionSystem(pPlayerModel, pServiceProvider, &mEventManager)
+  , mDamageInflictionSystem(
+      pPersistentPlayerState,
+      pServiceProvider,
+      &mEventManager)
   , mDynamicGeometrySystem(
       pRenderer,
       pServiceProvider,
@@ -299,7 +302,7 @@ WorldState::WorldState(
 void WorldState::synchronizeTo(
   const WorldState& other,
   IGameServiceProvider* pServiceProvider,
-  data::PlayerModel* pPlayerModel,
+  data::PersistentPlayerState* pPersistentPlayerState,
   const data::GameSessionId sessionId)
 {
   if (mBackdropSwitched != other.mBackdropSwitched)
@@ -370,7 +373,7 @@ void WorldState::synchronizeTo(
     mPlayer = Player{
       playerEntity,
       sessionId.mDifficulty,
-      pPlayerModel,
+      pPersistentPlayerState,
       pServiceProvider,
       mpOptions,
       &mCollisionChecker,

--- a/src/game_logic/world_state.hpp
+++ b/src/game_logic/world_state.hpp
@@ -104,7 +104,7 @@ struct LevelBonusInfo
 
 struct CheckpointData
 {
-  data::PlayerModel::CheckpointState mState;
+  data::PersistentPlayerState::CheckpointState mState;
   base::Vec2 mPosition;
 };
 
@@ -115,7 +115,7 @@ struct WorldState
     IGameServiceProvider* pServiceProvider,
     renderer::Renderer* pRenderer,
     const assets::ResourceLoader* pResources,
-    data::PlayerModel* pPlayerModel,
+    data::PersistentPlayerState* pPersistentPlayerState,
     const data::GameOptions* pOptions,
     engine::SpriteFactory* pSpriteFactory,
     data::GameSessionId sessionId);
@@ -123,7 +123,7 @@ struct WorldState
     IGameServiceProvider* pServiceProvider,
     renderer::Renderer* pRenderer,
     const assets::ResourceLoader* pResources,
-    data::PlayerModel* pPlayerModel,
+    data::PersistentPlayerState* pPersistentPlayerState,
     const data::GameOptions* pOptions,
     engine::SpriteFactory* pSpriteFactory,
     data::GameSessionId sessionId,
@@ -132,7 +132,7 @@ struct WorldState
     IGameServiceProvider* pServiceProvider,
     renderer::Renderer* pRenderer,
     const assets::ResourceLoader* pResources,
-    data::PlayerModel* pPlayerModel,
+    data::PersistentPlayerState* pPersistentPlayerState,
     const data::GameOptions* pOptions,
     engine::SpriteFactory* pSpriteFactory,
     data::GameSessionId sessionId,
@@ -142,7 +142,7 @@ struct WorldState
   void synchronizeTo(
     const WorldState& other,
     IGameServiceProvider* pServiceProvider,
-    data::PlayerModel* pPlayerModel,
+    data::PersistentPlayerState* pPersistentPlayerState,
     data::GameSessionId sessionId);
 
   data::map::Map mMap;

--- a/src/game_logic_classic/game_world_classic.cpp
+++ b/src/game_logic_classic/game_world_classic.cpp
@@ -254,17 +254,18 @@ void ShowTutorial(Context* ctx, TutorialId index)
 {
   const auto id = static_cast<rigel::data::TutorialMessageId>(index);
 
-  if (!getBridge(ctx).mpPlayerModel->tutorialMessages().hasBeenShown(id))
+  if (!getBridge(ctx).mpPersistentPlayerState->tutorialMessages().hasBeenShown(
+        id))
   {
     getBridge(ctx).mpMessageDisplay->setMessage(data::messageText(id));
-    getBridge(ctx).mpPlayerModel->tutorialMessages().markAsShown(id);
+    getBridge(ctx).mpPersistentPlayerState->tutorialMessages().markAsShown(id);
   }
 }
 
 
 void AddInventoryItem(Context* ctx, word item)
 {
-  getBridge(ctx).mpPlayerModel->giveItem(convertItemType(item));
+  getBridge(ctx).mpPersistentPlayerState->giveItem(convertItemType(item));
 }
 
 
@@ -272,12 +273,12 @@ bool RemoveFromInventory(Context* ctx, word item)
 {
   const auto type = convertItemType(item);
 
-  if (!getBridge(ctx).mpPlayerModel->hasItem(type))
+  if (!getBridge(ctx).mpPersistentPlayerState->hasItem(type))
   {
     return false;
   }
 
-  getBridge(ctx).mpPlayerModel->removeItem(type);
+  getBridge(ctx).mpPersistentPlayerState->removeItem(type);
   return true;
 }
 
@@ -332,19 +333,21 @@ void relayInput(const PlayerInput& input, State* pState)
 }
 
 
-void relayPlayerModel(const data::PlayerModel& playerModel, State* pState)
+void relayPlayerModel(
+  const data::PersistentPlayerState& persistentPlayerState,
+  State* pState)
 {
-  pState->plWeapon = static_cast<byte>(playerModel.weapon());
-  pState->plScore = dword(playerModel.score());
-  pState->plAmmo = byte(playerModel.ammo());
-  pState->plHealth = byte(playerModel.health());
+  pState->plWeapon = static_cast<byte>(persistentPlayerState.weapon());
+  pState->plScore = dword(persistentPlayerState.score());
+  pState->plAmmo = byte(persistentPlayerState.ammo());
+  pState->plHealth = byte(persistentPlayerState.health());
 }
 
 
 std::unique_ptr<State> createState(
   const data::GameSessionId& sessionId,
   const assets::ResourceLoader& resources,
-  const data::PlayerModel& playerModel,
+  const data::PersistentPlayerState& persistentPlayerState,
   Bridge* pBridge)
 {
   auto pState = std::make_unique<State>();
@@ -369,7 +372,7 @@ std::unique_ptr<State> createState(
   pState->gmCurrentEpisode = byte(sessionId.mEpisode);
   pState->gmDifficulty = byte(sessionId.mDifficulty) + 1;
 
-  relayPlayerModel(playerModel, pState.get());
+  relayPlayerModel(persistentPlayerState, pState.get());
 
   return pState;
 }
@@ -382,12 +385,12 @@ Bridge::Bridge(
   data::map::Map* pMap,
   IGameServiceProvider* pServiceProvider,
   ui::IngameMessageDisplay* pMessageDisplay,
-  data::PlayerModel* pPlayerModel)
+  data::PersistentPlayerState* pPersistentPlayerState)
   : mLevelHints(resources.loadHintMessages())
   , mpMap(pMap)
   , mpServiceProvider(pServiceProvider)
   , mpMessageDisplay(pMessageDisplay)
-  , mpPlayerModel(pPlayerModel)
+  , mpPersistentPlayerState(pPersistentPlayerState)
 {
 }
 
@@ -405,23 +408,23 @@ void Bridge::resetForNewFrame()
 struct GameWorld_Classic::QuickSaveData
 {
   QuickSaveData(
-    const data::PlayerModel& playerModel,
+    const data::PersistentPlayerState& persistentPlayerState,
     const data::map::Map& map,
     const State& state)
-    : mPlayerModel(playerModel)
+    : mPersistentPlayerState(persistentPlayerState)
     , mMap(map)
     , mState(state)
   {
   }
 
-  data::PlayerModel mPlayerModel;
+  data::PersistentPlayerState mPersistentPlayerState;
   data::map::Map mMap;
   State mState;
 };
 
 
 GameWorld_Classic::GameWorld_Classic(
-  data::PlayerModel* pPlayerModel,
+  data::PersistentPlayerState* pPersistentPlayerState,
   const data::GameSessionId& sessionId,
   GameMode::Context context,
   std::optional<base::Vec2> playerPositionOverride,
@@ -434,13 +437,13 @@ GameWorld_Classic::GameWorld_Classic(
       data::GameTraits::viewportSize,
       mpRenderer)
   , mTextRenderer(&mUiSpriteSheet, mpRenderer, *context.mpResources)
-  , mpPlayerModel(pPlayerModel)
+  , mpPersistentPlayerState(pPersistentPlayerState)
   , mpOptions(&context.mpUserProfile->mOptions)
   , mpResources(context.mpResources)
   , mpSpriteFactory(context.mpSpriteFactory)
   , mImageIdTable(engine::buildImageIdTable(*context.mpResources))
   , mSessionId(sessionId)
-  , mPlayerModelAtLevelStart(*mpPlayerModel)
+  , mPlayerModelAtLevelStart(*mpPersistentPlayerState)
   , mHudRenderer(
       sessionId.mIsDemo ? std::nullopt
                         : std::make_optional(sessionId.mLevel + 1),
@@ -467,9 +470,12 @@ GameWorld_Classic::GameWorld_Classic(
       &mMap,
       mpServiceProvider,
       &mMessageDisplay,
-      mpPlayerModel)
-  , mpState(
-      createState(sessionId, *context.mpResources, *mpPlayerModel, &mBridge))
+      mpPersistentPlayerState)
+  , mpState(createState(
+      sessionId,
+      *context.mpResources,
+      *mpPersistentPlayerState,
+      &mBridge))
 {
   LOG_SCOPE_FUNCTION(INFO);
 
@@ -611,7 +617,7 @@ void GameWorld_Classic::updateGameLogic(const PlayerInput& input)
 
   if (mpState->gmBeaconActivated && !beaconWasActive)
   {
-    mCheckpointState = mpPlayerModel->makeCheckpoint();
+    mCheckpointState = mpPersistentPlayerState->makeCheckpoint();
   }
 
   if (mpState->gmBossActivated && !bossWasActive)
@@ -653,7 +659,7 @@ void GameWorld_Classic::render(float)
     auto saved = setupIngameViewport(mpRenderer, mBridge.mScreenShift);
 
     drawWorld();
-    mHudRenderer.renderClassicHud(*mpPlayerModel, mBridge.mRadarDots);
+    mHudRenderer.renderClassicHud(*mpPersistentPlayerState, mBridge.mRadarDots);
   }
 
   auto saved = renderer::saveState(mpRenderer);
@@ -921,7 +927,7 @@ void GameWorld_Classic::processEndOfFrameActions()
 
     if (mpState->gmBeaconActivated)
     {
-      mpPlayerModel->restoreFromCheckpoint(*mCheckpointState);
+      mpPersistentPlayerState->restoreFromCheckpoint(*mCheckpointState);
 
       mpState->plPosX = mpState->gmBeaconPosX;
       mpState->plPosY = mpState->gmBeaconPosY;
@@ -929,7 +935,7 @@ void GameWorld_Classic::processEndOfFrameActions()
     }
     else
     {
-      *mpPlayerModel = mPlayerModelAtLevelStart;
+      *mpPersistentPlayerState = mPlayerModelAtLevelStart;
       loadLevel(mSessionId);
 
       if (mpState->gmRadarDishesLeft)
@@ -940,7 +946,7 @@ void GameWorld_Classic::processEndOfFrameActions()
 
     syncBackdrop();
 
-    relayPlayerModel(*mpPlayerModel, mpState.get());
+    relayPlayerModel(*mpPersistentPlayerState, mpState.get());
 
     CenterViewOnPlayer(mpState.get());
 
@@ -980,8 +986,8 @@ bool GameWorld_Classic::isGodModeOn() const
 
 void GameWorld_Classic::activateFullHealthCheat()
 {
-  mpPlayerModel->resetHealthAndScore();
-  relayPlayerModel(*mpPlayerModel, mpState.get());
+  mpPersistentPlayerState->resetHealthAndScore();
+  relayPlayerModel(*mpPersistentPlayerState, mpState.get());
 }
 
 
@@ -1075,7 +1081,8 @@ void GameWorld_Classic::quickSave()
 
   LOG_F(INFO, "Creating quick save");
 
-  mpQuickSave = std::make_unique<QuickSaveData>(*mpPlayerModel, mMap, *mpState);
+  mpQuickSave =
+    std::make_unique<QuickSaveData>(*mpPersistentPlayerState, mMap, *mpState);
 
   mMessageDisplay.setMessage(
     data::Messages::QuickSaved, ui::MessagePriority::Menu);
@@ -1093,7 +1100,7 @@ void GameWorld_Classic::quickLoad()
 
   LOG_F(INFO, "Loading quick save");
 
-  *mpPlayerModel = mpQuickSave->mPlayerModel;
+  *mpPersistentPlayerState = mpQuickSave->mPersistentPlayerState;
   mMap = mpQuickSave->mMap;
   *mpState = mpQuickSave->mState;
 
@@ -1305,36 +1312,37 @@ void GameWorld_Classic::syncPlayerModel()
 {
   using LT = data::CollectableLetterType;
 
-  mpPlayerModel->mWeapon = static_cast<data::WeaponType>(mpState->plWeapon);
-  mpPlayerModel->mScore = mpState->plScore;
-  mpPlayerModel->mAmmo = mpState->plAmmo;
-  mpPlayerModel->mHealth = mpState->plHealth;
+  mpPersistentPlayerState->mWeapon =
+    static_cast<data::WeaponType>(mpState->plWeapon);
+  mpPersistentPlayerState->mScore = mpState->plScore;
+  mpPersistentPlayerState->mAmmo = mpState->plAmmo;
+  mpPersistentPlayerState->mHealth = mpState->plHealth;
 
-  mpPlayerModel->mCollectedLetters.clear();
+  mpPersistentPlayerState->mCollectedLetters.clear();
 
   if (mpState->plCollectedLetters & 0x100)
   {
-    mpPlayerModel->mCollectedLetters.push_back(LT::N);
+    mpPersistentPlayerState->mCollectedLetters.push_back(LT::N);
   }
 
   if (mpState->plCollectedLetters & 0x200)
   {
-    mpPlayerModel->mCollectedLetters.push_back(LT::U);
+    mpPersistentPlayerState->mCollectedLetters.push_back(LT::U);
   }
 
   if (mpState->plCollectedLetters & 0x400)
   {
-    mpPlayerModel->mCollectedLetters.push_back(LT::K);
+    mpPersistentPlayerState->mCollectedLetters.push_back(LT::K);
   }
 
   if (mpState->plCollectedLetters & 0x800)
   {
-    mpPlayerModel->mCollectedLetters.push_back(LT::E);
+    mpPersistentPlayerState->mCollectedLetters.push_back(LT::E);
   }
 
   if (mpState->plCollectedLetters & 0x1000)
   {
-    mpPlayerModel->mCollectedLetters.push_back(LT::M);
+    mpPersistentPlayerState->mCollectedLetters.push_back(LT::M);
   }
 }
 

--- a/src/game_logic_classic/game_world_classic.hpp
+++ b/src/game_logic_classic/game_world_classic.hpp
@@ -92,7 +92,7 @@ struct Bridge
     data::map::Map* pMap,
     IGameServiceProvider* pServiceProvider,
     ui::IngameMessageDisplay* pMessageDisplay,
-    data::PlayerModel* pPlayerModel);
+    data::PersistentPlayerState* pPersistentPlayerState);
 
   void resetForNewFrame();
 
@@ -111,7 +111,7 @@ struct Bridge
   engine::MapRenderer* mpMapRenderer = nullptr;
   IGameServiceProvider* mpServiceProvider;
   ui::IngameMessageDisplay* mpMessageDisplay;
-  data::PlayerModel* mpPlayerModel;
+  data::PersistentPlayerState* mpPersistentPlayerState;
 };
 
 } // namespace detail
@@ -121,7 +121,7 @@ class GameWorld_Classic : public IGameWorld
 {
 public:
   GameWorld_Classic(
-    data::PlayerModel* pPlayerModel,
+    data::PersistentPlayerState* pPersistentPlayerState,
     const data::GameSessionId& sessionId,
     GameMode::Context context,
     std::optional<base::Vec2> playerPositionOverride = std::nullopt,
@@ -172,7 +172,7 @@ private:
   IGameServiceProvider* mpServiceProvider;
   engine::TiledTexture mUiSpriteSheet;
   ui::MenuElementRenderer mTextRenderer;
-  data::PlayerModel* mpPlayerModel;
+  data::PersistentPlayerState* mpPersistentPlayerState;
   const data::GameOptions* mpOptions;
   const assets::ResourceLoader* mpResources;
   engine::SpriteFactory* mpSpriteFactory;
@@ -184,7 +184,7 @@ private:
 
   data::map::Map mMap;
   std::optional<engine::MapRenderer> mMapRenderer;
-  data::PlayerModel mPlayerModelAtLevelStart;
+  data::PersistentPlayerState mPlayerModelAtLevelStart;
   ui::HudRenderer mHudRenderer;
   ui::IngameMessageDisplay mMessageDisplay;
   engine::SpecialEffectsRenderer mSpecialEffects;
@@ -197,7 +197,7 @@ private:
   std::unique_ptr<detail::State> mpState;
   std::unique_ptr<QuickSaveData> mpQuickSave;
 
-  std::optional<data::PlayerModel::CheckpointState> mCheckpointState;
+  std::optional<data::PersistentPlayerState::CheckpointState> mCheckpointState;
 };
 
 } // namespace rigel::game_logic

--- a/src/ui/hud_renderer.cpp
+++ b/src/ui/hud_renderer.cpp
@@ -282,7 +282,7 @@ void HudRenderer::updateAnimation()
 
 
 void HudRenderer::renderClassicHud(
-  const data::PlayerModel& playerModel,
+  const data::PersistentPlayerState& persistentPlayerState,
   const base::ArrayView<base::Vec2> radarPositions)
 {
   // We group drawing into what texture is used to minimize the amount of
@@ -300,25 +300,27 @@ void HudRenderer::renderClassicHud(
     2,
     data::tilesToPixels(HUD_START_BOTTOM_RIGHT));
   drawInventory(
-    playerModel.inventory(), data::tilesToPixels(INVENTORY_START_POS));
+    persistentPlayerState.inventory(),
+    data::tilesToPixels(INVENTORY_START_POS));
   drawCollectedLetters(
-    playerModel, data::tilesToPixels(LETTER_INDICATOR_POSITION));
+    persistentPlayerState, data::tilesToPixels(LETTER_INDICATOR_POSITION));
 
   // These use the UI sprite sheet texture.
   drawScore(
-    playerModel.score(),
+    persistentPlayerState.score(),
     *mpStatusSpriteSheetRenderer,
     {2, GameTraits::mapViewportSize.height + 1});
   drawWeaponIcon(
-    playerModel.weapon(),
+    persistentPlayerState.weapon(),
     *mpStatusSpriteSheetRenderer,
     {17, GameTraits::mapViewportSize.height + 1});
   drawAmmoBar(
-    playerModel.ammo(),
-    playerModel.currentMaxAmmo(),
+    persistentPlayerState.ammo(),
+    persistentPlayerState.currentMaxAmmo(),
     *mpStatusSpriteSheetRenderer,
     {22, GameTraits::mapViewportSize.height + 1});
-  drawHealthBar(playerModel, {24, GameTraits::mapViewportSize.height + 1});
+  drawHealthBar(
+    persistentPlayerState, {24, GameTraits::mapViewportSize.height + 1});
 
   if (mLevelNumber)
   {
@@ -336,7 +338,7 @@ void HudRenderer::renderClassicHud(
 void HudRenderer::renderWidescreenHud(
   const int viewportWidth,
   const data::WidescreenHudStyle style,
-  const data::PlayerModel& playerModel,
+  const data::PersistentPlayerState& persistentPlayerState,
   const base::ArrayView<base::Vec2> radarPositions)
 {
   auto drawClassicWidescreenHud = [&]() {
@@ -350,7 +352,7 @@ void HudRenderer::renderWidescreenHud(
     auto guard = renderer::saveState(mpRenderer);
     renderer::setLocalTranslation(mpRenderer, {hudOffset, 0});
 
-    renderClassicHud(playerModel, radarPositions);
+    renderClassicHud(persistentPlayerState, radarPositions);
   };
 
 
@@ -361,11 +363,11 @@ void HudRenderer::renderWidescreenHud(
       break;
 
     case data::WidescreenHudStyle::Modern:
-      drawModernHud(viewportWidth, playerModel, radarPositions);
+      drawModernHud(viewportWidth, persistentPlayerState, radarPositions);
       break;
 
     case data::WidescreenHudStyle::Ultrawide:
-      drawUltrawideHud(viewportWidth, playerModel, radarPositions);
+      drawUltrawideHud(viewportWidth, persistentPlayerState, radarPositions);
       break;
   }
 }
@@ -373,7 +375,7 @@ void HudRenderer::renderWidescreenHud(
 
 void HudRenderer::drawModernHud(
   int viewportWidth,
-  const data::PlayerModel& playerModel,
+  const data::PersistentPlayerState& persistentPlayerState,
   base::ArrayView<base::Vec2> radarPositions)
 {
   const auto screenWidth =
@@ -386,7 +388,7 @@ void HudRenderer::drawModernHud(
   const auto rightEdgeForFloatingParts =
     screenWidth - std::max(0, paddingForCentering);
   drawFloatingInventory(
-    playerModel.inventory(), {rightEdgeForFloatingParts - 2, 2});
+    persistentPlayerState.inventory(), {rightEdgeForFloatingParts - 2, 2});
 
   if (mpOptions->mShowRadarInModernHud)
   {
@@ -414,22 +416,23 @@ void HudRenderer::drawModernHud(
   auto guard = renderer::saveState(mpRenderer);
   renderer::setLocalTranslation(mpRenderer, {paddingForCentering + 29, 0});
 
-  drawCollectedLetters(playerModel, {33, -23});
+  drawCollectedLetters(persistentPlayerState, {33, -23});
 
   drawScore(
-    playerModel.score(),
+    persistentPlayerState.score(),
     *mpStatusSpriteSheetRenderer,
     {2, GameTraits::mapViewportSize.height + 1});
   drawWeaponIcon(
-    playerModel.weapon(),
+    persistentPlayerState.weapon(),
     *mpStatusSpriteSheetRenderer,
     {17, GameTraits::mapViewportSize.height + 1});
   drawAmmoBar(
-    playerModel.ammo(),
-    playerModel.currentMaxAmmo(),
+    persistentPlayerState.ammo(),
+    persistentPlayerState.currentMaxAmmo(),
     *mpStatusSpriteSheetRenderer,
     {22, GameTraits::mapViewportSize.height + 1});
-  drawHealthBar(playerModel, {24, GameTraits::mapViewportSize.height + 1});
+  drawHealthBar(
+    persistentPlayerState, {24, GameTraits::mapViewportSize.height + 1});
 
   if (mLevelNumber)
   {
@@ -445,7 +448,7 @@ void HudRenderer::drawModernHud(
 
 void HudRenderer::drawUltrawideHud(
   int viewportWidth,
-  const data::PlayerModel& playerModel,
+  const data::PersistentPlayerState& persistentPlayerState,
   base::ArrayView<base::Vec2> radarPositions)
 {
   const auto screenWidth =
@@ -470,22 +473,24 @@ void HudRenderer::drawUltrawideHud(
     auto guard = renderer::saveState(mpRenderer);
     renderer::setLocalTranslation(mpRenderer, {paddingForCentering, yPos});
 
-    drawInventory(playerModel.inventory(), {6, 15});
-    drawCollectedLetters(playerModel, {64, -138});
+    drawInventory(persistentPlayerState.inventory(), {6, 15});
+    drawCollectedLetters(persistentPlayerState, {64, -138});
   }
 
   auto guard = renderer::saveState(mpRenderer);
   renderer::setLocalTranslation(mpRenderer, {paddingForCentering, yPos - 2});
 
   // These use the UI sprite sheet texture.
-  drawScore(playerModel.score(), *mpStatusSpriteSheetRenderer, {12, 6});
-  drawWeaponIcon(playerModel.weapon(), *mpStatusSpriteSheetRenderer, {27, 6});
+  drawScore(
+    persistentPlayerState.score(), *mpStatusSpriteSheetRenderer, {12, 6});
+  drawWeaponIcon(
+    persistentPlayerState.weapon(), *mpStatusSpriteSheetRenderer, {27, 6});
   drawAmmoBar(
-    playerModel.ammo(),
-    playerModel.currentMaxAmmo(),
+    persistentPlayerState.ammo(),
+    persistentPlayerState.currentMaxAmmo(),
     *mpStatusSpriteSheetRenderer,
     {32, 6});
-  drawHealthBar(playerModel, {34, 6});
+  drawHealthBar(persistentPlayerState, {34, 6});
 
   if (mLevelNumber)
   {
@@ -603,7 +608,7 @@ void HudRenderer::drawFloatingInventory(
 
 
 void HudRenderer::drawHealthBar(
-  const data::PlayerModel& playerModel,
+  const data::PersistentPlayerState& persistentPlayerState,
   const base::Vec2& position) const
 {
   // Health slices start at col 20, row 4. The first 9 are for the "0 health"
@@ -611,7 +616,7 @@ void HudRenderer::drawHealthBar(
 
   // The model has a range of 1-9 for health, but the HUD shows only 8
   // slices, with a special animation for having 1 point of health.
-  const auto numFullSlices = playerModel.health() - 1;
+  const auto numFullSlices = persistentPlayerState.health() - 1;
   if (numFullSlices > 0)
   {
     for (int i = 0; i < NUM_HEALTH_SLICES; ++i)
@@ -636,7 +641,7 @@ void HudRenderer::drawHealthBar(
 
 
 void HudRenderer::drawCollectedLetters(
-  const data::PlayerModel& playerModel,
+  const data::PersistentPlayerState& persistentPlayerState,
   const base::Vec2& position) const
 {
   auto guard = renderer::saveState(mpRenderer);
@@ -652,7 +657,7 @@ void HudRenderer::drawCollectedLetters(
     {position + data::tilesToPixels(base::Vec2{35, 24}) + base::Vec2{1, 5},
      {29, 6}});
 
-  for (const auto letter : playerModel.collectedLetters())
+  for (const auto letter : persistentPlayerState.collectedLetters())
   {
     // The draw position is the same for all cases, because each actor
     // includes a draw offset in its actor info that positions it correctly.

--- a/src/ui/hud_renderer.hpp
+++ b/src/ui/hud_renderer.hpp
@@ -96,23 +96,23 @@ public:
   void updateAnimation();
 
   void renderClassicHud(
-    const data::PlayerModel& playerModel,
+    const data::PersistentPlayerState& persistentPlayerState,
     base::ArrayView<base::Vec2> radarPositions);
 
   void renderWidescreenHud(
     int viewportWidth,
     data::WidescreenHudStyle style,
-    const data::PlayerModel& playerModel,
+    const data::PersistentPlayerState& persistentPlayerState,
     base::ArrayView<base::Vec2> radarPositions);
 
 private:
   void drawModernHud(
     int viewportWidth,
-    const data::PlayerModel& playerModel,
+    const data::PersistentPlayerState& persistentPlayerState,
     base::ArrayView<base::Vec2> radarPositions);
   void drawUltrawideHud(
     int viewportWidth,
-    const data::PlayerModel& playerModel,
+    const data::PersistentPlayerState& persistentPlayerState,
     base::ArrayView<base::Vec2> radarPositions);
   void drawLeftSideExtension(int viewportWidth) const;
   void drawInventory(
@@ -122,10 +122,10 @@ private:
     const std::vector<data::InventoryItemType>& inventory,
     const base::Vec2& position) const;
   void drawHealthBar(
-    const data::PlayerModel& playerModel,
+    const data::PersistentPlayerState& persistentPlayerState,
     const base::Vec2& position) const;
   void drawCollectedLetters(
-    const data::PlayerModel& playerModel,
+    const data::PersistentPlayerState& persistentPlayerState,
     const base::Vec2& position) const;
   void drawRadar(
     base::ArrayView<base::Vec2> positions,

--- a/src/ui/ingame_menu.cpp
+++ b/src/ui/ingame_menu.cpp
@@ -79,15 +79,15 @@ constexpr int itemIndex(const std::string_view item)
 
 auto createSavedGame(
   const data::GameSessionId& sessionId,
-  const data::PlayerModel& playerModel)
+  const data::PersistentPlayerState& persistentPlayerState)
 {
   return data::SavedGame{
     sessionId,
-    playerModel.tutorialMessages(),
+    persistentPlayerState.tutorialMessages(),
     "", // will be filled in on saving
-    playerModel.weapon(),
-    playerModel.ammo(),
-    playerModel.score()};
+    persistentPlayerState.weapon(),
+    persistentPlayerState.ammo(),
+    persistentPlayerState.score()};
 }
 
 
@@ -303,11 +303,11 @@ IngameMenu::SavedGameNameEntry::SavedGameNameEntry(
 
 IngameMenu::IngameMenu(
   GameMode::Context context,
-  const data::PlayerModel* pPlayerModel,
+  const data::PersistentPlayerState* pPersistentPlayerState,
   game_logic::IGameWorld* pGameWorld,
   const data::GameSessionId& sessionId)
   : mContext(context)
-  , mSavedGame(createSavedGame(sessionId, *pPlayerModel))
+  , mSavedGame(createSavedGame(sessionId, *pPersistentPlayerState))
   , mSessionId(sessionId)
   , mpGameWorld(pGameWorld)
 {

--- a/src/ui/ingame_menu.hpp
+++ b/src/ui/ingame_menu.hpp
@@ -59,7 +59,7 @@ public:
 
   IngameMenu(
     GameMode::Context context,
-    const data::PlayerModel* pPlayerModel,
+    const data::PersistentPlayerState* pPersistentPlayerState,
     game_logic::IGameWorld* pGameWorld,
     const data::GameSessionId& sessionId);
 

--- a/test/test_elevator.cpp
+++ b/test/test_elevator.cpp
@@ -100,7 +100,7 @@ TEST_CASE("Rocket elevator")
   }
 
   CollisionChecker collisionChecker{&map, entityx.entities, entityx.events};
-  data::PlayerModel playerModel;
+  data::PersistentPlayerState persistentPlayerState;
   MockServiceProvider mockServiceProvider;
   engine::RandomNumberGenerator randomGenerator;
   MockSpriteFactory mockSpriteFactory;
@@ -121,7 +121,7 @@ TEST_CASE("Rocket elevator")
   Player player(
     playerEntity,
     data::Difficulty::Medium,
-    &playerModel,
+    &persistentPlayerState,
     &mockServiceProvider,
     &options,
     &collisionChecker,

--- a/test/test_letter_collection.cpp
+++ b/test/test_letter_collection.cpp
@@ -31,7 +31,7 @@ using namespace data;
 using namespace std;
 
 using LT = CollectableLetterType;
-using S = PlayerModel::LetterCollectionState;
+using S = PersistentPlayerState::LetterCollectionState;
 using ExpectedState = pair<LT, S>;
 
 
@@ -54,7 +54,7 @@ vector<S> getStates(const vector<ExpectedState>& expectations)
 
 vector<S> collectLetters(const vector<LT>& letters)
 {
-  PlayerModel model;
+  PersistentPlayerState model;
 
   return utils::transformed(
     letters, [&model](const auto letter) { return model.addLetter(letter); });

--- a/test/test_player.cpp
+++ b/test/test_player.cpp
@@ -212,7 +212,7 @@ TEST_CASE("Player movement")
 
   CollisionChecker collisionChecker{&map, entityx.entities, entityx.events};
 
-  data::PlayerModel playerModel;
+  data::PersistentPlayerState persistentPlayerState;
   MockEntityFactory mockEntityFactory{&entityx.entities};
   MockServiceProvider mockServiceProvider;
   engine::RandomNumberGenerator randomGenerator;
@@ -229,7 +229,7 @@ TEST_CASE("Player movement")
   Player player(
     playerEntity,
     data::Difficulty::Medium,
-    &playerModel,
+    &persistentPlayerState,
     &mockServiceProvider,
     &options,
     &collisionChecker,
@@ -1837,7 +1837,7 @@ TEST_CASE("Player movement")
 
       SECTION("Laser shot")
       {
-        playerModel.switchToWeapon(data::WeaponType::Laser);
+        persistentPlayerState.switchToWeapon(data::WeaponType::Laser);
 
         player.update(fireButtonTriggered);
         CHECK(lastFiredShot().type == ProjectileType::Laser);
@@ -1845,7 +1845,7 @@ TEST_CASE("Player movement")
 
       SECTION("Rocket shot")
       {
-        playerModel.switchToWeapon(data::WeaponType::Rocket);
+        persistentPlayerState.switchToWeapon(data::WeaponType::Rocket);
 
         player.update(fireButtonTriggered);
         CHECK(lastFiredShot().type == ProjectileType::Rocket);
@@ -1853,7 +1853,7 @@ TEST_CASE("Player movement")
 
       SECTION("Flame shot")
       {
-        playerModel.switchToWeapon(data::WeaponType::FlameThrower);
+        persistentPlayerState.switchToWeapon(data::WeaponType::FlameThrower);
 
         player.update(fireButtonTriggered);
         CHECK(lastFiredShot().type == ProjectileType::Flame);
@@ -1876,7 +1876,7 @@ TEST_CASE("Player movement")
 
       SECTION("Laser")
       {
-        playerModel.switchToWeapon(data::WeaponType::Laser);
+        persistentPlayerState.switchToWeapon(data::WeaponType::Laser);
 
         player.update(fireButtonTriggered);
         REQUIRE(mockServiceProvider.mLastTriggeredSoundId != std::nullopt);
@@ -1887,7 +1887,7 @@ TEST_CASE("Player movement")
 
       SECTION("Rocket launcher")
       {
-        playerModel.switchToWeapon(data::WeaponType::Rocket);
+        persistentPlayerState.switchToWeapon(data::WeaponType::Rocket);
 
         // The rocket launcher also uses the normal shot sound
         player.update(fireButtonTriggered);
@@ -1899,7 +1899,7 @@ TEST_CASE("Player movement")
 
       SECTION("Flame thrower")
       {
-        playerModel.switchToWeapon(data::WeaponType::FlameThrower);
+        persistentPlayerState.switchToWeapon(data::WeaponType::FlameThrower);
 
         player.update(fireButtonTriggered);
         REQUIRE(mockServiceProvider.mLastTriggeredSoundId != std::nullopt);
@@ -1910,8 +1910,8 @@ TEST_CASE("Player movement")
 
       SECTION("Last shot before ammo depletion still uses appropriate sound")
       {
-        playerModel.switchToWeapon(data::WeaponType::Laser);
-        playerModel.setAmmo(1);
+        persistentPlayerState.switchToWeapon(data::WeaponType::Laser);
+        persistentPlayerState.setAmmo(1);
 
         player.update(fireButtonTriggered);
 
@@ -1930,42 +1930,42 @@ TEST_CASE("Player movement")
     {
       SECTION("Normal shot doesn't consume ammo")
       {
-        playerModel.setAmmo(24);
+        persistentPlayerState.setAmmo(24);
         fireOneShot();
-        CHECK(playerModel.ammo() == 24);
+        CHECK(persistentPlayerState.ammo() == 24);
       }
 
       SECTION("Laser consumes 1 unit of ammo per shot")
       {
-        playerModel.switchToWeapon(data::WeaponType::Laser);
-        playerModel.setAmmo(10);
+        persistentPlayerState.switchToWeapon(data::WeaponType::Laser);
+        persistentPlayerState.setAmmo(10);
 
         fireOneShot();
-        CHECK(playerModel.ammo() == 9);
+        CHECK(persistentPlayerState.ammo() == 9);
       }
 
       SECTION("Rocket launcher consumes 1 unit of ammo per shot")
       {
-        playerModel.switchToWeapon(data::WeaponType::Rocket);
-        playerModel.setAmmo(10);
+        persistentPlayerState.switchToWeapon(data::WeaponType::Rocket);
+        persistentPlayerState.setAmmo(10);
 
         fireOneShot();
-        CHECK(playerModel.ammo() == 9);
+        CHECK(persistentPlayerState.ammo() == 9);
       }
 
       SECTION("Flame thrower consumes 1 unit of ammo per shot")
       {
-        playerModel.switchToWeapon(data::WeaponType::FlameThrower);
-        playerModel.setAmmo(10);
+        persistentPlayerState.switchToWeapon(data::WeaponType::FlameThrower);
+        persistentPlayerState.setAmmo(10);
 
         fireOneShot();
-        CHECK(playerModel.ammo() == 9);
+        CHECK(persistentPlayerState.ammo() == 9);
       }
 
       SECTION("Multiple shots consume several units of ammo")
       {
-        playerModel.switchToWeapon(data::WeaponType::Laser);
-        playerModel.setAmmo(20);
+        persistentPlayerState.switchToWeapon(data::WeaponType::Laser);
+        persistentPlayerState.setAmmo(20);
 
         const auto shotsToFire = 15;
         for (int i = 0; i < shotsToFire; ++i)
@@ -1973,25 +1973,27 @@ TEST_CASE("Player movement")
           fireOneShot();
         }
 
-        CHECK(playerModel.ammo() == 20 - shotsToFire);
+        CHECK(persistentPlayerState.ammo() == 20 - shotsToFire);
       }
 
       SECTION("Depleting ammo switches back to normal weapon")
       {
-        playerModel.switchToWeapon(data::WeaponType::Rocket);
-        playerModel.setAmmo(1);
+        persistentPlayerState.switchToWeapon(data::WeaponType::Rocket);
+        persistentPlayerState.setAmmo(1);
 
         fireOneShot();
 
-        CHECK(playerModel.weapon() == data::WeaponType::Normal);
-        CHECK(playerModel.ammo() == playerModel.currentMaxAmmo());
+        CHECK(persistentPlayerState.weapon() == data::WeaponType::Normal);
+        CHECK(
+          persistentPlayerState.ammo() ==
+          persistentPlayerState.currentMaxAmmo());
       }
     }
 
     SECTION(
       "Player fires continuously every other frame when owning rapid fire buff")
     {
-      playerModel.giveItem(data::InventoryItemType::RapidFire);
+      persistentPlayerState.giveItem(data::InventoryItemType::RapidFire);
 
       player.update(pressingFire & fireButtonTriggered);
       CHECK(fireShotSpy.size() == 1);
@@ -2009,7 +2011,7 @@ TEST_CASE("Player movement")
 
     SECTION("Firing stops when rapid fire is taken away")
     {
-      playerModel.giveItem(data::InventoryItemType::RapidFire);
+      persistentPlayerState.giveItem(data::InventoryItemType::RapidFire);
 
       for (int i = 0; i < 700; ++i)
       {
@@ -2017,7 +2019,7 @@ TEST_CASE("Player movement")
       }
       CHECK(fireShotSpy.size() == 350);
 
-      playerModel.removeItem(data::InventoryItemType::RapidFire);
+      persistentPlayerState.removeItem(data::InventoryItemType::RapidFire);
 
       for (int i = 0; i < 2; ++i)
       {

--- a/test/test_spike_ball.cpp
+++ b/test/test_spike_ball.cpp
@@ -105,11 +105,11 @@ TEST_CASE("Spike ball")
   playerEntity.assign<Sprite>();
   assignPlayerComponents(playerEntity, Orientation::Left);
 
-  data::PlayerModel playerModel;
+  data::PersistentPlayerState persistentPlayerState;
   Player player(
     playerEntity,
     data::Difficulty::Medium,
-    &playerModel,
+    &persistentPlayerState,
     &mockServiceProvider,
     &options,
     &collisionChecker,


### PR DESCRIPTION
## Summary
Hey @lethal-guitar 
This PR:

1. Addresses and closes #878 
2. Renames `PlayerModel` class and types of `PlayerModel*` to `PersistentPlayerState`
3. `RenamempPlayerModel -> mpPersistentPlayerState`, `pPlayerModel -> pPersistentPlayerState`

* [x] I've compiled the code locally on my machine, and it builds without errors
* [x] I've launched the game on my machine after making my changes, and I can successfully start a new game from the main menu

Edit: `clang-format` CI task fails, it seems it totally slipped my mind.

