### PR TITLE
WIP #846 Initial idea for unit tests for ModLibrary

### DIFF
--- a/src/data/mod_library.hpp
+++ b/src/data/mod_library.hpp
@@ -21,6 +21,27 @@
 #include <tuple>
 #include <vector>
 
+struct Filesystem
+{
+  using IsDirectoryFuncT =
+    bool (*)(const std::filesystem::path& p, std::error_code& ec);
+  using ExistsFuncT =
+    bool (*)(const std::filesystem::path& p, std::error_code& ec) noexcept;
+  using DirectoryIterateCallbackFuncT =
+    bool (*)(const std::filesystem::path& p, void* user_data) noexcept;
+  using DirectoryIterateFuncT = void (*)(
+    const std::filesystem::path& p,
+    std::filesystem::directory_options options,
+    std::error_code& ec,
+    DirectoryIterateCallbackFuncT callback,
+    void* user_data) noexcept;
+
+  IsDirectoryFuncT f_is_directory;
+  ExistsFuncT f_exists;
+  DirectoryIterateFuncT f_directory_iterate;
+};
+
+extern const Filesystem gNativeFilesystemHandle;
 
 namespace rigel::data
 {
@@ -57,7 +78,7 @@ public:
     std::vector<ModStatus> initialSelection);
 
   void updateGamePath(std::filesystem::path gamePath);
-  void rescan();
+  void rescan(const Filesystem& fsHandle = gNativeFilesystemHandle);
 
   [[nodiscard]] std::vector<std::filesystem::path> enabledModPaths() const;
   [[nodiscard]] const std::string& modDirName(int index) const;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,17 +1,19 @@
 add_executable(tests
     test_main.cpp
-    test_array_view.cpp
-    test_duke_script_loader.cpp
-    test_elevator.cpp
-    test_high_score_list.cpp
-    test_json_utils.cpp
-    test_letter_collection.cpp
-    test_physics_system.cpp
-    test_player.cpp
-    test_rng.cpp
-    test_spike_ball.cpp
-    test_string_utils.cpp
-    test_timing.cpp
+    # test_array_view.cpp
+    # test_duke_script_loader.cpp
+    # test_elevator.cpp
+    # test_high_score_list.cpp
+    # test_json_utils.cpp
+    # test_letter_collection.cpp
+    # test_physics_system.cpp
+    # test_player.cpp
+    # test_rng.cpp
+    # test_spike_ball.cpp
+    # test_string_utils.cpp
+    # test_timing.cpp
+
+    test_mod_library.cpp
 )
 
 target_link_libraries(tests

--- a/test/test_mod_library.cpp
+++ b/test/test_mod_library.cpp
@@ -1,0 +1,30 @@
+#include <base/warnings.hpp>
+#include <data/mod_library.hpp>
+
+RIGEL_DISABLE_WARNINGS
+#include <catch.hpp>
+RIGEL_RESTORE_WARNINGS
+
+#include <cstdio>
+
+TEST_CASE("Mod library rescan")
+{
+  namespace fs = std::filesystem;
+
+  rigel::data::ModLibrary ml{"/tmp", {}, {}};
+
+  Filesystem mockFsHandle{
+    [](const std::filesystem::path& p, std::error_code& ec) noexcept -> bool
+    { return true; },
+    [](const std::filesystem::path& p, std::error_code& ec) noexcept -> bool
+    { return true; },
+    [](
+      const std::filesystem::path& p,
+      std::filesystem::directory_options options,
+      std::error_code& ec,
+      Filesystem::DirectoryIterateCallbackFuncT callback,
+      void* user_data) noexcept {
+    }};
+
+  ml.rescan(mockFsHandle);
+}


### PR DESCRIPTION
hi, @lethal-guitar hope you're doing well!

I've noticed you closed this issue: #846. Why? I just came up with, I think, a cool idea to solve it!

I'm not there yet, but inching closer. Need to get some sleep soon (real late here) but if you approve of this idea, I'll absolutely go the extra mile!

Main points:

Add a fileshystem "stub" (handle?) for the filesystem functions used in `ModLibrary::rescan`
ideas: make a struct with function pointers, why?
  * simpler than virtual (yes, it is)
  * allows us to easily use std::filesystem::functions, no need for wrappers
  * we don't use gmock anyways, so mocking isn't as easy
  * simpler than virtual (yes, I really don't like 'em, that's why it's twice)

very veeeery much WIP, didn't test much apart from building the code and the unit test, didn't even have time to step through the debugger, it's really late, this commit message will change :)

* [ Y] I've compiled the code locally on my machine, and it builds without errors
* [ N] I've launched the game on my machine after making my changes, and I can successfully start a new game from the main menu (it's late don't have much time right now but wanted to just put this idea into writing)

@lethal-guitar what do you think? worth pursuing? 


here's the logs:

```
andrew@pop-os:~/Projects/RigelEngine$ ./build/gcc-11-Debug/test/tests 
2024-01-27 23:27:28.900 (   0.000s) [        8FE553C0]        mod_library.cpp:127   INFO| { rescan
2024-01-27 23:27:28.900 (   0.000s) [        8FE553C0]        mod_library.cpp:131   INFO| .   Listing mod directories
2024-01-27 23:27:28.900 (   0.000s) [        8FE553C0]        mod_library.cpp:157   INFO| .   Found 0 mods
2024-01-27 23:27:28.900 (   0.000s) [        8FE553C0]        mod_library.cpp:162   INFO| .   No previous mod library, creating default selection
2024-01-27 23:27:28.900 (   0.000s) [        8FE553C0]        mod_library.cpp:127   INFO| } 0.000 s: rescan
===============================================================================
test cases: 1 | 1 passed
assertions: - none -
```
